### PR TITLE
Mature Protect Frame registries and lightweight verifier (v0.2)

### DIFF
--- a/docs/security/PROTECT_FRAME_v0.1.md
+++ b/docs/security/PROTECT_FRAME_v0.1.md
@@ -59,6 +59,12 @@ Design rules in v0.1:
 
 The script is non-mutating and returns non-zero on any violation.
 
+## Operational Notes
+- Initial registries are scaffolded for real use with practical baseline entries.
+- Secrets are represented as metadata only and never stored as secret values.
+- Verification currently checks structural consistency and policy-value alignment only.
+- CI and incident linkage are intentionally deferred in this version.
+
 ## Incident Reconstruction Intent
 Protect Frame v0.1 is designed for post-event reconstruction support.
 By preserving explicit boundary and scope metadata, reviewers can reconstruct

--- a/scripts/security/verify_protect_frame.py
+++ b/scripts/security/verify_protect_frame.py
@@ -50,6 +50,10 @@ REQUIRED_ENTRY_KEYS = {
     },
 }
 
+ALLOWED_CRITICALITY = {"critical", "high", "medium"}
+ALLOWED_BLAST_RADIUS = {"high", "medium", "low"}
+ALLOWED_STATUS = {"active", "review_required", "disabled"}
+
 
 def _parse_scalar(value: str):
     lowered = value.lower()
@@ -132,9 +136,18 @@ def _load_yaml(file_path: Path):
     return _simple_yaml_load(text)
 
 
+def _is_non_empty(value: object) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    return True
+
+
 def main() -> int:
     repo_root = Path(__file__).resolve().parents[2]
     errors: list[str] = []
+    loaded_data: dict[str, dict] = {}
 
     for relative_path in REQUIRED_FILES:
         file_path = repo_root / relative_path
@@ -171,6 +184,7 @@ def main() -> int:
             errors.append(f"{relative_path}:{top_key} must be a list")
             continue
 
+        loaded_data[relative_path] = data
         required_keys = REQUIRED_ENTRY_KEYS[relative_path]
         for index, entry in enumerate(entries):
             if not isinstance(entry, dict):
@@ -185,13 +199,80 @@ def main() -> int:
                     f"{relative_path}:{top_key}[{index}] missing keys: {', '.join(missing)}"
                 )
 
+    zones_file = "security/trust_zones.yaml"
+    zone_entries = loaded_data.get(zones_file, {}).get("zones", [])
+    zone_ids = {
+        entry.get("zone_id")
+        for entry in zone_entries
+        if isinstance(entry, dict) and isinstance(entry.get("zone_id"), str)
+    }
+
+    for index, entry in enumerate(zone_entries):
+        if not isinstance(entry, dict):
+            continue
+
+        for list_key in ("allowed_assets", "forbidden_crossings"):
+            value = entry.get(list_key)
+            if not isinstance(value, list):
+                errors.append(
+                    f"{zones_file}:zones[{index}].{list_key} must be a list"
+                )
+
+    assets_file = "security/asset_registry.yaml"
+    asset_entries = loaded_data.get(assets_file, {}).get("assets", [])
+    for index, entry in enumerate(asset_entries):
+        if not isinstance(entry, dict):
+            continue
+
+        criticality = entry.get("criticality")
+        if criticality not in ALLOWED_CRITICALITY:
+            errors.append(
+                f"{assets_file}:assets[{index}].criticality must be one of "
+                f"{sorted(ALLOWED_CRITICALITY)}"
+            )
+
+        zone = entry.get("zone")
+        if zone not in zone_ids:
+            errors.append(
+                f"{assets_file}:assets[{index}].zone '{zone}' is not defined in {zones_file}"
+            )
+
+    secrets_file = "security/secret_scope_registry.yaml"
+    secret_entries = loaded_data.get(secrets_file, {}).get("secrets", [])
+    for index, entry in enumerate(secret_entries):
+        if not isinstance(entry, dict):
+            continue
+
+        zone = entry.get("zone")
+        if zone not in zone_ids:
+            errors.append(
+                f"{secrets_file}:secrets[{index}].zone '{zone}' is not defined in {zones_file}"
+            )
+
+        blast_radius = entry.get("blast_radius")
+        if blast_radius not in ALLOWED_BLAST_RADIUS:
+            errors.append(
+                f"{secrets_file}:secrets[{index}].blast_radius must be one of "
+                f"{sorted(ALLOWED_BLAST_RADIUS)}"
+            )
+
+        status = entry.get("status")
+        if status not in ALLOWED_STATUS:
+            errors.append(
+                f"{secrets_file}:secrets[{index}].status must be one of "
+                f"{sorted(ALLOWED_STATUS)}"
+            )
+
+        if not _is_non_empty(entry.get("max_lifetime")):
+            errors.append(f"{secrets_file}:secrets[{index}].max_lifetime must be non-empty")
+
     if errors:
         print("[FAIL] Protect Frame verification failed:")
         for err in errors:
             print(f" - {err}")
         return 1
 
-    print("[OK] Protect Frame v0.1 verification succeeded.")
+    print("[OK] Protect Frame verification passed.")
     return 0
 
 

--- a/security/asset_registry.yaml
+++ b/security/asset_registry.yaml
@@ -1,49 +1,49 @@
 assets:
-  - asset_id: ASSET-EMAIL-001
+  - asset_id: ASSET-EMAIL-PRIMARY
     category: email
-    criticality: high
-    owner: team_owner
-    notes: Primary communication account template entry.
+    criticality: critical
+    owner: operations_owner
+    notes: Primary email identity used for account recovery and security notifications.
     zone: daily
 
-  - asset_id: ASSET-GITHUB-001
+  - asset_id: ASSET-GITHUB-CONTROL
     category: github
-    criticality: high
-    owner: team_owner
-    notes: Source control organization or repository access template entry.
+    criticality: critical
+    owner: repository_admin
+    notes: GitHub account and repository control path for code, settings, and access grants.
     zone: development
 
-  - asset_id: ASSET-CLOUD-001
+  - asset_id: ASSET-CLOUD-EXECUTION
     category: cloud
-    criticality: high
+    criticality: critical
     owner: infra_owner
-    notes: Cloud project or account access template entry.
+    notes: Cloud execution environment hosting runtime resources and deployment surface.
     zone: admin
 
-  - asset_id: ASSET-DOMAIN-001
+  - asset_id: ASSET-DOMAIN-DNS-CONTROL
     category: domain
-    criticality: medium
-    owner: ops_owner
-    notes: Domain registrar and DNS management template entry.
-    zone: admin
-
-  - asset_id: ASSET-BILLING-001
-    category: billing
     criticality: high
-    owner: finance_owner
-    notes: Billing portal and payment profile template entry.
+    owner: ops_owner
+    notes: Domain and DNS control that determines routing and service reachability.
     zone: admin
 
-  - asset_id: ASSET-AIAPI-001
+  - asset_id: ASSET-BILLING-PAYMENT
+    category: billing
+    criticality: critical
+    owner: finance_owner
+    notes: Billing and payment control for service continuity and spend governance.
+    zone: admin
+
+  - asset_id: ASSET-AI-PROVIDER-ACCESS
     category: ai_api
-    criticality: medium
+    criticality: high
     owner: platform_owner
-    notes: External AI provider account or project template entry.
+    notes: AI provider account access controlling API usage and project boundaries.
     zone: external_ai
 
-  - asset_id: ASSET-LOCAL-001
+  - asset_id: ASSET-LOCAL-DEVICE-PRIMARY
     category: local_device
     criticality: medium
     owner: individual_owner
-    notes: Local workstation or endpoint template entry.
+    notes: Primary local device used for daily operations and development entry.
     zone: daily

--- a/security/secret_scope_registry.yaml
+++ b/security/secret_scope_registry.yaml
@@ -1,50 +1,60 @@
 secrets:
-  - secret_id: SECRET-GITHUB-TOKEN-001
-    secret_type: github_token
-    scope: repo_or_org_minimum
+  - secret_id: SECRET-GITHUB-PAT-PRIMARY
+    secret_type: github_personal_access_token
+    scope: repo_scoped_minimum_permissions
     zone: development
     rotation_required: true
-    max_lifetime: 90d
-    usage_context: ci_or_local_automation
-    blast_radius: source_control_operations
-    status: active_template
+    max_lifetime: 30d
+    usage_context: local_git_and_repository_maintenance
+    blast_radius: medium
+    status: active
 
-  - secret_id: SECRET-CLOUD-APIKEY-001
-    secret_type: cloud_api_key
-    scope: service_scoped
+  - secret_id: SECRET-GITHUB-ACTIONS-AUTOMATION
+    secret_type: github_actions_secret
+    scope: workflow_specific_repository_secret
+    zone: development
+    rotation_required: true
+    max_lifetime: 45d
+    usage_context: ci_automation_and_release_steps
+    blast_radius: medium
+    status: review_required
+
+  - secret_id: SECRET-CLOUD-API-CREDENTIAL
+    secret_type: cloud_api_credential
+    scope: service_account_limited_to_runtime_ops
     zone: admin
     rotation_required: true
-    max_lifetime: 90d
-    usage_context: infrastructure_automation
-    blast_radius: cloud_resource_control
-    status: active_template
+    max_lifetime: 30d
+    usage_context: infrastructure_provisioning_and_runtime_admin
+    blast_radius: high
+    status: active
 
-  - secret_id: SECRET-DNS-CRED-001
+  - secret_id: SECRET-DNS-DOMAIN-CREDENTIAL
     secret_type: dns_domain_credential
-    scope: dns_only
+    scope: registrar_or_dns_provider_limited_access
     zone: admin
-    rotation_required: true
-    max_lifetime: 180d
-    usage_context: domain_and_dns_updates
-    blast_radius: domain_routing_and_resolution
-    status: active_template
-
-  - secret_id: SECRET-BILLING-CRED-001
-    secret_type: billing_credential
-    scope: billing_portal_only
-    zone: admin
-    rotation_required: true
-    max_lifetime: 180d
-    usage_context: invoicing_and_payment_admin
-    blast_radius: spending_and_payment_profile
-    status: active_template
-
-  - secret_id: SECRET-AI-APIKEY-001
-    secret_type: ai_provider_api_key
-    scope: project_scoped
-    zone: external_ai
     rotation_required: true
     max_lifetime: 60d
-    usage_context: model_api_calls
-    blast_radius: api_usage_and_data_exposure
-    status: active_template
+    usage_context: domain_records_and_zone_management
+    blast_radius: high
+    status: active
+
+  - secret_id: SECRET-BILLING-CREDENTIAL
+    secret_type: billing_credential
+    scope: billing_portal_with_payment_admin_limits
+    zone: admin
+    rotation_required: true
+    max_lifetime: 60d
+    usage_context: invoices_payment_methods_and_spend_review
+    blast_radius: high
+    status: review_required
+
+  - secret_id: SECRET-AI-PROVIDER-API-KEY
+    secret_type: ai_provider_api_key
+    scope: project_scoped_non_admin_key
+    zone: external_ai
+    rotation_required: true
+    max_lifetime: 30d
+    usage_context: model_api_calls_for_non_privileged_workloads
+    blast_radius: low
+    status: active

--- a/security/trust_zones.yaml
+++ b/security/trust_zones.yaml
@@ -1,50 +1,50 @@
 zones:
   - zone_id: daily
-    description: Daily-use user environment for routine communication and lightweight work.
+    description: Daily user environment for communication and routine operational tasks.
     allowed_assets:
       - email
       - local_device
     forbidden_crossings:
-      - direct_admin_credential_management
-      - unrestricted_cloud_control
-    notes: Keep day-to-day activities separate from privileged operations.
+      - direct_admin_credentials_use
+      - direct_admin_console_access
+    notes: Keep daily activity separate from privileged administration paths.
 
   - zone_id: development
-    description: Development and source-control execution surface.
+    description: Source-control and build surface used for implementation and repo workflows.
     allowed_assets:
       - github
       - local_device
     forbidden_crossings:
-      - direct_billing_operations
-      - registrar_level_domain_control
-    notes: Code operations should not imply finance or registrar authority.
+      - direct_billing_management
+      - registrar_level_domain_changes_without_admin_handoff
+    notes: Development can manage code but should not directly hold broad admin authority.
 
   - zone_id: admin
-    description: Privileged administration surface for cloud, billing, and domain governance.
+    description: Highest-trust control plane for cloud, domain, and billing administration.
     allowed_assets:
       - cloud
       - domain
       - billing
     forbidden_crossings:
-      - routine_daily_browsing_context
-      - unrestricted_external_ai_submission
-    notes: Highest-risk zone; requires tighter credential scope and review.
+      - mixed_daily_session_operations
+      - broad_secret_export_to_external_ai
+    notes: Most critical boundary; maintain strong separation from daily and external contexts.
 
   - zone_id: external_ai
-    description: External AI provider interaction boundary.
+    description: External AI interaction boundary for inference and model service usage.
     allowed_assets:
       - ai_api
     forbidden_crossings:
-      - raw_admin_secret_exposure
-      - direct_billing_authority_reuse
-    notes: Treat as controlled egress boundary for prompts and outputs.
+      - admin_privilege_delegation
+      - cross_zone_secret_reuse
+    notes: Do not provide management-level credentials or wide-scope secrets to this zone.
 
   - zone_id: public_surface
-    description: Public-facing published surface such as websites, docs, or open artifacts.
+    description: Public-facing publication surface for domains and open repository artifacts.
     allowed_assets:
       - domain
       - github
     forbidden_crossings:
+      - internal_admin_interface_exposure
       - privileged_secret_storage
-      - internal_admin_console_access
-    notes: Public exposure must not imply private control-plane reachability.
+    notes: Public surface stays isolated from internal control and privileged administration.


### PR DESCRIPTION
### Motivation
- Move the Protect Frame scaffold from template-first to a practical initial operational baseline while remaining lightweight and non-destructive.
- Improve readability and alignment between assets, secrets, and trust zones so reviewers can quickly understand what is protected and what must not cross boundaries.
- Strengthen structural verification slightly to catch common misconfigurations without adding enforcement or external dependencies.

### Description
- Updated `security/asset_registry.yaml` to enumerate seven practical baseline assets (primary email, GitHub control, cloud execution, domain/DNS control, billing/payment, AI provider access, primary local device) with normalized fields `asset_id`, `category`, `criticality`, `owner`, `notes`, and `zone`, and aligned `criticality` values (`critical`, `high`, `medium`).
- Updated `security/secret_scope_registry.yaml` to list six secret metadata entries (GitHub PAT, GitHub Actions secret, Cloud API credential, DNS/domain credential, Billing credential, AI provider API key) including `secret_id`, `secret_type`, `scope`, `zone`, `rotation_required`, `max_lifetime`, `usage_context`, `blast_radius`, and `status`, and made `blast_radius` and `status` comparable (`high|medium|low`, `active|review_required|disabled`) with finite `max_lifetime` examples.
- Clarified `security/trust_zones.yaml` zone definitions (`daily`, `development`, `admin`, `external_ai`, `public_surface`) with improved `description`, explicit `allowed_assets` lists, `forbidden_crossings` lists, and notes that emphasize `admin` as the highest-trust boundary and the separation principles for `daily`/`admin` and `external_ai`/public surfaces.
- Strengthened `scripts/security/verify_protect_frame.py` (still lightweight) by adding explicit allowed-value sets and checks for: `criticality` values, asset/secret `zone` existence against `trust_zones.yaml`, secret `blast_radius` and `status` values, non-empty `max_lifetime`, and list-type checks for `allowed_assets` and `forbidden_crossings`; preserved the PyYAML fallback parser and non-mutating behavior.
- Added an `Operational Notes` section to `docs/security/PROTECT_FRAME_v0.1.md` to state that registries are scaffolded for real use, secrets are metadata-only, verification is structural, and CI/incident linkage is deferred.

### Testing
- Ran `python scripts/security/verify_protect_frame.py` and it passed (exit 0) with the enhanced checks. 
- Verified YAML files are parseable via the script; an attempted `yaml.safe_load` run indicated `PyYAML` was not installed in the environment, but the script’s fallback parser successfully validated the files. 
- Confirmed the change set is limited to the requested Protect Frame files and that no new files, workflows, incidents, or enforcement logic were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8395215cc832bb7973d7ec7845218)