### PR TITLE
Add pack_id to execution_record required fields

### DIFF
--- a/schemas/execution_record.schema.yaml
+++ b/schemas/execution_record.schema.yaml
@@ -3,6 +3,7 @@ purpose: store minimal execution results in reconstructable form
 required_fields:
   - skill_id
   - drive_id
+  - pack_id
   - trigger
   - result
   - timestamp


### PR DESCRIPTION
### Motivation
- Make the minimal `execution_record` schema slightly more descriptive for the first cross-repo test flow by including `pack_id` in the required fields.

### Description
- Modified `schemas/execution_record.schema.yaml` to add `pack_id` to `required_fields` while preserving `record_type`, `purpose`, and all existing fields.

### Testing
- Verified the file contents with `cat schemas/execution_record.schema.yaml` and confirmed the change is present using `git diff --name-only`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e67162f6f8832b992e5ec40981e616)