### PR TITLE
Add record_scope to execution_record schema

### DIFF
--- a/schemas/execution_record.schema.yaml
+++ b/schemas/execution_record.schema.yaml
@@ -7,3 +7,4 @@ required_fields:
   - trigger
   - result
   - timestamp
+record_scope: cross_repo_skill_execution


### PR DESCRIPTION
### Motivation
- Make the `execution_record` schema explicitly indicate its cross-repo skill execution scope while keeping the artifact minimal and backward-compatible.

### Description
- Modified `schemas/execution_record.schema.yaml` to add top-level `record_scope: cross_repo_skill_execution` and preserved existing `record_type`, `purpose`, and `required_fields` unchanged; no other files were modified.

### Testing
- Verified the change with `git diff -- schemas/execution_record.schema.yaml`, `git diff --name-only`, and a successful `git commit`, confirming only `schemas/execution_record.schema.yaml` was changed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6bbf06810832b89d43085f31f6ecc)