### PR TITLE
Add intent/execution overview doc and intent_record schema

### DIFF
--- a/docs/overview/INTENT_AND_EXECUTION.md
+++ b/docs/overview/INTENT_AND_EXECUTION.md
@@ -1,0 +1,26 @@
+# Intent and Execution
+
+## Purpose
+This note describes the minimal structural relationship between `intent_record` and `execution_record` in the RTS core.
+
+## Intent Record
+`intent_record` is the minimal record of requested execution intent. It includes:
+- `intent_id`
+- `skill_id`
+- `requested_by`
+- `requested_at`
+
+## Execution Record
+`execution_record` is the minimal record of executed skill flow. It includes:
+- `skill_id`
+- `drive_id`
+- `pack_id`
+- `trigger`
+- `result`
+- `timestamp`
+
+## Relationship
+Reconstructable execution may rely on both intent records and execution records.
+
+## Boundary
+This is a structural overview only. It does not define full linkage or runtime implementation.

--- a/schemas/intent_record.schema.yaml
+++ b/schemas/intent_record.schema.yaml
@@ -1,0 +1,8 @@
+record_type: intent_record
+purpose: store minimal intent records for reconstructable execution flows
+required_fields:
+  - intent_id
+  - skill_id
+  - requested_by
+  - requested_at
+record_scope: cross_repo_execution_intent


### PR DESCRIPTION
### Motivation
- Document the minimal structural relationship between `intent_record` and `execution_record` to support reconstructable execution flows.
- Provide a canonical, machine-readable schema for `intent_record` to standardize cross-repo intent storage.
- Clarify that the note is a structural overview and not a runtime or linkage specification.

### Description
- Add `docs/overview/INTENT_AND_EXECUTION.md` which defines the purpose, minimal fields for `intent_record` and `execution_record`, their relationship, and the boundary of the note.
- Add `schemas/intent_record.schema.yaml` which declares `record_type: intent_record`, `purpose`, `record_scope`, and the `required_fields` list.
- The schema requires `intent_id`, `skill_id`, `requested_by`, and `requested_at` as the minimal intent payload.

### Testing
- No automated tests were run for these documentation and schema additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e83a986c94832bb5262af7fdcfb557)