### PR TITLE
Add Protect Frame v0.1 scaffold, registries, and verification script

### DIFF
--- a/docs/security/PROTECT_FRAME_v0.1.md
+++ b/docs/security/PROTECT_FRAME_v0.1.md
@@ -1,0 +1,75 @@
+# Protect Frame v0.1
+
+## Purpose
+Protect Frame v0.1 is a lightweight boundary-audit layer added beside RTS Core.
+It does not replace RTS recording behavior; it clarifies what must be protected,
+where boundaries exist, and how current state can be verified and reconstructed later.
+
+## Scope
+This version defines only:
+- a minimal protected asset registry,
+- a minimal secret scope registry,
+- a minimal trust zone definition,
+- and an offline verification script for structural consistency.
+
+It is intentionally insert-only and avoids operational behavior changes in RTS Core.
+
+## Non-Goals
+Protect Frame v0.1 does **not** implement:
+- active access enforcement,
+- runtime blocking or isolation,
+- automated incident generation,
+- SIEM-style aggregation,
+- production intrusion detection,
+- secret storage backends.
+
+## Protected Assets
+Assets are tracked in `security/asset_registry.yaml` with normalized fields:
+- `asset_id`, `category`, `criticality`, `owner`, `notes`, `zone`.
+
+The registry is intended as a practical initial baseline for real operation,
+while still keeping sensitive implementation detail out of this layer.
+
+## Trust Zones
+Zones are tracked in `security/trust_zones.yaml` and separate operational surfaces:
+- daily
+- development
+- admin
+- external_ai
+- public_surface
+
+Each zone documents allowed assets, forbidden crossings, and notes for reviewers.
+The objective is explicit boundary readability rather than hard enforcement.
+
+## Secret Scope Rules
+Secret scope entries are tracked in `security/secret_scope_registry.yaml`.
+
+Design rules in v0.1:
+- avoid omnibus credentials,
+- prefer short-lived secrets,
+- separate credentials by usage context,
+- document expected blast radius on leak,
+- maintain explicit status for lifecycle review.
+
+## Verification Rules
+`scripts/security/verify_protect_frame.py` verifies:
+1. required Protect Frame files exist,
+2. all registries are valid YAML and loadable,
+3. each registry entry contains required keys,
+4. selected value constraints and zone consistency rules.
+
+The script is non-mutating and returns non-zero on any violation.
+
+## Operational Notes
+- Initial registries are scaffolded for real use and periodic review.
+- Secrets are represented as metadata and scope intent, not secret values.
+- Verification currently checks structural consistency and constrained value validity.
+- CI and incident linkage are intentionally deferred to later phases.
+
+## Incident Reconstruction Intent
+Protect Frame v0.1 is designed for post-event reconstruction support.
+By preserving explicit boundary and scope metadata, reviewers can reconstruct
+which asset, secret scope, and zone relationships were in effect at validation time.
+
+Future versions may connect this scaffold to ledgers, incident packs, and workflow
+automation, but v0.1 keeps those integrations out of scope.

--- a/scripts/security/verify_protect_frame.py
+++ b/scripts/security/verify_protect_frame.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Minimal verifier for Protect Frame v0.1 scaffold.
+
+Uses PyYAML when available; otherwise falls back to a tiny parser that supports
+this scaffold subset (top-level mapping with list entries and scalar/list fields).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+try:  # pragma: no cover - depends on environment
+    import yaml
+except Exception:  # pragma: no cover - intentional fallback
+    yaml = None
+
+REQUIRED_FILES = {
+    "docs/security/PROTECT_FRAME_v0.1.md": None,
+    "security/asset_registry.yaml": "assets",
+    "security/secret_scope_registry.yaml": "secrets",
+    "security/trust_zones.yaml": "zones",
+}
+
+REQUIRED_ENTRY_KEYS = {
+    "security/asset_registry.yaml": {
+        "asset_id",
+        "category",
+        "criticality",
+        "owner",
+        "notes",
+        "zone",
+    },
+    "security/secret_scope_registry.yaml": {
+        "secret_id",
+        "secret_type",
+        "scope",
+        "zone",
+        "rotation_required",
+        "max_lifetime",
+        "usage_context",
+        "blast_radius",
+        "status",
+    },
+    "security/trust_zones.yaml": {
+        "zone_id",
+        "description",
+        "allowed_assets",
+        "forbidden_crossings",
+        "notes",
+    },
+}
+
+ALLOWED_CRITICALITY = {"critical", "high", "medium"}
+ALLOWED_BLAST_RADIUS = {"high", "medium", "low"}
+ALLOWED_SECRET_STATUS = {"active", "review_required", "disabled"}
+
+
+def _parse_scalar(value: str):
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in {"null", "~"}:
+        return None
+    return value
+
+
+def _simple_yaml_load(text: str):
+    lines = [ln.rstrip("\n") for ln in text.splitlines()]
+    filtered = [ln for ln in lines if ln.strip() and not ln.lstrip().startswith("#")]
+    if not filtered:
+        return {}
+
+    first = filtered[0].strip()
+    if not first.endswith(":"):
+        raise ValueError("top-level key must end with ':'")
+
+    top_key = first[:-1]
+    root = {top_key: []}
+    entries = root[top_key]
+    current_entry: dict | None = None
+    current_list_key: str | None = None
+
+    for raw_line in filtered[1:]:
+        indent = len(raw_line) - len(raw_line.lstrip(" "))
+        stripped = raw_line.strip()
+
+        if indent == 2 and stripped.startswith("- "):
+            body = stripped[2:]
+            if ": " not in body:
+                raise ValueError(f"entry start must be 'key: value': {raw_line}")
+            key, value = body.split(": ", 1)
+            current_entry = {key: _parse_scalar(value)}
+            entries.append(current_entry)
+            current_list_key = None
+            continue
+
+        if current_entry is None:
+            raise ValueError(f"line appears before first entry: {raw_line}")
+
+        if indent == 4 and ": " in stripped:
+            key, value = stripped.split(": ", 1)
+            current_entry[key] = _parse_scalar(value)
+            current_list_key = None
+            continue
+
+        if indent == 4 and stripped.endswith(":"):
+            key = stripped[:-1]
+            current_entry[key] = []
+            current_list_key = key
+            continue
+
+        if indent == 6 and stripped.startswith("- "):
+            if current_list_key is None:
+                raise ValueError(f"list item without list key: {raw_line}")
+            current_entry[current_list_key].append(_parse_scalar(stripped[2:]))
+            continue
+
+        raise ValueError(f"unsupported YAML structure: {raw_line}")
+
+    return root
+
+
+def _load_yaml(file_path: Path):
+    text = file_path.read_text(encoding="utf-8")
+    if yaml is not None:
+        return yaml.safe_load(text)
+    return _simple_yaml_load(text)
+
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[2]
+    errors: list[str] = []
+    loaded: dict[str, dict] = {}
+
+    for relative_path in REQUIRED_FILES:
+        file_path = repo_root / relative_path
+        if not file_path.exists():
+            errors.append(f"missing required file: {relative_path}")
+
+    for relative_path, top_key in REQUIRED_FILES.items():
+        if top_key is None:
+            continue
+
+        file_path = repo_root / relative_path
+        if not file_path.exists():
+            continue
+
+        try:
+            data = _load_yaml(file_path)
+        except Exception as exc:
+            errors.append(f"invalid YAML in {relative_path}: {exc}")
+            continue
+
+        if not isinstance(data, dict):
+            errors.append(f"{relative_path} must load as a YAML mapping")
+            continue
+
+        if top_key not in data:
+            errors.append(f"{relative_path} is missing top-level key '{top_key}'")
+            continue
+
+        entries = data[top_key]
+        if not isinstance(entries, list):
+            errors.append(f"{relative_path}:{top_key} must be a list")
+            continue
+
+        required_keys = REQUIRED_ENTRY_KEYS[relative_path]
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                errors.append(
+                    f"{relative_path}:{top_key}[{index}] must be a mapping entry"
+                )
+                continue
+
+            missing = sorted(required_keys - set(entry.keys()))
+            if missing:
+                errors.append(
+                    f"{relative_path}:{top_key}[{index}] missing keys: {', '.join(missing)}"
+                )
+
+        loaded[relative_path] = data
+
+    zones_data = loaded.get("security/trust_zones.yaml", {}).get("zones", [])
+    known_zones = {
+        zone.get("zone_id")
+        for zone in zones_data
+        if isinstance(zone, dict) and isinstance(zone.get("zone_id"), str)
+    }
+
+    for index, zone in enumerate(zones_data):
+        if not isinstance(zone, dict):
+            continue
+        for list_key in ("allowed_assets", "forbidden_crossings"):
+            if not isinstance(zone.get(list_key), list):
+                errors.append(
+                    f"security/trust_zones.yaml:zones[{index}].{list_key} must be a list"
+                )
+
+    assets = loaded.get("security/asset_registry.yaml", {}).get("assets", [])
+    for index, asset in enumerate(assets):
+        if not isinstance(asset, dict):
+            continue
+
+        criticality = str(asset.get("criticality", "")).strip()
+        if criticality not in ALLOWED_CRITICALITY:
+            errors.append(
+                "security/asset_registry.yaml:assets"
+                f"[{index}] invalid criticality '{criticality}'"
+            )
+
+        zone = str(asset.get("zone", "")).strip()
+        if zone and zone not in known_zones:
+            errors.append(
+                f"security/asset_registry.yaml:assets[{index}] zone '{zone}' is undefined"
+            )
+
+    secrets = loaded.get("security/secret_scope_registry.yaml", {}).get("secrets", [])
+    for index, secret in enumerate(secrets):
+        if not isinstance(secret, dict):
+            continue
+
+        zone = str(secret.get("zone", "")).strip()
+        if zone and zone not in known_zones:
+            errors.append(
+                "security/secret_scope_registry.yaml:secrets"
+                f"[{index}] zone '{zone}' is undefined"
+            )
+
+        blast_radius = str(secret.get("blast_radius", "")).strip()
+        if blast_radius not in ALLOWED_BLAST_RADIUS:
+            errors.append(
+                "security/secret_scope_registry.yaml:secrets"
+                f"[{index}] invalid blast_radius '{blast_radius}'"
+            )
+
+        status = str(secret.get("status", "")).strip()
+        if status not in ALLOWED_SECRET_STATUS:
+            errors.append(
+                "security/secret_scope_registry.yaml:secrets"
+                f"[{index}] invalid status '{status}'"
+            )
+
+        max_lifetime = str(secret.get("max_lifetime", "")).strip()
+        if not max_lifetime:
+            errors.append(
+                "security/secret_scope_registry.yaml:secrets"
+                f"[{index}] max_lifetime must not be empty"
+            )
+
+    if errors:
+        print("[FAIL] Protect Frame verification failed:")
+        for err in errors:
+            print(f" - {err}")
+        return 1
+
+    print("[OK] Protect Frame v0.1 verification succeeded with v0.2 checks.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/security/asset_registry.yaml
+++ b/security/asset_registry.yaml
@@ -1,0 +1,49 @@
+assets:
+  - asset_id: ASSET-EMAIL-PRIMARY
+    category: email
+    criticality: high
+    owner: security_owner_placeholder
+    notes: Primary operational inbox used for account recovery and security notifications.
+    zone: daily
+
+  - asset_id: ASSET-GITHUB-CONTROL
+    category: github
+    criticality: critical
+    owner: engineering_owner_placeholder
+    notes: GitHub account and repository control path for source integrity and automation trust.
+    zone: development
+
+  - asset_id: ASSET-CLOUD-EXECUTION
+    category: cloud
+    criticality: critical
+    owner: infrastructure_owner_placeholder
+    notes: Cloud execution environment hosting RTS workloads and runtime control surfaces.
+    zone: admin
+
+  - asset_id: ASSET-DOMAIN-DNS-CONTROL
+    category: domain
+    criticality: critical
+    owner: operations_owner_placeholder
+    notes: Domain and DNS authority that determines public routing and service reachability.
+    zone: admin
+
+  - asset_id: ASSET-BILLING-CONTROL
+    category: billing
+    criticality: high
+    owner: finance_owner_placeholder
+    notes: Billing and payment control for continuity of cloud and external services.
+    zone: admin
+
+  - asset_id: ASSET-AI-PROVIDER-ACCESS
+    category: ai_api
+    criticality: medium
+    owner: platform_owner_placeholder
+    notes: External AI provider access used for model calls and scoped integration tasks.
+    zone: external_ai
+
+  - asset_id: ASSET-LOCAL-PRIMARY-DEVICE
+    category: local_device
+    criticality: medium
+    owner: operator_owner_placeholder
+    notes: Primary local device used for daily and development entry points.
+    zone: daily

--- a/security/secret_scope_registry.yaml
+++ b/security/secret_scope_registry.yaml
@@ -1,0 +1,60 @@
+secrets:
+  - secret_id: SECRET-GITHUB-PAT-REPO
+    secret_type: github_pat_or_repo_credential
+    scope: repository_scoped_minimum_permissions
+    zone: development
+    rotation_required: true
+    max_lifetime: 90d
+    usage_context: maintainer_cli_and_repository_operations
+    blast_radius: high
+    status: active
+
+  - secret_id: SECRET-GITHUB-ACTIONS-AUTOMATION
+    secret_type: github_actions_automation_secret
+    scope: workflow_specific_environment_scope
+    zone: development
+    rotation_required: true
+    max_lifetime: 60d
+    usage_context: ci_cd_or_automation_jobs
+    blast_radius: medium
+    status: active
+
+  - secret_id: SECRET-CLOUD-API-CREDENTIAL
+    secret_type: cloud_api_credential
+    scope: service_account_or_project_scoped
+    zone: admin
+    rotation_required: true
+    max_lifetime: 60d
+    usage_context: infrastructure_provisioning_and_runtime_ops
+    blast_radius: high
+    status: active
+
+  - secret_id: SECRET-DNS-DOMAIN-CREDENTIAL
+    secret_type: dns_domain_credential
+    scope: dns_and_registrar_limited_scope
+    zone: admin
+    rotation_required: true
+    max_lifetime: 90d
+    usage_context: domain_updates_and_dns_record_management
+    blast_radius: high
+    status: review_required
+
+  - secret_id: SECRET-BILLING-CREDENTIAL
+    secret_type: billing_credential
+    scope: billing_portal_limited_scope
+    zone: admin
+    rotation_required: true
+    max_lifetime: 90d
+    usage_context: payment_profile_and_cost_administration
+    blast_radius: medium
+    status: active
+
+  - secret_id: SECRET-AI-PROVIDER-API-KEY
+    secret_type: ai_provider_api_key
+    scope: project_scoped_non_admin_usage
+    zone: external_ai
+    rotation_required: true
+    max_lifetime: 30d
+    usage_context: model_inference_requests_and_tool_integration
+    blast_radius: low
+    status: active

--- a/security/trust_zones.yaml
+++ b/security/trust_zones.yaml
@@ -1,0 +1,50 @@
+zones:
+  - zone_id: daily
+    description: Daily operator environment for communication and low-privilege routine work.
+    allowed_assets:
+      - email
+      - local_device
+    forbidden_crossings:
+      - direct_admin_session_reuse
+      - direct_admin_secret_handling
+    notes: Daily workflows should stay separate from privileged administration.
+
+  - zone_id: development
+    description: Source and build surface for repository changes and scoped automation.
+    allowed_assets:
+      - github
+      - local_device
+    forbidden_crossings:
+      - direct_billing_management
+      - registrar_or_dns_admin_control
+    notes: Development access must not implicitly gain finance or registrar authority.
+
+  - zone_id: admin
+    description: Highest-trust control plane for cloud, domain, and billing administration.
+    allowed_assets:
+      - cloud
+      - domain
+      - billing
+    forbidden_crossings:
+      - blended_daily_and_admin_sessions
+      - broad_external_ai_secret_sharing
+    notes: Admin is the most critical boundary and should remain tightly isolated.
+
+  - zone_id: external_ai
+    description: Boundary for external AI provider calls and outputs.
+    allowed_assets:
+      - ai_api
+    forbidden_crossings:
+      - admin_control_credentials
+      - cross_zone_omnibus_secrets
+    notes: External AI interactions must not receive admin authority or broad credentials.
+
+  - zone_id: public_surface
+    description: Public-facing publication surface for externally visible artifacts.
+    allowed_assets:
+      - domain
+      - github
+    forbidden_crossings:
+      - internal_admin_plane_access
+      - private_secret_material_exposure
+    notes: Public surface is intentionally separated from internal management boundaries.


### PR DESCRIPTION
### Motivation
- Introduce a lightweight boundary-audit layer (Protect Frame v0.1) to document protected assets, secret scopes, and trust zones for post-incident reconstruction without changing RTS Core runtime behavior.
- Provide a minimal, insert-only scaffold that makes boundary relationships explicit and verifiable in CI or audits.

### Description
- Add high-level specification document `docs/security/PROTECT_FRAME_v0.1.md` describing purpose, scope, non-goals, and operational notes for Protect Frame v0.1. 
- Add scaffold registries `security/asset_registry.yaml`, `security/secret_scope_registry.yaml`, and `security/trust_zones.yaml` that enumerate assets, secret scopes, and trust zones with normalized fields. 
- Add verification script `scripts/security/verify_protect_frame.py` that validates required files, loads YAML (using PyYAML when available or a built-in simple parser fallback), enforces required entry keys, allowed value constraints, and zone consistency, and returns non-zero on violations. 
- Encoding of validation rules includes allowed `criticality`, `blast_radius`, and secret `status`, plus checks for non-empty `max_lifetime` and that referenced zones are defined. 

### Testing
- Ran the verifier via `python3 scripts/security/verify_protect_frame.py` against the new scaffold and the script completed indicating success (exit 0). 
- Verification exercised both structural checks and value constraints and reported no violations for the provided registry files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e812a3c988832b801c488b5ff6a079)