### PR TITLE
Add minimal checkpoint_ref schema artifact

### DIFF
--- a/schemas/checkpoint_ref.schema.yaml
+++ b/schemas/checkpoint_ref.schema.yaml
@@ -1,0 +1,8 @@
+record_type: checkpoint_ref
+purpose: store minimal references to resumable checkpoints in reconstructable execution flows
+required_fields:
+  - checkpoint_id
+  - skill_id
+  - checkpoint_ref
+  - recorded_at
+record_scope: cross_repo_checkpoint_reference


### PR DESCRIPTION
### Motivation
- Provide an initial, minimal RTS-side schema artifact to reference resumable checkpoints in reconstructable execution flows.

### Description
- Create `schemas/checkpoint_ref.schema.yaml` containing only `record_type`, `purpose`, `required_fields` (``checkpoint_id``, ``skill_id``, ``checkpoint_ref``, ``recorded_at``), and `record_scope` with the specified values.

### Testing
- Ran repository verification commands `nl -ba schemas/checkpoint_ref.schema.yaml`, `git status --short`, and `git show --name-only HEAD`, and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8525ecb58832b94b47f7621af9dac)