### PR TITLE
Add minimal checkpoint_ref schema artifact

### DIFF
--- a/schemas/checkpoint_ref.schema.yaml
+++ b/schemas/checkpoint_ref.schema.yaml
@@ -1,0 +1,8 @@
+record_type: checkpoint_ref
+purpose: store minimal references to resumable checkpoints in reconstructable execution flows
+required_fields:
+  - checkpoint_id
+  - skill_id
+  - checkpoint_ref
+  - recorded_at
+record_scope: cross_repo_checkpoint_reference


### PR DESCRIPTION
### Motivation
- Introduce a minimal RTS-side schema artifact to represent references to resumable checkpoints across repositories for reconstructable execution flows.

### Description
- Add `schemas/checkpoint_ref.schema.yaml` with only the requested keys and values: `record_type: checkpoint_ref`, `purpose: store minimal references to resumable checkpoints in reconstructable execution flows`, `required_fields: [checkpoint_id, skill_id, checkpoint_ref, recorded_at]`, and `record_scope: cross_repo_checkpoint_reference`.

### Testing
- Ran repository and git checks including `find .. -name AGENTS.md -print`, `git status --short`, and `git show --name-only --pretty=format: HEAD`, and committed the new file, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87596d440832b82f9bdb11b4d8708)