### PR TITLE
Add Protect Frame v0.1 minimal security scaffold

### DIFF
--- a/docs/security/PROTECT_FRAME_v0.1.md
+++ b/docs/security/PROTECT_FRAME_v0.1.md
@@ -1,0 +1,68 @@
+# Protect Frame v0.1
+
+## Purpose
+Protect Frame v0.1 is a lightweight boundary-audit layer added beside RTS Core.
+It does not replace RTS recording behavior; it clarifies what must be protected,
+where boundaries exist, and how current state can be verified and reconstructed later.
+
+## Scope
+This version defines only:
+- a minimal protected asset registry,
+- a minimal secret scope registry,
+- a minimal trust zone definition,
+- and an offline verification script for structural consistency.
+
+It is intentionally insert-only and avoids operational behavior changes in RTS Core.
+
+## Non-Goals
+Protect Frame v0.1 does **not** implement:
+- active access enforcement,
+- runtime blocking or isolation,
+- automated incident generation,
+- SIEM-style aggregation,
+- production intrusion detection,
+- secret storage backends.
+
+## Protected Assets
+Assets are tracked in `security/asset_registry.yaml` with normalized fields:
+- `asset_id`, `category`, `criticality`, `owner`, `notes`, `zone`.
+
+The registry is template-first. It should remain general at this stage and avoid
+overfitting to transient operational details.
+
+## Trust Zones
+Zones are tracked in `security/trust_zones.yaml` and separate operational surfaces:
+- daily
+- development
+- admin
+- external_ai
+- public_surface
+
+Each zone documents allowed assets, forbidden crossings, and notes for reviewers.
+The objective is explicit boundary readability rather than hard enforcement.
+
+## Secret Scope Rules
+Secret scope entries are tracked in `security/secret_scope_registry.yaml`.
+
+Design rules in v0.1:
+- avoid omnibus credentials,
+- prefer short-lived secrets,
+- separate credentials by usage context,
+- document expected blast radius on leak,
+- maintain explicit status for lifecycle review.
+
+## Verification Rules
+`scripts/security/verify_protect_frame.py` verifies:
+1. required Protect Frame files exist,
+2. all registries are valid YAML and loadable,
+3. each registry entry contains required keys.
+
+The script is non-mutating and returns non-zero on any violation.
+
+## Incident Reconstruction Intent
+Protect Frame v0.1 is designed for post-event reconstruction support.
+By preserving explicit boundary and scope metadata, reviewers can reconstruct
+which asset, secret scope, and zone relationships were in effect at validation time.
+
+Future versions may connect this scaffold to ledgers, incident packs, and workflow
+automation, but v0.1 keeps those integrations out of scope.

--- a/scripts/security/verify_protect_frame.py
+++ b/scripts/security/verify_protect_frame.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Minimal verifier for Protect Frame v0.1 scaffold.
+
+Uses PyYAML when available; otherwise falls back to a tiny parser that supports
+the subset used by this scaffold (mappings + lists + scalar values).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:  # pragma: no cover - depends on environment
+    import yaml
+except Exception:  # pragma: no cover - intentional fallback
+    yaml = None
+
+REQUIRED_FILES = {
+    "docs/security/PROTECT_FRAME_v0.1.md": None,
+    "security/asset_registry.yaml": "assets",
+    "security/secret_scope_registry.yaml": "secrets",
+    "security/trust_zones.yaml": "zones",
+}
+
+REQUIRED_ENTRY_KEYS = {
+    "security/asset_registry.yaml": {
+        "asset_id",
+        "category",
+        "criticality",
+        "owner",
+        "notes",
+        "zone",
+    },
+    "security/secret_scope_registry.yaml": {
+        "secret_id",
+        "secret_type",
+        "scope",
+        "zone",
+        "rotation_required",
+        "max_lifetime",
+        "usage_context",
+        "blast_radius",
+        "status",
+    },
+    "security/trust_zones.yaml": {
+        "zone_id",
+        "description",
+        "allowed_assets",
+        "forbidden_crossings",
+        "notes",
+    },
+}
+
+
+def _parse_scalar(value: str):
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "~"}:
+        return None
+    return value
+
+
+def _simple_yaml_load(text: str):
+    """
+    Parse a constrained YAML subset used by Protect Frame templates.
+
+    Supported:
+    - top-level mapping with one key
+    - list of mapping entries
+    - scalar values and nested scalar lists inside an entry
+    """
+    lines = [ln.rstrip("\n") for ln in text.splitlines()]
+    filtered = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+    if not filtered:
+        return {}
+
+    first = filtered[0].strip()
+    if not first.endswith(":"):
+        raise ValueError("top-level key must end with ':'")
+    top_key = first[:-1]
+    root = {top_key: []}
+    entries = root[top_key]
+    current_entry: dict | None = None
+    current_list_key: str | None = None
+
+    for raw_line in filtered[1:]:
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+
+        if indent == 2 and stripped.startswith("- "):
+            body = stripped[2:]
+            if ": " not in body:
+                raise ValueError(f"entry start must be 'key: value': {raw_line}")
+            key, value = body.split(": ", 1)
+            current_entry = {key: _parse_scalar(value)}
+            entries.append(current_entry)
+            current_list_key = None
+            continue
+
+        if current_entry is None:
+            raise ValueError(f"line appears before first entry: {raw_line}")
+
+        if indent == 4 and ": " in stripped:
+            key, value = stripped.split(": ", 1)
+            current_entry[key] = _parse_scalar(value)
+            current_list_key = None
+            continue
+
+        if indent == 4 and stripped.endswith(":"):
+            key = stripped[:-1]
+            current_entry[key] = []
+            current_list_key = key
+            continue
+
+        if indent == 6 and stripped.startswith("- "):
+            if current_list_key is None:
+                raise ValueError(f"list item without list key: {raw_line}")
+            current_entry[current_list_key].append(_parse_scalar(stripped[2:]))
+            continue
+
+        raise ValueError(f"unsupported YAML structure: {raw_line}")
+
+    return root
+
+
+def _load_yaml(file_path: Path):
+    text = file_path.read_text(encoding="utf-8")
+    if yaml is not None:
+        return yaml.safe_load(text)
+    return _simple_yaml_load(text)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    errors: list[str] = []
+
+    for relative_path in REQUIRED_FILES:
+        file_path = repo_root / relative_path
+        if not file_path.exists():
+            errors.append(f"missing required file: {relative_path}")
+
+    for relative_path, top_key in REQUIRED_FILES.items():
+        if top_key is None:
+            continue
+
+        file_path = repo_root / relative_path
+        if not file_path.exists():
+            continue
+
+        try:
+            data = _load_yaml(file_path)
+        except Exception as exc:
+            errors.append(f"invalid YAML in {relative_path}: {exc}")
+            continue
+        except OSError as exc:
+            errors.append(f"cannot read {relative_path}: {exc}")
+            continue
+
+        if not isinstance(data, dict):
+            errors.append(f"{relative_path} must load as a YAML mapping")
+            continue
+
+        if top_key not in data:
+            errors.append(f"{relative_path} is missing top-level key '{top_key}'")
+            continue
+
+        entries = data[top_key]
+        if not isinstance(entries, list):
+            errors.append(f"{relative_path}:{top_key} must be a list")
+            continue
+
+        required_keys = REQUIRED_ENTRY_KEYS[relative_path]
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                errors.append(
+                    f"{relative_path}:{top_key}[{index}] must be a mapping entry"
+                )
+                continue
+
+            missing = sorted(required_keys - set(entry.keys()))
+            if missing:
+                errors.append(
+                    f"{relative_path}:{top_key}[{index}] missing keys: {', '.join(missing)}"
+                )
+
+    if errors:
+        print("[FAIL] Protect Frame verification failed:")
+        for err in errors:
+            print(f" - {err}")
+        return 1
+
+    print("[OK] Protect Frame v0.1 verification succeeded.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security/asset_registry.yaml
+++ b/security/asset_registry.yaml
@@ -1,0 +1,49 @@
+assets:
+  - asset_id: ASSET-EMAIL-001
+    category: email
+    criticality: high
+    owner: team_owner
+    notes: Primary communication account template entry.
+    zone: daily
+
+  - asset_id: ASSET-GITHUB-001
+    category: github
+    criticality: high
+    owner: team_owner
+    notes: Source control organization or repository access template entry.
+    zone: development
+
+  - asset_id: ASSET-CLOUD-001
+    category: cloud
+    criticality: high
+    owner: infra_owner
+    notes: Cloud project or account access template entry.
+    zone: admin
+
+  - asset_id: ASSET-DOMAIN-001
+    category: domain
+    criticality: medium
+    owner: ops_owner
+    notes: Domain registrar and DNS management template entry.
+    zone: admin
+
+  - asset_id: ASSET-BILLING-001
+    category: billing
+    criticality: high
+    owner: finance_owner
+    notes: Billing portal and payment profile template entry.
+    zone: admin
+
+  - asset_id: ASSET-AIAPI-001
+    category: ai_api
+    criticality: medium
+    owner: platform_owner
+    notes: External AI provider account or project template entry.
+    zone: external_ai
+
+  - asset_id: ASSET-LOCAL-001
+    category: local_device
+    criticality: medium
+    owner: individual_owner
+    notes: Local workstation or endpoint template entry.
+    zone: daily

--- a/security/secret_scope_registry.yaml
+++ b/security/secret_scope_registry.yaml
@@ -1,0 +1,50 @@
+secrets:
+  - secret_id: SECRET-GITHUB-TOKEN-001
+    secret_type: github_token
+    scope: repo_or_org_minimum
+    zone: development
+    rotation_required: true
+    max_lifetime: 90d
+    usage_context: ci_or_local_automation
+    blast_radius: source_control_operations
+    status: active_template
+
+  - secret_id: SECRET-CLOUD-APIKEY-001
+    secret_type: cloud_api_key
+    scope: service_scoped
+    zone: admin
+    rotation_required: true
+    max_lifetime: 90d
+    usage_context: infrastructure_automation
+    blast_radius: cloud_resource_control
+    status: active_template
+
+  - secret_id: SECRET-DNS-CRED-001
+    secret_type: dns_domain_credential
+    scope: dns_only
+    zone: admin
+    rotation_required: true
+    max_lifetime: 180d
+    usage_context: domain_and_dns_updates
+    blast_radius: domain_routing_and_resolution
+    status: active_template
+
+  - secret_id: SECRET-BILLING-CRED-001
+    secret_type: billing_credential
+    scope: billing_portal_only
+    zone: admin
+    rotation_required: true
+    max_lifetime: 180d
+    usage_context: invoicing_and_payment_admin
+    blast_radius: spending_and_payment_profile
+    status: active_template
+
+  - secret_id: SECRET-AI-APIKEY-001
+    secret_type: ai_provider_api_key
+    scope: project_scoped
+    zone: external_ai
+    rotation_required: true
+    max_lifetime: 60d
+    usage_context: model_api_calls
+    blast_radius: api_usage_and_data_exposure
+    status: active_template

--- a/security/trust_zones.yaml
+++ b/security/trust_zones.yaml
@@ -1,0 +1,50 @@
+zones:
+  - zone_id: daily
+    description: Daily-use user environment for routine communication and lightweight work.
+    allowed_assets:
+      - email
+      - local_device
+    forbidden_crossings:
+      - direct_admin_credential_management
+      - unrestricted_cloud_control
+    notes: Keep day-to-day activities separate from privileged operations.
+
+  - zone_id: development
+    description: Development and source-control execution surface.
+    allowed_assets:
+      - github
+      - local_device
+    forbidden_crossings:
+      - direct_billing_operations
+      - registrar_level_domain_control
+    notes: Code operations should not imply finance or registrar authority.
+
+  - zone_id: admin
+    description: Privileged administration surface for cloud, billing, and domain governance.
+    allowed_assets:
+      - cloud
+      - domain
+      - billing
+    forbidden_crossings:
+      - routine_daily_browsing_context
+      - unrestricted_external_ai_submission
+    notes: Highest-risk zone; requires tighter credential scope and review.
+
+  - zone_id: external_ai
+    description: External AI provider interaction boundary.
+    allowed_assets:
+      - ai_api
+    forbidden_crossings:
+      - raw_admin_secret_exposure
+      - direct_billing_authority_reuse
+    notes: Treat as controlled egress boundary for prompts and outputs.
+
+  - zone_id: public_surface
+    description: Public-facing published surface such as websites, docs, or open artifacts.
+    allowed_assets:
+      - domain
+      - github
+    forbidden_crossings:
+      - privileged_secret_storage
+      - internal_admin_console_access
+    notes: Public exposure must not imply private control-plane reachability.


### PR DESCRIPTION
### Motivation
- Introduce a minimal, insert-only Protect Frame v0.1 scaffold to make RTS boundaries, protected assets, secret scopes, and trust zones explicit for verification and incident reconstruction.
- Provide a lightweight verification layer that records and validates structure without changing runtime enforcement or existing RTS behavior.

### Description
- Add `docs/security/PROTECT_FRAME_v0.1.md` containing purpose, scope, non-goals, protected assets, trust zones, secret scope rules, verification rules, and incident reconstruction intent.
- Add template registries `security/asset_registry.yaml`, `security/secret_scope_registry.yaml`, and `security/trust_zones.yaml` with the required fields and the requested categories/zones.
- Add `scripts/security/verify_protect_frame.py`, a Python 3.11-compatible verifier that checks file existence, loads YAML (uses PyYAML when available and ships a small fallback parser), validates top-level keys and per-entry required fields, and exits non-zero on violations.
- Keep the change insert-only and avoid modifying any existing logs, incidents, memory, sessions, workflows, or analyze scripts.

### Testing
- Ran `python scripts/security/verify_protect_frame.py` which initially failed due to missing `PyYAML`, prompting a fallback parser to be implemented, and then succeeded (final run returned success and printed a concise success message).
- Automated file-existence checks (`test -f ...`) were run and confirmed all required files exist.
- Performed `git status --short` and committed the new files; the commit succeeded and no unrelated files were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e812a3c988832b801c488b5ff6a079)