### PR TITLE
Add minimal intent_record schema artifact

### DIFF
--- a/schemas/intent_record.schema.yaml
+++ b/schemas/intent_record.schema.yaml
@@ -1,0 +1,8 @@
+record_type: intent_record
+purpose: store minimal intent records for reconstructable execution flows
+required_fields:
+  - intent_id
+  - skill_id
+  - requested_by
+  - requested_at
+record_scope: cross_repo_execution_intent


### PR DESCRIPTION
### Motivation
- Provide an initial, minimal RTS-side schema for recording execution intent in a reconstructable way.

### Description
- Add `schemas/intent_record.schema.yaml` containing only `record_type: intent_record`, `purpose: store minimal intent records for reconstructable execution flows`, `required_fields` (`intent_id`, `skill_id`, `requested_by`, `requested_at`), and `record_scope: cross_repo_execution_intent`.

### Testing
- Verified presence and content with `nl -ba schemas/intent_record.schema.yaml` and repository operations `git add` and `git commit`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83a986c94832bb5262af7fdcfb557)