### PR TITLE
Add RTS ecosystem map and project registry

### DIFF
--- a/docs/ecosystem/INDEX.md
+++ b/docs/ecosystem/INDEX.md
@@ -3,6 +3,7 @@
 This directory provides **map-level documentation only** for ecosystem alignment around RTS core.
 
 - `REPO_MAP.md` — repository boundaries and adjacency map
+- `PROJECT_REGISTRY.md` — current rescue classification and project registry
 - `OPERATING_MODEL.md` — trust core operating model and non-responsibilities
 - `CODEX_ROUTING.md` — contribution routing rules for Codex/local tasks
 - `BOOTSTRAP.md` — minimal bootstrap reading path

--- a/docs/ecosystem/PROJECT_REGISTRY.md
+++ b/docs/ecosystem/PROJECT_REGISTRY.md
@@ -1,0 +1,98 @@
+# RTS Ecosystem Project Registry
+
+This registry records the current rescue classification of repositories around RTS.
+
+It is a working registry, not a protocol change.
+
+The purpose is to prevent frozen, half-built, or adjacent repositories from becoming ambiguous debt.
+
+## Classification Labels
+
+- ACTIVE: continue using or maintaining now
+- CANON: canonical reference point
+- REFERENCE: minimal reference implementation or proof
+- RESCUE: valuable but needs boundary stabilization
+- MONEY-LINE: closest to revenue-producing workflow
+- SALES-LP: external sales surface
+- PRODUCT: independent product candidate
+- PARTS: reusable component shelf
+- FREEZE: keep but do not actively develop now
+- ARCHIVE CANDIDATE: likely keep only for history/testing
+- DELETE CANDIDATE: safe to delete after final operator confirmation
+
+## Active / Canonical
+
+| Repository | Status | Role | Next Safe Action |
+|---|---|---|---|
+| RTS | ACTIVE / CANON | Canonical protocol and structural ledger | Keep core stable; maintain ecosystem map |
+| RTS-Minimal-Runtime | ACTIVE / REFERENCE | Minimal reconstructable runtime proof | Keep small; avoid feature expansion |
+| RTS-AGE | RESCUE / GATEWAY | Agentic gateway and execution lab | Stabilize gateway/provider boundary |
+| RTS-minicompany | ACTIVE / MONEY-LINE | Solo business operation MVP | Validate local CLI and human approval workflow |
+| rts01-offer | ACTIVE / SALES-LP | Static offer landing page | Document delivery workflow relation |
+| seminar-compass | ACTIVE / PRODUCT | Learning reconstruction product candidate | Validate local test/app path and output contract |
+| nobutakayamauchi | ACTIVE / PROFILE | Public profile and RTS positioning surface | Keep aligned with current RTS ecosystem position |
+
+## Parts / Extension Shelves
+
+| Repository | Status | Role | Next Safe Action |
+|---|---|---|---|
+| RTS-Skills | PARTS / SKILLS | Reusable operational skills | Later skill inventory pass |
+| RTS-MCP-Packs | PARTS / CONNECTOR-PACKS | Connector pack definitions | Later pack inventory pass |
+| RTS-Hermes-Drive | PARTS / ORCHESTRATION | Orchestration bridge | Later relationship review with Skills/Packs |
+| RTS-Design-Research | PARTS / DESIGN-LAYER | Design research extension | Later design decision workflow review |
+| rts-dev-protocol | PARTS / DOCTRINE | Structure-first development notes | Extract useful doctrine into stable docs if needed |
+
+## Frozen / Later Review
+
+| Repository | Status | Role | Next Safe Action |
+|---|---|---|---|
+| RTS-Talent-Registry | FREEZE / GOVERNANCE-PARTS | AI talent governance registry | Keep for later ecosystem governance review |
+| RTS-Signal-Feeds | FREEZE / SIGNAL-PARTS | Signal intelligence layer | Keep for later signal workflow review |
+| rts-video-flow | FREEZE / MEDIA-PARTS | Video workflow scaffold | Keep for later media workflow review |
+| AIX | FREEZE / RESEARCH | Execution-aware arbitrage research scaffold | Keep separate from RTS business/product line |
+
+## Archive / Delete Candidates
+
+| Repository | Status | Role | Next Safe Action |
+|---|---|---|---|
+| codex-connector-test | ARCHIVE CANDIDATE | Connector test repository | Archive after confirming no active dependency |
+| ryoushuushotesutoyou | DELETE CANDIDATE | Receipt image/output test | Delete or archive after final operator confirmation |
+| rts-lite | ARCHIVE / DELETE CANDIDATE | Empty or obsolete lightweight placeholder | Delete or archive after confirming no active dependency |
+
+## Promotion Rule
+
+A repository may move from PARTS or FREEZE to ACTIVE only after:
+
+1. Its role is documented.
+2. Its relation to RTS core is clear.
+3. It has a Minimum Alive status document.
+4. It has a next safe task.
+5. It does not require changing RTS core to become useful.
+
+## Deletion Rule
+
+A repository should not be deleted only because it is inactive.
+
+Deletion is appropriate when:
+
+1. The repository is a pure test artifact.
+2. It has no reusable code, documentation, or decision history.
+3. It is superseded by a clearer repository.
+4. The operator confirms it has no remaining practical value.
+
+## Current Rescue Order
+
+Completed or in progress:
+
+1. RTS-AGE
+2. RTS-minicompany
+3. seminar-compass
+4. rts01-offer
+5. RTS ecosystem map / registry
+
+Recommended next:
+
+1. RTS-Minimal-Runtime status lock
+2. RTS-Skills inventory pass
+3. RTS-Design-Research inventory pass
+4. Archive/delete candidate confirmation

--- a/docs/ecosystem/REPO_MAP.md
+++ b/docs/ecosystem/REPO_MAP.md
@@ -1,23 +1,228 @@
 # RTS Ecosystem Repository Map
 
-## Core repository (this repo)
+This document maps repositories around RTS without changing RTS core behavior.
 
-RTS trust and reconstruction core:
-- canonical schemas
-- append-only session/evidence surfaces
-- reconstruction and integrity rules
-- governance and rollback-safe documentation
+RTS remains the canonical decision reconstructability protocol and structural ledger.
 
-## External/adjacent domains (reference only)
+Surrounding repositories may implement, demonstrate, sell, test, or extend RTS-style workflows, but they are not RTS core unless explicitly promoted by a separate decision record.
 
-The following are ecosystem-adjacent and intentionally out of this repository implementation scope:
-- Skills runtime/catalog
-- MCP Packs
-- Hermes orchestration layer
-- Talent Registry operations
-- Signal Feed operations
+## Core Repository
 
-## Integration posture
+### RTS
 
-This repository should expose stable contracts (schemas/rules/docs) that external systems can consume.
-It should not absorb execution harness implementations from adjacent domains.
+Role: Canonical protocol / structural ledger.
+
+Status: ACTIVE / CANON.
+
+Purpose:
+
+- define reconstructable decision and execution structures
+- preserve decision authority, assumptions, and execution state
+- expose stable schemas, rules, and documentation that other systems can consume
+- serve as the reference point for the surrounding ecosystem
+
+Boundary:
+
+- do not absorb execution harness implementations from adjacent domains
+- do not use surrounding repository behavior to silently redefine RTS core
+- do not merge runtime, sales, connector, signal, design, or product experiments into RTS core without a separate decision record
+
+## Reference Runtime
+
+### RTS-Minimal-Runtime
+
+Role: Minimal reference runtime.
+
+Status: ACTIVE / REFERENCE.
+
+Purpose:
+
+- demonstrate the smallest reconstructable flow
+- preserve `intent -> spec -> execution_record -> manifest -> reconstruction` as a reference path
+
+Boundary:
+
+- do not expand into RTS-AGE
+- do not turn into a UI, cloud runner, or multi-agent platform
+
+## Execution Gateway
+
+### RTS-AGE
+
+Role: Agentic Gateway & Execution Lab.
+
+Status: RESCUE / GATEWAY.
+
+Purpose:
+
+- receive work orders, signals, and operator instructions
+- produce plans, patches, dry-runs, validation reports, and RTS record proposals
+
+Boundary:
+
+- not RTS core
+- not the canonical home of skills, packs, feeds, design research, or talent registry data
+- proposal-first by default
+
+## Money-Line / Business Operations
+
+### RTS-minicompany
+
+Role: Solo business operation MVP.
+
+Status: ACTIVE / MONEY-LINE.
+
+Purpose:
+
+- process one business case at a time
+- generate sales, proposal, delivery preparation, risk check, and trace outputs
+- support human-reviewed solo business execution
+
+Boundary:
+
+- not a fully autonomous sales agent
+- not a customer contact system by default
+- human approval remains required for price, scope, contract, and contact decisions
+
+### rts01-offer
+
+Role: Static offer landing page.
+
+Status: ACTIVE / SALES-LP.
+
+Purpose:
+
+- present the AI development reset / project audit offer
+- direct prospects to a human-reviewed contact path
+
+Boundary:
+
+- not the delivery workflow itself
+- not RTS core
+- should not overpromise results or automation capability
+
+## Product Candidates
+
+### seminar-compass
+
+Role: Learning reconstruction product candidate.
+
+Status: ACTIVE / PRODUCT.
+
+Purpose:
+
+- transform learning material into structured outputs such as claims, assumptions, prerequisites, priorities, practical takeaways, and retrieval prompts
+
+Boundary:
+
+- not a generic summarizer
+- not RTS core
+- not RTS-AGE
+
+## Parts / Extension Shelves
+
+### RTS-Skills
+
+Role: Reusable operational skills.
+
+Status: PARTS / SKILLS.
+
+Purpose:
+
+- hold reusable AI-agnostic operational skills and wrappers
+
+### RTS-MCP-Packs
+
+Role: Connector pack definitions.
+
+Status: PARTS / CONNECTOR-PACKS.
+
+Purpose:
+
+- hold reusable MCP connector pack definitions for future operator environments
+
+### RTS-Hermes-Drive
+
+Role: Orchestration bridge.
+
+Status: PARTS / ORCHESTRATION.
+
+Purpose:
+
+- bridge RTS skills and pack concepts into Hermes-style drive/orchestration structures
+
+### RTS-Design-Research
+
+Role: Design research extension layer.
+
+Status: PARTS / DESIGN-LAYER.
+
+Purpose:
+
+- convert design references and UI research into RTS-compatible design decision material
+
+### rts-dev-protocol
+
+Role: Development doctrine notes.
+
+Status: PARTS / DOCTRINE.
+
+Purpose:
+
+- preserve structure-first development protocol notes and architecture vocabulary
+
+## Freeze / Later Review
+
+### RTS-Talent-Registry
+
+Role: AI talent governance registry.
+
+Status: FREEZE / GOVERNANCE-PARTS.
+
+### RTS-Signal-Feeds
+
+Role: Signal intelligence layer.
+
+Status: FREEZE / SIGNAL-PARTS.
+
+### rts-video-flow
+
+Role: Video workflow scaffold.
+
+Status: FREEZE / MEDIA-PARTS.
+
+### AIX
+
+Role: Execution-aware arbitrage research scaffold.
+
+Status: FREEZE / RESEARCH.
+
+## Archive / Delete Candidates
+
+### codex-connector-test
+
+Role: Connector test repository.
+
+Status: ARCHIVE CANDIDATE.
+
+### ryoushuushotesutoyou
+
+Role: Receipt image/output test.
+
+Status: DELETE CANDIDATE.
+
+### rts-lite
+
+Role: Empty or obsolete lightweight RTS placeholder.
+
+Status: ARCHIVE / DELETE CANDIDATE.
+
+## Rule of Thumb
+
+- RTS defines the protocol.
+- RTS-Minimal-Runtime proves the smallest runtime.
+- RTS-AGE prepares proposals and validation artifacts.
+- RTS-minicompany operates the money-line workflow.
+- rts01-offer sells the audit/reset offer.
+- seminar-compass is an independent product candidate.
+- skills, packs, drive, design, talent, and signal repositories are extension shelves until promoted.

--- a/docs/ecosystem/REPO_MAP.md
+++ b/docs/ecosystem/REPO_MAP.md
@@ -119,6 +119,25 @@ Boundary:
 - not RTS core
 - not RTS-AGE
 
+## Public Profile Surface
+
+### nobutakayamauchi
+
+Role: Public profile and RTS positioning surface.
+
+Status: ACTIVE / PROFILE.
+
+Purpose:
+
+- present the operator identity and RTS positioning
+- point readers toward the canonical RTS repository and ecosystem direction
+
+Boundary:
+
+- not RTS core
+- not a runtime or delivery workflow
+- should stay aligned with the current RTS ecosystem position
+
 ## Parts / Extension Shelves
 
 ### RTS-Skills
@@ -225,4 +244,5 @@ Status: ARCHIVE / DELETE CANDIDATE.
 - RTS-minicompany operates the money-line workflow.
 - rts01-offer sells the audit/reset offer.
 - seminar-compass is an independent product candidate.
+- nobutakayamauchi is the public profile and positioning surface.
 - skills, packs, drive, design, talent, and signal repositories are extension shelves until promoted.


### PR DESCRIPTION
## Summary

This PR adds ecosystem-level documentation to RTS so adjacent repositories can be classified without changing RTS core behavior.

## Files Changed

- `docs/ecosystem/REPO_MAP.md`
- `docs/ecosystem/PROJECT_REGISTRY.md`

## What Changed

- Expands the RTS ecosystem repository map.
- Adds a working project registry for active, rescue, parts, freeze, archive, and delete-candidate repositories.
- Clarifies that RTS remains the canonical protocol / structural ledger.
- Clarifies that surrounding repositories do not redefine RTS core unless promoted by a separate decision record.
- Records the current rescue order and next recommended repositories.

## What Did Not Change

- No runtime code changed.
- No protocol schemas changed.
- No dependencies changed.
- No GitHub Actions changed.
- No RTS core behavior changed.
- No surrounding repositories were modified by this PR.

## Validation

Documentation-only change. No runtime validation was performed.

## Residual Risks

- Repository classifications are current working labels and may need updates as rescue passes continue.
- The next pass should lock RTS-Minimal-Runtime as a minimal reference repository.
