### PR TITLE
Add overview doc for execution_record and evidence_ref

### DIFF
--- a/docs/overview/EXECUTION_AND_EVIDENCE.md
+++ b/docs/overview/EXECUTION_AND_EVIDENCE.md
@@ -1,0 +1,26 @@
+# Execution Record and Evidence Reference
+
+## Purpose
+Provide a minimal structural overview of how `execution_record` and `evidence_ref` relate in the current RTS core.
+
+## Execution Record
+`execution_record` is the minimal record of a skill execution and includes:
+- `skill_id`
+- `drive_id`
+- `pack_id`
+- `trigger`
+- `result`
+- `timestamp`
+
+## Evidence Reference
+`evidence_ref` is the minimal reference to evidence used in reconstructable flows and includes:
+- `evidence_id`
+- `source_type`
+- `source_ref`
+- `retrieved_at`
+
+## Relationship
+Reconstructable execution may rely on both execution records and evidence references.
+
+## Boundary
+This document is a structural overview only. It does not define full linkage or runtime implementation.


### PR DESCRIPTION
### Motivation
- Provide a minimal structural overview of how `execution_record` and `evidence_ref` relate in the RTS core to guide documentation and future implementation.

### Description
- Add `docs/overview/EXECUTION_AND_EVIDENCE.md` describing the fields of `execution_record` (`skill_id`, `drive_id`, `pack_id`, `trigger`, `result`, `timestamp`) and `evidence_ref` (`evidence_id`, `source_type`, `source_ref`, `retrieved_at`), their relationship, and a boundary note that this is a structural overview only.

### Testing
- No automated tests were added or run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e81ea31c64832b995aa0d8aef91546)