### PR TITLE
Add minimal execution_record schema artifact

### DIFF
--- a/schemas/execution_record.schema.yaml
+++ b/schemas/execution_record.schema.yaml
@@ -1,0 +1,7 @@
+record_type: execution_record
+purpose: store minimal execution results in reconstructable form
+required_fields:
+  - skill_id
+  - trigger
+  - result
+  - timestamp


### PR DESCRIPTION
### Motivation
- Introduce the first RTS-side record contract to provide a minimal, reconstructable shape for execution results used by cross-repo test flows.

### Description
- Add a single YAML schema file `schemas/execution_record.schema.yaml` that defines `record_type: execution_record`, a short `purpose`, and `required_fields` containing `skill_id`, `trigger`, `result`, and `timestamp`.

### Testing
- Verified file creation and contents with workspace inspection and committed the change (`git status`, file listing and `git commit`) and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e66a08749c832b80e0ce104782fccb)