### PR TITLE
Add canonical index, ecosystem map docs, minimal manifest and templates

### DIFF
--- a/docs/CANONICAL_INDEX.md
+++ b/docs/CANONICAL_INDEX.md
@@ -1,0 +1,48 @@
+# Canonical Index (RTS Trust and Reconstruction Core)
+
+This index defines the canonical reading order and boundaries for this repository.
+
+## Scope declaration
+
+This repository remains the **RTS trust and reconstruction core**.
+
+Out of scope for this repo (reference only, no bundled implementation here):
+- Skills
+- MCP Packs
+- Hermes
+- Talent Registry
+- Signal Feeds
+
+## Classification model
+
+### Canonical (active reference set)
+- `README.md`
+- `AGENTS.md`
+- `docs/overview/POSITION.md`
+- `docs/technical_overview.md`
+- `docs/core/`
+- `docs/spec/`
+- `schemas/`
+- `security/`
+- `sessions/` (append-only record surface)
+
+### Genesis (historical origin set)
+- `docs/genesis/`
+- `docs/history/`
+- `logs/BLOCK_00000015_RTS_PUBLIC_RELEASE.md`
+- `logs/BLOCK_00000016_RTS_TESTER_RECRUITMENT.md`
+- `logs/BLOCK_00000017_GENESIS_AUTONOMOUS.md`
+- `logs/BLOCK_00000018_AUTORESET_ENGINE_ONLINE.md`
+
+### Archive / operational evidence (high-volume record set)
+- `analysis/`
+- `incidents/`
+- `sessions/` monthly snapshots and evidence packs
+- `logs/implementation/`
+- `logs/organization/`
+
+## Entry points
+
+- Ecosystem map: `docs/ecosystem/INDEX.md`
+- RTS-only operating boundary: `docs/ecosystem/OPERATING_MODEL.md`
+- Canonical manifest pointer: `docs/manifest.md`

--- a/docs/ecosystem/BOOTSTRAP.md
+++ b/docs/ecosystem/BOOTSTRAP.md
@@ -1,0 +1,9 @@
+# RTS Core Bootstrap (Minimal)
+
+1. Read `README.md`
+2. Read `docs/overview/POSITION.md`
+3. Read `docs/technical_overview.md`
+4. Read `docs/CANONICAL_INDEX.md`
+5. Read `docs/ecosystem/OPERATING_MODEL.md`
+
+Then validate that planned work stays within trust and reconstruction core boundaries.

--- a/docs/ecosystem/CODEX_ROUTING.md
+++ b/docs/ecosystem/CODEX_ROUTING.md
@@ -1,0 +1,20 @@
+# Codex Routing for RTS Core
+
+## Task routing heuristic
+
+- **Implementation in RTS core contracts**: allowed in this repo
+- **Organization/indexing for RTS docs**: allowed in this repo
+- **External subsystem implementation (Skills/MCP/Hermes/Talent/Signal)**: route out of repo
+
+## Allowed contribution types here
+
+- canonical index updates
+- ecosystem map updates
+- schema/rulebook/document alignment
+- integrity-safe link/reference fixes
+
+## Disallowed contribution types here
+
+- importing external ecosystem runtime artifacts
+- adding orchestration-specific business logic
+- bundling registry/feed production data

--- a/docs/ecosystem/INDEX.md
+++ b/docs/ecosystem/INDEX.md
@@ -1,0 +1,10 @@
+# RTS Ecosystem Map Index
+
+This directory provides **map-level documentation only** for ecosystem alignment around RTS core.
+
+- `REPO_MAP.md` — repository boundaries and adjacency map
+- `OPERATING_MODEL.md` — trust core operating model and non-responsibilities
+- `CODEX_ROUTING.md` — contribution routing rules for Codex/local tasks
+- `BOOTSTRAP.md` — minimal bootstrap reading path
+
+No external subsystem implementation is included in this repository.

--- a/docs/ecosystem/OPERATING_MODEL.md
+++ b/docs/ecosystem/OPERATING_MODEL.md
@@ -1,0 +1,25 @@
+# RTS Trust Core Operating Model
+
+## Principle
+
+RTS is a structural trust core, not a general execution platform.
+
+## Owns
+
+- Decision reconstructability contracts
+- Record and evidence structure
+- Checkpoint/resume semantics
+- Integrity and governance constraints
+
+## Does not own
+
+- Runtime connector packs
+- Agent skill libraries
+- External operator registries
+- Live signal ingestion systems
+
+## Change discipline
+
+- Prefer additive, minimal, reviewable documentation changes
+- Preserve append-only record surfaces
+- Keep implementation and organization tasks separated

--- a/docs/ecosystem/REPO_MAP.md
+++ b/docs/ecosystem/REPO_MAP.md
@@ -1,0 +1,23 @@
+# RTS Ecosystem Repository Map
+
+## Core repository (this repo)
+
+RTS trust and reconstruction core:
+- canonical schemas
+- append-only session/evidence surfaces
+- reconstruction and integrity rules
+- governance and rollback-safe documentation
+
+## External/adjacent domains (reference only)
+
+The following are ecosystem-adjacent and intentionally out of this repository implementation scope:
+- Skills runtime/catalog
+- MCP Packs
+- Hermes orchestration layer
+- Talent Registry operations
+- Signal Feed operations
+
+## Integration posture
+
+This repository should expose stable contracts (schemas/rules/docs) that external systems can consume.
+It should not absorb execution harness implementations from adjacent domains.

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -1,0 +1,15 @@
+# RTS Manifest (Minimal)
+
+This manifest is a stable entry pointer from `README.md`.
+
+## Core entry set
+- `README.md`
+- `docs/overview/POSITION.md`
+- `docs/technical_overview.md`
+- `docs/CANONICAL_INDEX.md`
+- `docs/ecosystem/INDEX.md`
+
+## Boundary note
+
+This repository is the RTS trust and reconstruction core.
+Ecosystem components (Skills / MCP Packs / Hermes / Talent Registry / Signal Feeds) are reference-only and not implemented here.

--- a/templates/signal-record.template.yaml
+++ b/templates/signal-record.template.yaml
@@ -1,0 +1,19 @@
+# Template only. Do not store live signal feed records in this repo.
+record_type: signal_record
+version: 0.1
+status: draft
+metadata:
+  created_at: "YYYY-MM-DDTHH:MM:SSZ"
+  created_by: ""
+  source_system: "external"
+signal:
+  signal_id: ""
+  category: ""
+  severity: "low|medium|high"
+  observed_at: "YYYY-MM-DDTHH:MM:SSZ"
+assessment:
+  structural_impact: ""
+  reconstruction_relevance: ""
+links:
+  external_feed_ref: ""
+  evidence_ref: ""

--- a/templates/talent-adoption-record.template.yaml
+++ b/templates/talent-adoption-record.template.yaml
@@ -1,0 +1,18 @@
+# Template only. Do not store live registry records in this repo.
+record_type: talent_adoption_record
+version: 0.1
+status: draft
+metadata:
+  created_at: "YYYY-MM-DDTHH:MM:SSZ"
+  created_by: ""
+  source_system: "external"
+subject:
+  talent_id: ""
+  role: ""
+adoption:
+  decision_ref: ""
+  rationale: ""
+  effective_date: "YYYY-MM-DD"
+links:
+  external_registry_ref: ""
+  evidence_ref: ""


### PR DESCRIPTION
### Motivation
- Establish a minimal, reviewable ecosystem map and canonical classification for the RTS trust-and-reconstruction core without pulling in external runtime artifacts. 
- Resolve a missing README reference to `docs/manifest.md` by providing a minimal manifest pointer while preserving existing primary docs and boundaries. 
- Provide template stubs for external-record shape guidance so implementers have safe examples without storing live registry/feed data in this repo.

### Description
- Added `docs/CANONICAL_INDEX.md` to classify repository surfaces into `canonical / genesis / archive` and to declare out-of-scope ecosystem components. 
- Added an ecosystem map under `docs/ecosystem/` with `INDEX.md`, `REPO_MAP.md`, `OPERATING_MODEL.md`, `CODEX_ROUTING.md`, and `BOOTSTRAP.md` to document operating boundaries and contribution routing. 
- Added a minimal `docs/manifest.md` as a stable README pointer so existing README links are valid. 
- Added template-only YAML examples `templates/talent-adoption-record.template.yaml` and `templates/signal-record.template.yaml` as non-production stubs. 
- No existing files were overwritten, no code or external subsystem implementations were added, and no file moves or renames were performed.

### Testing
- Verified repository file listing with `rg --files` and located `AGENTS.md` with `find .. -name AGENTS.md -print`, both succeeding. 
- Inspected primary documents using `sed -n '1,220p'` on `README.md`, `AGENTS.md`, `docs/overview/POSITION.md`, and `docs/technical_overview.md` to ensure no unintended changes. 
- Confirmed `docs/manifest.md` did not exist prior to these changes via `test -f docs/manifest.md` and validated README references to `manifest.md`. 
- Performed a repository status check with `git status --short` and verified the new files appear as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f97e5369c8832b96c78c7441d39eec)