### PR TITLE
Add CURRENT_MINIMAL_CORE.md documenting minimal RTS core snapshot

### DIFF
--- a/docs/overview/CURRENT_MINIMAL_CORE.md
+++ b/docs/overview/CURRENT_MINIMAL_CORE.md
@@ -1,0 +1,41 @@
+# CURRENT MINIMAL CORE (Snapshot)
+
+## Purpose
+This document is a current-state structural summary of the minimal RTS core and connected operator-side structure. It is not a final design.
+
+## RTS Core
+The current minimal RTS core is centered on a shared execution/evidence foundation:
+- `schemas/execution_record.schema.yaml`
+- `schemas/evidence_ref.schema.yaml`
+- `docs/overview/EXECUTION_AND_EVIDENCE.md`
+
+## Skill Set
+The current minimal operator-side structure includes 10 skills:
+- `weekly_dev_report`
+- `monthly_revenue_summary`
+- `client_payment_status_report`
+- `issue_to_fix_pr`
+- `failed_build_to_patch_plan`
+- `sentry_error_to_root_cause_report`
+- `notion_knowledge_retrieval`
+- `slack_thread_summary`
+- `important_mail_triage`
+- `site_price_watch_with_screenshot`
+
+## Pack Set
+The current pack set includes 5 packs:
+- `dev_pack`
+- `knowledge_pack`
+- `mail_pack`
+- `revenue_pack`
+- `research_pack`
+
+## Drive
+Current drive:
+- `hermes_drive`
+
+## Structural Meaning
+The current minimal RTS core now supports a multi-skill, multi-pack operator structure through a shared execution record model and evidence reference layer.
+
+## Boundary
+This document is only a structural inventory and does not define runtime logic, full evidence linkage, checkpointing, or full orchestration behavior.


### PR DESCRIPTION
### Motivation
- Provide a current-state structural inventory of the minimal RTS core and operator-side components as a snapshot document.
- Capture the shared execution/evidence foundation and list the active skills, packs, and drive for team visibility.

### Description
- Add `docs/overview/CURRENT_MINIMAL_CORE.md` which summarizes the minimal RTS core and its purpose.
- Document the shared execution/evidence artifacts including `schemas/execution_record.schema.yaml`, `schemas/evidence_ref.schema.yaml`, and `docs/overview/EXECUTION_AND_EVIDENCE.md`.
- Enumerate the current operator-side skills, pack set, and drive (`weekly_dev_report`, `dev_pack`, `hermes_drive`, etc.) and clarify the document is a structural inventory only.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e812a3c988832b801c488b5ff6a079)