### PR TITLE
Add drive_id to execution_record required fields

### DIFF
--- a/schemas/execution_record.schema.yaml
+++ b/schemas/execution_record.schema.yaml
@@ -2,6 +2,7 @@ record_type: execution_record
 purpose: store minimal execution results in reconstructable form
 required_fields:
   - skill_id
+  - drive_id
   - trigger
   - result
   - timestamp


### PR DESCRIPTION
### Motivation
- Make the minimal `execution_record` schema slightly more descriptive for the first cross-repo test flow by adding a `drive_id` identifier while preserving the minimal shape.

### Description
- Added `drive_id` to the `required_fields` list in `schemas/execution_record.schema.yaml`, preserving `record_type`, `purpose`, and the existing required fields and modifying only this single file.

### Testing
- Verified the change and repository state with local checks (`git status --short`, `git diff --name-only HEAD~1..HEAD`, and `nl -ba schemas/execution_record.schema.yaml`) and confirmed the file content and that only one file was changed; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e670aa9ca8832bbb59e180e9952f5b)