### PR TITLE
Add minimal evidence_ref schema artifact

### DIFF
--- a/schemas/evidence_ref.schema.yaml
+++ b/schemas/evidence_ref.schema.yaml
@@ -1,0 +1,8 @@
+record_type: evidence_ref
+purpose: store minimal references to evidence used in reconstructable execution flows
+required_fields:
+  - evidence_id
+  - source_type
+  - source_ref
+  - retrieved_at
+record_scope: cross_repo_evidence_reference


### PR DESCRIPTION
### Motivation
- Introduce a minimal, reconstructable cross-repo reference artifact for evidence so code can reference evidence without adding a full evidence system.

### Description
- Create `schemas/evidence_ref.schema.yaml` containing YAML with `record_type: evidence_ref`, `purpose: store minimal references to evidence used in reconstructable execution flows`, `required_fields` set to `evidence_id`, `source_type`, `source_ref`, and `retrieved_at`, and `record_scope: cross_repo_evidence_reference`.

### Testing
- Committed the new file and verified creation with `git commit`, `git diff --name-only`, and `git status --short`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e78d06da08832b9793a7889fa83a71)