### PR TITLE
Add Governed Skill Regression Dataset v1

### DIFF
--- a/.github/workflows/freezer-tests.yml
+++ b/.github/workflows/freezer-tests.yml
@@ -8,6 +8,7 @@ on:
       - "loop_core/**"
       - "execution_controller/**"
       - "outcome_evidence/**"
+      - "skill_regression/**"
       - "tests/test_freezer.py"
       - "tests/test_freezer_build_assessment.py"
       - "tests/test_asset_manifest.py"
@@ -15,9 +16,11 @@ on:
       - "tests/test_execution_controller.py"
       - "tests/test_execution_controller_state_continuity.py"
       - "tests/test_outcome_evidence.py"
+      - "tests/test_skill_regression.py"
       - "docs/implementation/READ_ONLY_LOOP_CORE_V1_TASK.md"
       - "docs/implementation/GOVERNED_EXECUTION_CONTROLLER_V1_TASK.md"
       - "docs/implementation/GOVERNED_OUTCOME_EVIDENCE_CORPUS_V1_TASK.md"
+      - "docs/implementation/GOVERNED_SKILL_REGRESSION_DATASET_V1_TASK.md"
       - ".github/workflows/freezer-tests.yml"
   push:
     branches:
@@ -28,6 +31,7 @@ on:
       - "loop_core/**"
       - "execution_controller/**"
       - "outcome_evidence/**"
+      - "skill_regression/**"
       - "tests/test_freezer.py"
       - "tests/test_freezer_build_assessment.py"
       - "tests/test_asset_manifest.py"
@@ -35,9 +39,11 @@ on:
       - "tests/test_execution_controller.py"
       - "tests/test_execution_controller_state_continuity.py"
       - "tests/test_outcome_evidence.py"
+      - "tests/test_skill_regression.py"
       - "docs/implementation/READ_ONLY_LOOP_CORE_V1_TASK.md"
       - "docs/implementation/GOVERNED_EXECUTION_CONTROLLER_V1_TASK.md"
       - "docs/implementation/GOVERNED_OUTCOME_EVIDENCE_CORPUS_V1_TASK.md"
+      - "docs/implementation/GOVERNED_SKILL_REGRESSION_DATASET_V1_TASK.md"
       - ".github/workflows/freezer-tests.yml"
 
 permissions:
@@ -59,6 +65,7 @@ jobs:
           python -m loop_core.cli verify
           python -m execution_controller.cli verify
           python -m outcome_evidence.cli verify
+          python -m skill_regression.cli verify
       - name: Fail on stale committed indexes
         run: |
           python - <<'PY'
@@ -116,3 +123,4 @@ jobs:
           python -m loop_core.cli verify
           python -m execution_controller.cli verify
           python -m outcome_evidence.cli verify
+          python -m skill_regression.cli verify

--- a/docs/implementation/GOVERNED_SKILL_REGRESSION_DATASET_V1_TASK.md
+++ b/docs/implementation/GOVERNED_SKILL_REGRESSION_DATASET_V1_TASK.md
@@ -1,0 +1,67 @@
+# Governed Skill Regression Dataset v1 — Implementation Contract
+
+## Purpose
+
+Create the second research prerequisite for `RTS-FRZ-000007 Outcome Learning and Skill Promotion`: an immutable baseline/candidate Skill comparison with deterministic fixtures and a rollback snapshot.
+
+## Source baseline
+
+The baseline is pinned to the public RTS-Skills asset:
+
+```text
+repository: nobutakayamauchi/RTS-Skills-
+commit: 66991529519795e62d61874d6a6197ae14e01967
+path: rts-skills/bundles/feature-build.md
+```
+
+The source repository remains unchanged.
+
+## Candidate scope
+
+The candidate is a repository-local fixture derived from the pinned baseline. It adds rollback-snapshot preparation and explicit human-approval boundaries. It is not a publication candidate and must remain `NOT_ELIGIBLE`.
+
+## Required artifacts
+
+- pinned baseline content and metadata
+- local candidate content and metadata
+- structured baseline and candidate contracts
+- explicit references to the three governed outcome bundles
+- deterministic functional and safety fixtures
+- immutable acceptance/rejection thresholds
+- rollback snapshot that restores the baseline content hash
+- committed deterministic evaluation result
+- read-only validator and CLI
+- mutation and boundary tests
+- governed CI coverage
+
+## Acceptance policy
+
+The candidate is `RESEARCH_READY` only when all are true:
+
+- regressions equal zero
+- candidate safety failures equal zero
+- candidate improves at least two fixtures
+- candidate passes all applicable fixtures
+- rollback snapshot reconstructs the exact baseline
+- all fingerprints and file hashes verify
+- no external execution or adjacent-repository mutation is claimed
+
+## Permanent prohibitions
+
+This package must not:
+
+- promote, publish, retire, or mutate a Skill
+- write to RTS-Skills or any adjacent repository
+- create a promotion proposal or human decision record
+- create or pass the `RTS-FRZ-000007` Implementation Preflight
+- change FREEZER status or build authority
+- use network, provider, subprocess, shell, publish, deploy, send, or schedule
+- ingest prompts, secrets, credentials, customer data, provider payloads, or private repository bodies
+- weaken the committed v1 thresholds
+
+## Verification
+
+```text
+python -m skill_regression.cli verify
+python -B -m unittest tests.test_skill_regression -v
+```

--- a/outcome_evidence/README.md
+++ b/outcome_evidence/README.md
@@ -34,13 +34,13 @@ python -m outcome_evidence.cli show RTS-OUTCOME-000001
 
 `verify` is read-only. It checks exact schemas, canonical fingerprints, evidence-file hashes, cross-record agreement, required scenario variation, privacy-sensitive keys, path containment, no external-execution claims, and the permanent `NOT_ELIGIBLE` promotion boundary.
 
-## What this unlocks
+## Companion prerequisite
 
-This satisfies only the evidence-corpus research prerequisite. It does not create:
+The governed baseline/candidate comparison, immutable thresholds, deterministic fixtures, and rollback snapshot now live in `skill_regression/`.
 
-- a baseline/candidate Skill regression dataset
-- acceptance or rejection thresholds
-- an immutable rollback snapshot
+Together, the two packages provide research evidence for a future FREEZER reassessment. They still do not create:
+
 - a promotion proposal or human decision record
 - an Implementation Preflight for `RTS-FRZ-000007`
 - build authority or a lifecycle transition
+- automatic Skill promotion, publication, retirement, or adjacent-repository mutation

--- a/skill_regression/README.md
+++ b/skill_regression/README.md
@@ -1,0 +1,71 @@
+# Governed Skill Regression Dataset v1
+
+This package supplies the baseline/candidate comparison and rollback evidence required by the readiness work that precedes `RTS-FRZ-000007`.
+
+It is deliberately **not** a Skill promotion engine.
+
+## Pinned baseline
+
+The baseline is a repository-local snapshot of:
+
+```text
+nobutakayamauchi/RTS-Skills-
+commit: 66991529519795e62d61874d6a6197ae14e01967
+path: rts-skills/bundles/feature-build.md
+```
+
+The copied content, source metadata, structured contract, and SHA-256 fingerprint are immutable evaluation inputs.
+
+## Candidate fixture
+
+The candidate is local to this repository. It adds:
+
+- a `rollback-snapshot-writer` step
+- an immutable rollback output
+- explicit human-approval and rollback safety rules
+
+It is an evaluation fixture only. It is not published to `RTS-Skills-` and is never promotion eligible.
+
+## Deterministic comparison
+
+The dataset is explicitly linked to `RTS-OUTCOME-000001` through `RTS-OUTCOME-000003`, then applies six fixed fixtures:
+
+- standard feature-build compatibility
+- rollback-ready feature build
+- promotion authority boundary
+- adjacent-repository boundary
+- tiny one-step non-applicability
+- urgent break/fix non-applicability
+
+The immutable v1 thresholds are:
+
+```text
+regressions: 0
+safety failures: 0
+minimum improvements: 2
+candidate applicable pass rate: 1.0
+rollback snapshot: required
+```
+
+The committed result is recomputed from structured contracts. No model judgment, network call, provider call, subprocess, shell command, or adjacent-repository mutation is used.
+
+## Result boundary
+
+A passing evaluation produces:
+
+```text
+recommendation: RESEARCH_READY
+promotion_eligibility: NOT_ELIGIBLE
+```
+
+`RESEARCH_READY` means only that the candidate fixture, deterministic regression set, and rollback evidence are suitable inputs for a future FREEZER reassessment. It does not authorize promotion, publication, mutation, or an Implementation Preflight.
+
+## Commands
+
+```text
+python -m skill_regression.cli verify
+python -m skill_regression.cli evaluate
+python -m skill_regression.cli summary
+```
+
+`verify` is read-only. It checks exact schemas, source and content hashes, canonical fingerprints, path containment, privacy-sensitive keys, cross-artifact references, fixed thresholds, deterministic fixture outcomes, rollback integrity, and the permanent `NOT_ELIGIBLE` boundary.

--- a/skill_regression/__init__.py
+++ b/skill_regression/__init__.py
@@ -1,0 +1,1 @@
+"""Governed local Skill regression fixtures for RTS-FRZ-000007 readiness."""

--- a/skill_regression/cli.py
+++ b/skill_regression/cli.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from skill_regression.corpus import DEFAULT_ROOT, load_artifacts, verify_all
+from skill_regression.models import SkillRegressionError, evaluate_dataset, pretty_json
+
+
+def parser() -> argparse.ArgumentParser:
+    value = argparse.ArgumentParser(description="Verify the governed Skill regression dataset.")
+    value.add_argument("--root", type=Path, default=DEFAULT_ROOT)
+    sub = value.add_subparsers(dest="command", required=True)
+    sub.add_parser("verify", help="verify snapshots, rollback, fixtures, and committed result")
+    sub.add_parser("evaluate", help="print the deterministic regression result")
+    sub.add_parser("summary", help="print a compact dataset summary")
+    return value
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parser().parse_args(argv)
+    root = args.root.resolve()
+    try:
+        if args.command == "verify":
+            summary = verify_all(root)
+            print(
+                "Skill regression verification passed: "
+                f"{summary['dataset_id']} recommendation={summary['recommendation']} "
+                f"promotion={summary['promotion_eligibility']}"
+            )
+        elif args.command == "evaluate":
+            artifacts = load_artifacts(root)
+            result = evaluate_dataset(
+                artifacts["baseline"],
+                artifacts["candidate"],
+                artifacts["rollback"],
+                artifacts["dataset"],
+            )
+            print(pretty_json(result), end="")
+        elif args.command == "summary":
+            print(json.dumps(verify_all(root), ensure_ascii=False, sort_keys=True, indent=2))
+        else:
+            raise SkillRegressionError(f"unknown command: {args.command}")
+    except SkillRegressionError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skill_regression/common.py
+++ b/skill_regression/common.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+SNAPSHOT_SCHEMA = "RTS-SKILL-SNAPSHOT-V1"
+ROLLBACK_SCHEMA = "RTS-SKILL-ROLLBACK-SNAPSHOT-V1"
+DATASET_SCHEMA = "RTS-SKILL-REGRESSION-DATASET-V1"
+RESULT_SCHEMA = "RTS-SKILL-REGRESSION-RESULT-V1"
+EXECUTION_SCOPE = "LOCAL_STATIC_EVALUATION_ONLY"
+PROMOTION = "NOT_ELIGIBLE"
+OUTCOMES = {"PASS", "FAIL", "NOT_APPLICABLE"}
+V1_OUTCOMES = ["RTS-OUTCOME-000001", "RTS-OUTCOME-000002", "RTS-OUTCOME-000003"]
+V1_THRESHOLDS = {
+    "maximum_regressions": 0,
+    "maximum_safety_failures": 0,
+    "minimum_improvements": 2,
+    "minimum_candidate_pass_rate": 1.0,
+    "rollback_snapshot_required": True,
+}
+SAFE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+GIT_SHA = re.compile(r"^[0-9a-f]{40}$")
+PRIVATE = {
+    "prompt", "prompts", "secret", "secrets", "credential", "credentials",
+    "password", "passwords", "token", "tokens", "customer", "private",
+    "payload", "provider",
+}
+
+
+class SkillRegressionError(RuntimeError):
+    pass
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def pretty_json(value: Any) -> str:
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+
+
+def sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def sha256_value(value: Any) -> str:
+    return sha256_bytes(canonical_json(value).encode())
+
+
+def sha256_file(path: Path) -> str:
+    try:
+        return sha256_bytes(path.read_bytes())
+    except FileNotFoundError as exc:
+        raise SkillRegressionError(f"missing file: {path}") from exc
+
+
+def load_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise SkillRegressionError(f"missing JSON file: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise SkillRegressionError(f"invalid JSON: {path}: {exc}") from exc
+
+
+def exact(value: Any, fields: set[str], label: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SkillRegressionError(f"{label} must be an object")
+    missing, extra = sorted(fields - value.keys()), sorted(value.keys() - fields)
+    if missing:
+        raise SkillRegressionError(f"{label} missing fields: {', '.join(missing)}")
+    if extra:
+        raise SkillRegressionError(f"{label} unknown fields: {', '.join(extra)}")
+    return value
+
+
+def text(value: Any, label: str, limit: int = 512) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise SkillRegressionError(f"{label} must be a non-empty string")
+    if len(value) > limit or any(c in value for c in ("\x00", "\r")):
+        raise SkillRegressionError(f"{label} contains unsafe or excessive text")
+    return value
+
+
+def safe_id(value: Any, label: str) -> str:
+    value = text(value, label, 128)
+    if not SAFE_ID.fullmatch(value):
+        raise SkillRegressionError(f"{label} contains unsafe characters")
+    return value
+
+
+def digest(value: Any, label: str) -> str:
+    if not isinstance(value, str) or len(value) != 64 or set(value) - set("0123456789abcdef"):
+        raise SkillRegressionError(f"{label} must be a lowercase SHA-256 digest")
+    return value
+
+
+def git_sha(value: Any, label: str) -> str:
+    if not isinstance(value, str) or not GIT_SHA.fullmatch(value):
+        raise SkillRegressionError(f"{label} must be a lowercase 40-character Git SHA")
+    return value
+
+
+def relative(value: Any, label: str, prefix: str) -> str:
+    value = text(value, label)
+    path = Path(value)
+    if path.is_absolute() or ".." in path.parts:
+        raise SkillRegressionError(f"{label} must be repository-relative")
+    if not value.startswith(prefix):
+        raise SkillRegressionError(f"{label} must stay inside {prefix}")
+    return value
+
+
+def strings(value: Any, label: str, *, sorted_unique: bool, empty: bool = False) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(v, str) or not v.strip() for v in value):
+        raise SkillRegressionError(f"{label} must be an array of non-empty strings")
+    if not empty and not value:
+        raise SkillRegressionError(f"{label} must not be empty")
+    if len(value) != len(set(value)):
+        raise SkillRegressionError(f"{label} must contain unique entries")
+    if sorted_unique and value != sorted(value):
+        raise SkillRegressionError(f"{label} must be sorted")
+    return value
+
+
+def reject_private_keys(value: Any, path: str = "document") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            parts = set(str(key).lower().replace("-", "_").replace(" ", "_").split("_"))
+            if parts & PRIVATE:
+                raise SkillRegressionError(f"{path} contains a forbidden private field: {key}")
+            reject_private_keys(child, f"{path}.{key}")
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            reject_private_keys(child, f"{path}[{index}]")
+
+
+def material(value: dict[str, Any], fingerprint: str) -> dict[str, Any]:
+    result = dict(value)
+    result.pop(fingerprint, None)
+    return result
+
+
+def fingerprint_material(value: dict[str, Any], fingerprint: str) -> dict[str, Any]:
+    return material(value, fingerprint)

--- a/skill_regression/corpus.py
+++ b/skill_regression/corpus.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skill_regression.models import (
+    SkillRegressionError,
+    evaluate_dataset,
+    load_json,
+    sha256_file,
+    validate_dataset,
+    validate_result,
+    validate_rollback,
+    validate_snapshot,
+)
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+DEFAULT_ROOT = PACKAGE_DIR.parent
+
+
+def resolve_inside(root: Path, relative: str, *, prefix: str) -> Path:
+    candidate = (root / relative).resolve()
+    allowed = (root / prefix).resolve()
+    try:
+        candidate.relative_to(allowed)
+    except ValueError as exc:
+        raise SkillRegressionError(f"path escapes {prefix}: {relative}") from exc
+    return candidate
+
+
+def artifact_paths(root: Path) -> dict[str, Path]:
+    return {
+        "baseline": root / "skill_regression" / "snapshots" / "feature-build" / "baseline.json",
+        "candidate": root / "skill_regression" / "snapshots" / "feature-build" / "candidate.json",
+        "rollback": root / "skill_regression" / "rollback" / "feature-build-v1.json",
+        "dataset": root / "skill_regression" / "datasets" / "feature-build-v1.json",
+        "result": root / "skill_regression" / "results" / "feature-build-v1.json",
+    }
+
+
+def load_artifacts(root: Path = DEFAULT_ROOT) -> dict[str, dict[str, Any]]:
+    paths = artifact_paths(root)
+    return {name: load_json(path) for name, path in paths.items()}
+
+
+def verify_snapshot_content(root: Path, snapshot: dict[str, Any]) -> None:
+    content_path = resolve_inside(
+        root,
+        snapshot["content_path"],
+        prefix="skill_regression/snapshots",
+    )
+    digest = sha256_file(content_path)
+    if digest != snapshot["content_sha256"]:
+        raise SkillRegressionError(
+            f"{snapshot['snapshot_id']}: content digest mismatch"
+        )
+    if digest != snapshot["source"]["source_content_sha256"]:
+        raise SkillRegressionError(
+            f"{snapshot['snapshot_id']}: source content digest mismatch"
+        )
+
+
+def verify_outcome_bundle_links(root: Path, dataset: dict[str, Any]) -> None:
+    examples = root / "outcome_evidence" / "examples"
+    by_id: dict[str, dict[str, Any]] = {}
+    for path in sorted(examples.glob("*.json")):
+        value = load_json(path)
+        bundle_id = value.get("bundle_id")
+        if isinstance(bundle_id, str):
+            by_id[bundle_id] = value
+    for bundle_id in dataset["outcome_bundle_ids"]:
+        value = by_id.get(bundle_id)
+        if value is None:
+            raise SkillRegressionError(f"missing referenced outcome bundle: {bundle_id}")
+        if value.get("execution_scope") != "SIMULATED_ONLY":
+            raise SkillRegressionError(f"{bundle_id}: linked outcome must remain SIMULATED_ONLY")
+        if value.get("promotion_eligibility") != "NOT_ELIGIBLE":
+            raise SkillRegressionError(f"{bundle_id}: linked outcome must remain NOT_ELIGIBLE")
+
+
+def verify_all(root: Path = DEFAULT_ROOT) -> dict[str, Any]:
+    artifacts = load_artifacts(root)
+    baseline = validate_snapshot(artifacts["baseline"])
+    candidate = validate_snapshot(artifacts["candidate"])
+    rollback = validate_rollback(artifacts["rollback"])
+    dataset = validate_dataset(artifacts["dataset"])
+    committed_result = validate_result(artifacts["result"])
+
+    verify_snapshot_content(root, baseline)
+    verify_snapshot_content(root, candidate)
+    verify_outcome_bundle_links(root, dataset)
+
+    computed = evaluate_dataset(baseline, candidate, rollback, dataset)
+    if committed_result != computed:
+        raise SkillRegressionError(
+            "committed regression result does not match deterministic evaluation"
+        )
+
+    return {
+        "dataset_id": dataset["dataset_id"],
+        "skill_id": dataset["skill_id"],
+        "fixtures": len(dataset["fixture_set"]),
+        "recommendation": computed["recommendation"],
+        "promotion_eligibility": computed["promotion_eligibility"],
+        "regressions": computed["summary"]["regressions"],
+        "improvements": computed["summary"]["improvements"],
+        "safety_failures": computed["summary"]["safety_failures"],
+        "candidate_pass_rate": computed["summary"]["candidate_pass_rate"],
+        "result_fingerprint": computed["result_fingerprint"],
+    }

--- a/skill_regression/datasets/feature-build-v1.json
+++ b/skill_regression/datasets/feature-build-v1.json
@@ -1,0 +1,128 @@
+{
+  "baseline_snapshot_id": "RTS-SKILL-SNAPSHOT-000001",
+  "candidate_snapshot_id": "RTS-SKILL-SNAPSHOT-000002",
+  "dataset_fingerprint": "fc139152a6792917365a46d651408dbbcb3e7780d02d448e7f42e28f2e5e940e",
+  "dataset_id": "RTS-SKILL-REGRESSION-000001",
+  "execution_scope": "LOCAL_STATIC_EVALUATION_ONLY",
+  "external_execution_performed": false,
+  "fixture_set": [
+    {
+      "expected": {"baseline": "PASS", "candidate": "PASS"},
+      "fixture_id": "RTS-SKILL-FIXTURE-000001",
+      "kind": "FUNCTIONAL",
+      "mode": "APPLICABLE",
+      "requirements": {
+        "not_for": [],
+        "outputs": [
+          "Clarified requirement contract",
+          "Continuation-ready handoff package",
+          "Evidence-backed verified/unverified/assumed report",
+          "Explicit scope boundary statement",
+          "Minimal implementation diff summary",
+          "Ordered scoped implementation plan"
+        ],
+        "safety_rules": [
+          "AUTOMATIC_CANONICAL_PROMOTION_FORBIDDEN",
+          "RUNTIME_IMPLEMENTATION_FORBIDDEN"
+        ],
+        "steps": [
+          "requirement-clarifier",
+          "task-decomposer",
+          "scope-locker",
+          "safe-implementer",
+          "verification-runner",
+          "handoff-writer"
+        ]
+      },
+      "scenario": "STANDARD_FEATURE_BUILD"
+    },
+    {
+      "expected": {"baseline": "FAIL", "candidate": "PASS"},
+      "fixture_id": "RTS-SKILL-FIXTURE-000002",
+      "kind": "FUNCTIONAL",
+      "mode": "APPLICABLE",
+      "requirements": {
+        "not_for": [],
+        "outputs": ["Immutable local rollback snapshot"],
+        "safety_rules": ["ROLLBACK_SNAPSHOT_REQUIRED"],
+        "steps": ["verification-runner", "rollback-snapshot-writer", "handoff-writer"]
+      },
+      "scenario": "ROLLBACK_READY_FEATURE_BUILD"
+    },
+    {
+      "expected": {"baseline": "FAIL", "candidate": "PASS"},
+      "fixture_id": "RTS-SKILL-FIXTURE-000003",
+      "kind": "SAFETY",
+      "mode": "APPLICABLE",
+      "requirements": {
+        "not_for": [],
+        "outputs": [],
+        "safety_rules": [
+          "AUTOMATIC_CANONICAL_PROMOTION_FORBIDDEN",
+          "HUMAN_APPROVAL_REQUIRED",
+          "ROLLBACK_SNAPSHOT_REQUIRED"
+        ],
+        "steps": []
+      },
+      "scenario": "PROMOTION_AUTHORITY_BOUNDARY"
+    },
+    {
+      "expected": {"baseline": "PASS", "candidate": "PASS"},
+      "fixture_id": "RTS-SKILL-FIXTURE-000004",
+      "kind": "SAFETY",
+      "mode": "APPLICABLE",
+      "requirements": {
+        "not_for": [],
+        "outputs": [],
+        "safety_rules": [
+          "ADJACENT_REPOSITORY_INTERNALS_FORBIDDEN",
+          "RUNTIME_IMPLEMENTATION_FORBIDDEN"
+        ],
+        "steps": []
+      },
+      "scenario": "ADJACENT_REPOSITORY_BOUNDARY"
+    },
+    {
+      "expected": {"baseline": "NOT_APPLICABLE", "candidate": "NOT_APPLICABLE"},
+      "fixture_id": "RTS-SKILL-FIXTURE-000005",
+      "kind": "FUNCTIONAL",
+      "mode": "NOT_APPLICABLE",
+      "requirements": {
+        "not_for": ["TINY_ONE_STEP_CHANGE"],
+        "outputs": [],
+        "safety_rules": [],
+        "steps": []
+      },
+      "scenario": "TINY_ONE_STEP_CHANGE"
+    },
+    {
+      "expected": {"baseline": "NOT_APPLICABLE", "candidate": "NOT_APPLICABLE"},
+      "fixture_id": "RTS-SKILL-FIXTURE-000006",
+      "kind": "FUNCTIONAL",
+      "mode": "NOT_APPLICABLE",
+      "requirements": {
+        "not_for": ["URGENT_BREAK_FIX"],
+        "outputs": [],
+        "safety_rules": [],
+        "steps": []
+      },
+      "scenario": "URGENT_BREAK_FIX"
+    }
+  ],
+  "outcome_bundle_ids": [
+    "RTS-OUTCOME-000001",
+    "RTS-OUTCOME-000002",
+    "RTS-OUTCOME-000003"
+  ],
+  "promotion_eligibility": "NOT_ELIGIBLE",
+  "rollback_id": "RTS-SKILL-ROLLBACK-000001",
+  "schema_version": "RTS-SKILL-REGRESSION-DATASET-V1",
+  "skill_id": "feature-build",
+  "thresholds": {
+    "maximum_regressions": 0,
+    "maximum_safety_failures": 0,
+    "minimum_candidate_pass_rate": 1.0,
+    "minimum_improvements": 2,
+    "rollback_snapshot_required": true
+  }
+}

--- a/skill_regression/evaluation.py
+++ b/skill_regression/evaluation.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from typing import Any
+
+from skill_regression.common import (
+    PROMOTION,
+    RESULT_SCHEMA,
+    V1_THRESHOLDS,
+    SkillRegressionError,
+    sha256_value,
+)
+from skill_regression.validators import (
+    validate_dataset,
+    validate_rollback,
+    validate_snapshot,
+)
+
+
+def subsequence(required: list[str], actual: list[str]) -> bool:
+    cursor = iter(actual)
+    return all(any(item == step for item in cursor) for step in required)
+
+
+def fixture_outcome(contract: dict[str, Any], fixture: dict[str, Any]) -> str:
+    req = fixture["requirements"]
+    if fixture["mode"] == "NOT_APPLICABLE":
+        return "NOT_APPLICABLE" if set(req["not_for"]) <= set(contract["not_for"]) else "FAIL"
+    if not subsequence(req["steps"], contract["ordered_steps"]):
+        return "FAIL"
+    if not set(req["outputs"]) <= set(contract["expected_outputs"]):
+        return "FAIL"
+    if not set(req["safety_rules"]) <= set(contract["safety_rules"]):
+        return "FAIL"
+    return "PASS"
+
+
+def evaluate_dataset(
+    baseline: dict[str, Any],
+    candidate: dict[str, Any],
+    rollback: dict[str, Any],
+    dataset: dict[str, Any],
+) -> dict[str, Any]:
+    validate_snapshot(baseline)
+    validate_snapshot(candidate)
+    validate_rollback(rollback)
+    validate_dataset(dataset)
+    if baseline["role"] != "BASELINE" or candidate["role"] != "CANDIDATE":
+        raise SkillRegressionError("evaluation requires BASELINE and CANDIDATE snapshots")
+    if len({baseline["skill_id"], candidate["skill_id"], dataset["skill_id"]}) != 1:
+        raise SkillRegressionError("Skill id mismatch across regression artifacts")
+    if candidate["source"]["derived_from_snapshot_id"] != baseline["snapshot_id"]:
+        raise SkillRegressionError("candidate must derive from the selected baseline")
+    if dataset["baseline_snapshot_id"] != baseline["snapshot_id"]:
+        raise SkillRegressionError("dataset baseline snapshot mismatch")
+    if dataset["candidate_snapshot_id"] != candidate["snapshot_id"]:
+        raise SkillRegressionError("dataset candidate snapshot mismatch")
+    if dataset["rollback_id"] != rollback["rollback_id"]:
+        raise SkillRegressionError("dataset rollback id mismatch")
+    if rollback["baseline_snapshot_id"] != baseline["snapshot_id"]:
+        raise SkillRegressionError("rollback baseline snapshot mismatch")
+    if rollback["candidate_snapshot_id"] != candidate["snapshot_id"]:
+        raise SkillRegressionError("rollback candidate snapshot mismatch")
+    if rollback["baseline_snapshot_fingerprint"] != baseline["snapshot_fingerprint"]:
+        raise SkillRegressionError("rollback baseline fingerprint mismatch")
+    if rollback["restore_content_path"] != baseline["content_path"]:
+        raise SkillRegressionError("rollback restore path mismatch")
+    if rollback["restore_content_sha256"] != baseline["content_sha256"]:
+        raise SkillRegressionError("rollback restore digest mismatch")
+
+    rows = []
+    for fixture in dataset["fixture_set"]:
+        old = fixture_outcome(baseline["contract"], fixture)
+        new = fixture_outcome(candidate["contract"], fixture)
+        if {"baseline": old, "candidate": new} != fixture["expected"]:
+            raise SkillRegressionError(
+                f"{fixture['fixture_id']}: committed expected outcomes do not match deterministic evaluation"
+            )
+        rows.append({
+            "fixture_id": fixture["fixture_id"],
+            "baseline": old,
+            "candidate": new,
+            "regression": old == "PASS" and new != "PASS",
+            "improvement": old != "PASS" and new == "PASS",
+            "safety_failure": fixture["kind"] == "SAFETY" and new != "PASS",
+        })
+
+    applicable = [row for row in rows if row["candidate"] != "NOT_APPLICABLE"]
+    summary = {
+        "total_fixtures": len(rows),
+        "applicable_fixtures": len(applicable),
+        "baseline_passed": sum(row["baseline"] == "PASS" for row in rows),
+        "candidate_passed": sum(row["candidate"] == "PASS" for row in rows),
+        "regressions": sum(row["regression"] for row in rows),
+        "improvements": sum(row["improvement"] for row in rows),
+        "safety_failures": sum(row["safety_failure"] for row in rows),
+        "candidate_pass_rate": round(
+            sum(row["candidate"] == "PASS" for row in applicable) / len(applicable), 4
+        ) if applicable else 0.0,
+    }
+    ready = (
+        summary["regressions"] <= V1_THRESHOLDS["maximum_regressions"]
+        and summary["safety_failures"] <= V1_THRESHOLDS["maximum_safety_failures"]
+        and summary["improvements"] >= V1_THRESHOLDS["minimum_improvements"]
+        and summary["candidate_pass_rate"] >= V1_THRESHOLDS["minimum_candidate_pass_rate"]
+    )
+    result = {
+        "schema_version": RESULT_SCHEMA,
+        "result_id": "RTS-SKILL-REGRESSION-RESULT-000001",
+        "dataset_id": dataset["dataset_id"],
+        "dataset_fingerprint": dataset["dataset_fingerprint"],
+        "baseline_snapshot_fingerprint": baseline["snapshot_fingerprint"],
+        "candidate_snapshot_fingerprint": candidate["snapshot_fingerprint"],
+        "rollback_fingerprint": rollback["rollback_fingerprint"],
+        "fixture_results": rows,
+        "summary": summary,
+        "recommendation": "RESEARCH_READY" if ready else "REJECT_CANDIDATE",
+        "promotion_eligibility": PROMOTION,
+    }
+    result["result_fingerprint"] = sha256_value(result)
+    return result

--- a/skill_regression/models.py
+++ b/skill_regression/models.py
@@ -1,0 +1,10 @@
+from skill_regression.common import *  # noqa: F401,F403
+from skill_regression.evaluation import evaluate_dataset, fixture_outcome, subsequence
+from skill_regression.validators import (
+    validate_contract,
+    validate_dataset,
+    validate_fixture,
+    validate_result,
+    validate_rollback,
+    validate_snapshot,
+)

--- a/skill_regression/results/feature-build-v1.json
+++ b/skill_regression/results/feature-build-v1.json
@@ -1,0 +1,30 @@
+{
+  "baseline_snapshot_fingerprint": "321f7e927ecd9ad83135111d3995abcdbb144b80d4aeccd8fa8815e82b78dcf2",
+  "candidate_snapshot_fingerprint": "272dd85916e4aa7d0de1cb65517e77a13d76681b8f779392f1b61f6871494d58",
+  "dataset_fingerprint": "fc139152a6792917365a46d651408dbbcb3e7780d02d448e7f42e28f2e5e940e",
+  "dataset_id": "RTS-SKILL-REGRESSION-000001",
+  "fixture_results": [
+    {"baseline": "PASS", "candidate": "PASS", "fixture_id": "RTS-SKILL-FIXTURE-000001", "improvement": false, "regression": false, "safety_failure": false},
+    {"baseline": "FAIL", "candidate": "PASS", "fixture_id": "RTS-SKILL-FIXTURE-000002", "improvement": true, "regression": false, "safety_failure": false},
+    {"baseline": "FAIL", "candidate": "PASS", "fixture_id": "RTS-SKILL-FIXTURE-000003", "improvement": true, "regression": false, "safety_failure": false},
+    {"baseline": "PASS", "candidate": "PASS", "fixture_id": "RTS-SKILL-FIXTURE-000004", "improvement": false, "regression": false, "safety_failure": false},
+    {"baseline": "NOT_APPLICABLE", "candidate": "NOT_APPLICABLE", "fixture_id": "RTS-SKILL-FIXTURE-000005", "improvement": false, "regression": false, "safety_failure": false},
+    {"baseline": "NOT_APPLICABLE", "candidate": "NOT_APPLICABLE", "fixture_id": "RTS-SKILL-FIXTURE-000006", "improvement": false, "regression": false, "safety_failure": false}
+  ],
+  "promotion_eligibility": "NOT_ELIGIBLE",
+  "recommendation": "RESEARCH_READY",
+  "result_fingerprint": "1b7a29e57915e9750e32f4f8c11c0ddbe35a356c088b177de6e5457bca10f53a",
+  "result_id": "RTS-SKILL-REGRESSION-RESULT-000001",
+  "rollback_fingerprint": "016d65543a681b729fbf3f6d589034ae3f098b73634882db6a724a3cedd154fd",
+  "schema_version": "RTS-SKILL-REGRESSION-RESULT-V1",
+  "summary": {
+    "applicable_fixtures": 4,
+    "baseline_passed": 2,
+    "candidate_pass_rate": 1.0,
+    "candidate_passed": 4,
+    "improvements": 2,
+    "regressions": 0,
+    "safety_failures": 0,
+    "total_fixtures": 6
+  }
+}

--- a/skill_regression/rollback/feature-build-v1.json
+++ b/skill_regression/rollback/feature-build-v1.json
@@ -1,0 +1,20 @@
+{
+  "adjacent_repository_write_authorized": false,
+  "baseline_snapshot_fingerprint": "321f7e927ecd9ad83135111d3995abcdbb144b80d4aeccd8fa8815e82b78dcf2",
+  "baseline_snapshot_id": "RTS-SKILL-SNAPSHOT-000001",
+  "candidate_snapshot_id": "RTS-SKILL-SNAPSHOT-000002",
+  "human_approval_required": true,
+  "mutation_authorized": false,
+  "restore_content_path": "skill_regression/snapshots/feature-build/baseline.md",
+  "restore_content_sha256": "04b5f118bcefda4a0057d697e452e2815ce12f8f2f79ee24be2b693f2e155fee",
+  "rollback_fingerprint": "016d65543a681b729fbf3f6d589034ae3f098b73634882db6a724a3cedd154fd",
+  "rollback_id": "RTS-SKILL-ROLLBACK-000001",
+  "schema_version": "RTS-SKILL-ROLLBACK-SNAPSHOT-V1",
+  "skill_id": "feature-build",
+  "trigger_conditions": [
+    "candidate introduces any regression",
+    "candidate result fingerprint cannot be reconstructed",
+    "candidate violates a safety fixture",
+    "human reviewer rejects the candidate"
+  ]
+}

--- a/skill_regression/schemas/regression_dataset.schema.json
+++ b/skill_regression/schemas/regression_dataset.schema.json
@@ -1,0 +1,43 @@
+{
+  "$id": "https://example.invalid/rts/skill_regression_dataset.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "baseline_snapshot_id": {"type": "string"},
+    "candidate_snapshot_id": {"type": "string"},
+    "dataset_fingerprint": {"pattern": "^[0-9a-f]{64}$", "type": "string"},
+    "dataset_id": {"type": "string"},
+    "execution_scope": {"const": "LOCAL_STATIC_EVALUATION_ONLY"},
+    "external_execution_performed": {"const": false},
+    "fixture_set": {"minItems": 4, "type": "array"},
+    "outcome_bundle_ids": {"const": ["RTS-OUTCOME-000001", "RTS-OUTCOME-000002", "RTS-OUTCOME-000003"]},
+    "promotion_eligibility": {"const": "NOT_ELIGIBLE"},
+    "rollback_id": {"type": "string"},
+    "schema_version": {"const": "RTS-SKILL-REGRESSION-DATASET-V1"},
+    "skill_id": {"type": "string"},
+    "thresholds": {
+      "additionalProperties": false,
+      "properties": {
+        "maximum_regressions": {"const": 0},
+        "maximum_safety_failures": {"const": 0},
+        "minimum_candidate_pass_rate": {"const": 1.0},
+        "minimum_improvements": {"const": 2},
+        "rollback_snapshot_required": {"const": true}
+      },
+      "required": [
+        "maximum_regressions", "maximum_safety_failures",
+        "minimum_candidate_pass_rate", "minimum_improvements",
+        "rollback_snapshot_required"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "baseline_snapshot_id", "candidate_snapshot_id", "dataset_fingerprint",
+    "dataset_id", "execution_scope", "external_execution_performed",
+    "fixture_set", "outcome_bundle_ids", "promotion_eligibility",
+    "rollback_id", "schema_version", "skill_id", "thresholds"
+  ],
+  "title": "RTS Skill Regression Dataset v1",
+  "type": "object"
+}

--- a/skill_regression/schemas/skill_snapshot.schema.json
+++ b/skill_regression/schemas/skill_snapshot.schema.json
@@ -1,0 +1,25 @@
+{
+  "$id": "https://example.invalid/rts/skill_snapshot.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "content_path": {"type": "string"},
+    "content_sha256": {"pattern": "^[0-9a-f]{64}$", "type": "string"},
+    "contract": {"type": "object"},
+    "external_mutation_performed": {"const": false},
+    "promotion_eligibility": {"const": "NOT_ELIGIBLE"},
+    "role": {"enum": ["BASELINE", "CANDIDATE"]},
+    "schema_version": {"const": "RTS-SKILL-SNAPSHOT-V1"},
+    "skill_id": {"type": "string"},
+    "snapshot_fingerprint": {"pattern": "^[0-9a-f]{64}$", "type": "string"},
+    "snapshot_id": {"pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$", "type": "string"},
+    "source": {"type": "object"}
+  },
+  "required": [
+    "content_path", "content_sha256", "contract", "external_mutation_performed",
+    "promotion_eligibility", "role", "schema_version", "skill_id",
+    "snapshot_fingerprint", "snapshot_id", "source"
+  ],
+  "title": "RTS Skill Snapshot v1",
+  "type": "object"
+}

--- a/skill_regression/snapshots/feature-build/baseline.json
+++ b/skill_regression/snapshots/feature-build/baseline.json
@@ -1,0 +1,47 @@
+{
+  "content_path": "skill_regression/snapshots/feature-build/baseline.md",
+  "content_sha256": "04b5f118bcefda4a0057d697e452e2815ce12f8f2f79ee24be2b693f2e155fee",
+  "contract": {
+    "expected_outputs": [
+      "Clarified requirement contract",
+      "Continuation-ready handoff package",
+      "Evidence-backed verified/unverified/assumed report",
+      "Explicit scope boundary statement",
+      "Minimal implementation diff summary",
+      "Ordered scoped implementation plan"
+    ],
+    "not_for": [
+      "TINY_ONE_STEP_CHANGE",
+      "URGENT_BREAK_FIX"
+    ],
+    "ordered_steps": [
+      "requirement-clarifier",
+      "task-decomposer",
+      "scope-locker",
+      "safe-implementer",
+      "verification-runner",
+      "handoff-writer"
+    ],
+    "safety_rules": [
+      "ADJACENT_REPOSITORY_INTERNALS_FORBIDDEN",
+      "AUTOMATIC_CANONICAL_PROMOTION_FORBIDDEN",
+      "FACT_ASSUMPTION_UNVERIFIED_SEPARATION_REQUIRED",
+      "RUNTIME_IMPLEMENTATION_FORBIDDEN"
+    ]
+  },
+  "external_mutation_performed": false,
+  "promotion_eligibility": "NOT_ELIGIBLE",
+  "role": "BASELINE",
+  "schema_version": "RTS-SKILL-SNAPSHOT-V1",
+  "skill_id": "feature-build",
+  "snapshot_fingerprint": "321f7e927ecd9ad83135111d3995abcdbb144b80d4aeccd8fa8815e82b78dcf2",
+  "snapshot_id": "RTS-SKILL-SNAPSHOT-000001",
+  "source": {
+    "derived_from_snapshot_id": null,
+    "path": "rts-skills/bundles/feature-build.md",
+    "reference_commit_sha": "66991529519795e62d61874d6a6197ae14e01967",
+    "repository": "nobutakayamauchi/RTS-Skills-",
+    "source_content_sha256": "04b5f118bcefda4a0057d697e452e2815ce12f8f2f79ee24be2b693f2e155fee",
+    "source_type": "PINNED_PUBLIC_SOURCE"
+  }
+}

--- a/skill_regression/snapshots/feature-build/baseline.md
+++ b/skill_regression/snapshots/feature-build/baseline.md
@@ -1,0 +1,32 @@
+# Feature Build Bundle
+
+## Goal
+Deliver a scoped new capability from clarified requirement to handoff-ready output.
+
+## Included Skills
+- requirement-clarifier
+- task-decomposer
+- scope-locker
+- safe-implementer
+- verification-runner
+- handoff-writer
+
+## Recommended Execution Order
+1. requirement-clarifier (objective, constraints, acceptance criteria)
+2. task-decomposer (ordered, scoped task plan)
+3. scope-locker (explicit in-scope vs protected areas)
+4. safe-implementer (minimal approved changes only)
+5. verification-runner (verified/unverified/assumed with evidence)
+6. handoff-writer (continuation-ready summary)
+
+## Expected Outputs
+- Clarified requirement contract
+- Ordered scoped implementation plan
+- Explicit scope boundary statement
+- Minimal implementation diff summary
+- Evidence-backed verified/unverified/assumed report
+- Continuation-ready handoff package
+
+## When Not to Use
+- Tiny one-step changes with no meaningful planning overhead.
+- Urgent break/fix incidents where debugging flow is primary.

--- a/skill_regression/snapshots/feature-build/candidate.json
+++ b/skill_regression/snapshots/feature-build/candidate.json
@@ -1,0 +1,51 @@
+{
+  "content_path": "skill_regression/snapshots/feature-build/candidate.md",
+  "content_sha256": "6ed1a4a8ff27cba7aa795d525289e262901f9223d5f0608f4e4fd12fb5a4127e",
+  "contract": {
+    "expected_outputs": [
+      "Clarified requirement contract",
+      "Continuation-ready handoff package",
+      "Evidence-backed verified/unverified/assumed report",
+      "Explicit scope boundary statement",
+      "Immutable local rollback snapshot",
+      "Minimal implementation diff summary",
+      "Ordered scoped implementation plan"
+    ],
+    "not_for": [
+      "TINY_ONE_STEP_CHANGE",
+      "URGENT_BREAK_FIX"
+    ],
+    "ordered_steps": [
+      "requirement-clarifier",
+      "task-decomposer",
+      "scope-locker",
+      "safe-implementer",
+      "verification-runner",
+      "rollback-snapshot-writer",
+      "handoff-writer"
+    ],
+    "safety_rules": [
+      "ADJACENT_REPOSITORY_INTERNALS_FORBIDDEN",
+      "AUTOMATIC_CANONICAL_PROMOTION_FORBIDDEN",
+      "FACT_ASSUMPTION_UNVERIFIED_SEPARATION_REQUIRED",
+      "HUMAN_APPROVAL_REQUIRED",
+      "ROLLBACK_SNAPSHOT_REQUIRED",
+      "RUNTIME_IMPLEMENTATION_FORBIDDEN"
+    ]
+  },
+  "external_mutation_performed": false,
+  "promotion_eligibility": "NOT_ELIGIBLE",
+  "role": "CANDIDATE",
+  "schema_version": "RTS-SKILL-SNAPSHOT-V1",
+  "skill_id": "feature-build",
+  "snapshot_fingerprint": "272dd85916e4aa7d0de1cb65517e77a13d76681b8f779392f1b61f6871494d58",
+  "snapshot_id": "RTS-SKILL-SNAPSHOT-000002",
+  "source": {
+    "derived_from_snapshot_id": "RTS-SKILL-SNAPSHOT-000001",
+    "path": "skill_regression/snapshots/feature-build/candidate.md",
+    "reference_commit_sha": "cf3782619fdb455087ee574d7570d607c941bc58",
+    "repository": "nobutakayamauchi/RTS",
+    "source_content_sha256": "6ed1a4a8ff27cba7aa795d525289e262901f9223d5f0608f4e4fd12fb5a4127e",
+    "source_type": "LOCAL_CANDIDATE_FIXTURE"
+  }
+}

--- a/skill_regression/snapshots/feature-build/candidate.md
+++ b/skill_regression/snapshots/feature-build/candidate.md
@@ -1,0 +1,44 @@
+# Feature Build Bundle — Local Candidate Fixture
+
+## Status
+Evaluation fixture only. Not approved for promotion or adjacent-repository publication.
+
+## Goal
+Deliver a scoped new capability from clarified requirement to handoff-ready output while preserving an immutable local rollback target.
+
+## Included Skills
+- requirement-clarifier
+- task-decomposer
+- scope-locker
+- safe-implementer
+- verification-runner
+- rollback-snapshot-writer
+- handoff-writer
+
+## Recommended Execution Order
+1. requirement-clarifier (objective, constraints, acceptance criteria)
+2. task-decomposer (ordered, scoped task plan)
+3. scope-locker (explicit in-scope vs protected areas)
+4. safe-implementer (minimal approved changes only)
+5. verification-runner (verified/unverified/assumed with evidence)
+6. rollback-snapshot-writer (pin the approved baseline and restoration evidence)
+7. handoff-writer (continuation-ready summary)
+
+## Expected Outputs
+- Clarified requirement contract
+- Ordered scoped implementation plan
+- Explicit scope boundary statement
+- Minimal implementation diff summary
+- Evidence-backed verified/unverified/assumed report
+- Immutable local rollback snapshot
+- Continuation-ready handoff package
+
+## Safety Rules
+- Automatic canonical promotion is forbidden.
+- Human approval is required before any promotion proposal can advance.
+- Adjacent-repository mutation is forbidden by this fixture.
+- Runtime and connector implementation remain out of scope.
+
+## When Not to Use
+- Tiny one-step changes with no meaningful planning overhead.
+- Urgent break/fix incidents where debugging flow is primary.

--- a/skill_regression/validators.py
+++ b/skill_regression/validators.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from skill_regression.common import (
+    DATASET_SCHEMA,
+    EXECUTION_SCOPE,
+    OUTCOMES,
+    PROMOTION,
+    RESULT_SCHEMA,
+    ROLLBACK_SCHEMA,
+    SNAPSHOT_SCHEMA,
+    V1_OUTCOMES,
+    V1_THRESHOLDS,
+    SkillRegressionError,
+    digest,
+    exact,
+    git_sha,
+    material,
+    reject_private_keys,
+    relative,
+    safe_id,
+    sha256_value,
+    strings,
+    text,
+)
+
+SNAPSHOT_FIELDS = {
+    "schema_version", "snapshot_id", "role", "skill_id", "source",
+    "content_path", "content_sha256", "contract",
+    "external_mutation_performed", "promotion_eligibility",
+    "snapshot_fingerprint",
+}
+SOURCE_FIELDS = {
+    "source_type", "repository", "reference_commit_sha", "path",
+    "derived_from_snapshot_id", "source_content_sha256",
+}
+CONTRACT_FIELDS = {"ordered_steps", "expected_outputs", "not_for", "safety_rules"}
+ROLLBACK_FIELDS = {
+    "schema_version", "rollback_id", "skill_id", "baseline_snapshot_id",
+    "baseline_snapshot_fingerprint", "candidate_snapshot_id",
+    "restore_content_path", "restore_content_sha256", "trigger_conditions",
+    "human_approval_required", "mutation_authorized",
+    "adjacent_repository_write_authorized", "rollback_fingerprint",
+}
+DATASET_FIELDS = {
+    "schema_version", "dataset_id", "skill_id", "baseline_snapshot_id",
+    "candidate_snapshot_id", "rollback_id", "outcome_bundle_ids",
+    "execution_scope", "fixture_set", "thresholds",
+    "external_execution_performed", "promotion_eligibility",
+    "dataset_fingerprint",
+}
+FIXTURE_FIELDS = {"fixture_id", "kind", "scenario", "mode", "requirements", "expected"}
+REQ_FIELDS = {"steps", "outputs", "safety_rules", "not_for"}
+RESULT_FIELDS = {
+    "schema_version", "result_id", "dataset_id", "dataset_fingerprint",
+    "baseline_snapshot_fingerprint", "candidate_snapshot_fingerprint",
+    "rollback_fingerprint", "fixture_results", "summary", "recommendation",
+    "promotion_eligibility", "result_fingerprint",
+}
+ROW_FIELDS = {
+    "fixture_id", "baseline", "candidate", "regression", "improvement",
+    "safety_failure",
+}
+SUMMARY_FIELDS = {
+    "total_fixtures", "applicable_fixtures", "baseline_passed",
+    "candidate_passed", "regressions", "improvements", "safety_failures",
+    "candidate_pass_rate",
+}
+
+
+def validate_contract(value: Any, label: str) -> dict[str, Any]:
+    value = exact(value, CONTRACT_FIELDS, label)
+    strings(value["ordered_steps"], f"{label}.ordered_steps", sorted_unique=False)
+    for field in ("expected_outputs", "not_for", "safety_rules"):
+        strings(value[field], f"{label}.{field}", sorted_unique=True)
+    return value
+
+
+def validate_snapshot(value: Any) -> dict[str, Any]:
+    value = exact(value, SNAPSHOT_FIELDS, "Skill snapshot")
+    if value["schema_version"] != SNAPSHOT_SCHEMA:
+        raise SkillRegressionError("Skill snapshot schema_version mismatch")
+    safe_id(value["snapshot_id"], "Skill snapshot.snapshot_id")
+    safe_id(value["skill_id"], "Skill snapshot.skill_id")
+    if value["role"] not in {"BASELINE", "CANDIDATE"}:
+        raise SkillRegressionError("unsupported Skill snapshot role")
+
+    source = exact(value["source"], SOURCE_FIELDS, "Skill snapshot.source")
+    if source["source_type"] not in {"PINNED_PUBLIC_SOURCE", "LOCAL_CANDIDATE_FIXTURE"}:
+        raise SkillRegressionError("unsupported Skill source_type")
+    repository = text(source["repository"], "Skill snapshot.source.repository")
+    if "/" not in repository:
+        raise SkillRegressionError("Skill snapshot.source.repository must be owner/name")
+    git_sha(source["reference_commit_sha"], "Skill snapshot.source.reference_commit_sha")
+    source_path = text(source["path"], "Skill snapshot.source.path")
+    if Path(source_path).is_absolute() or ".." in Path(source_path).parts:
+        raise SkillRegressionError("Skill snapshot.source.path must be repository-relative")
+    digest(source["source_content_sha256"], "Skill snapshot.source.source_content_sha256")
+
+    if value["role"] == "BASELINE":
+        if source["source_type"] != "PINNED_PUBLIC_SOURCE" or source["derived_from_snapshot_id"] is not None:
+            raise SkillRegressionError("baseline source boundary mismatch")
+        if repository != "nobutakayamauchi/RTS-Skills-":
+            raise SkillRegressionError("baseline repository mismatch")
+    else:
+        if source["source_type"] != "LOCAL_CANDIDATE_FIXTURE":
+            raise SkillRegressionError("candidate source boundary mismatch")
+        safe_id(source["derived_from_snapshot_id"], "Skill snapshot.source.derived_from_snapshot_id")
+        if repository != "nobutakayamauchi/RTS":
+            raise SkillRegressionError("candidate fixture repository mismatch")
+
+    content_path = relative(
+        value["content_path"], "Skill snapshot.content_path",
+        "skill_regression/snapshots/",
+    )
+    digest(value["content_sha256"], "Skill snapshot.content_sha256")
+    if source["source_type"] == "LOCAL_CANDIDATE_FIXTURE" and source_path != content_path:
+        raise SkillRegressionError("candidate source.path must match content_path")
+    if source["source_content_sha256"] != value["content_sha256"]:
+        raise SkillRegressionError("source and snapshot content digests must match")
+    validate_contract(value["contract"], "Skill snapshot.contract")
+    if value["external_mutation_performed"] is not False:
+        raise SkillRegressionError("Skill snapshots must not claim external mutation")
+    if value["promotion_eligibility"] != PROMOTION:
+        raise SkillRegressionError("Skill snapshots are never promotion eligible")
+    supplied = digest(value["snapshot_fingerprint"], "Skill snapshot.snapshot_fingerprint")
+    if supplied != sha256_value(material(value, "snapshot_fingerprint")):
+        raise SkillRegressionError("Skill snapshot fingerprint mismatch")
+    reject_private_keys(value, "Skill snapshot")
+    return value
+
+
+def validate_rollback(value: Any) -> dict[str, Any]:
+    value = exact(value, ROLLBACK_FIELDS, "rollback snapshot")
+    if value["schema_version"] != ROLLBACK_SCHEMA:
+        raise SkillRegressionError("rollback snapshot schema_version mismatch")
+    for field in ("rollback_id", "skill_id", "baseline_snapshot_id", "candidate_snapshot_id"):
+        safe_id(value[field], f"rollback snapshot.{field}")
+    digest(value["baseline_snapshot_fingerprint"], "rollback snapshot.baseline_snapshot_fingerprint")
+    relative(value["restore_content_path"], "rollback snapshot.restore_content_path", "skill_regression/snapshots/")
+    digest(value["restore_content_sha256"], "rollback snapshot.restore_content_sha256")
+    strings(value["trigger_conditions"], "rollback snapshot.trigger_conditions", sorted_unique=True)
+    if value["human_approval_required"] is not True:
+        raise SkillRegressionError("rollback snapshot must require human approval")
+    if value["mutation_authorized"] is not False:
+        raise SkillRegressionError("rollback snapshot must not authorize mutation")
+    if value["adjacent_repository_write_authorized"] is not False:
+        raise SkillRegressionError("rollback snapshot must not authorize adjacent-repository writes")
+    supplied = digest(value["rollback_fingerprint"], "rollback snapshot.rollback_fingerprint")
+    if supplied != sha256_value(material(value, "rollback_fingerprint")):
+        raise SkillRegressionError("rollback snapshot fingerprint mismatch")
+    reject_private_keys(value, "rollback snapshot")
+    return value
+
+
+def validate_fixture(value: Any, label: str) -> dict[str, Any]:
+    value = exact(value, FIXTURE_FIELDS, label)
+    safe_id(value["fixture_id"], f"{label}.fixture_id")
+    if value["kind"] not in {"FUNCTIONAL", "SAFETY"}:
+        raise SkillRegressionError(f"{label}.kind is unsupported")
+    safe_id(value["scenario"], f"{label}.scenario")
+    if value["mode"] not in {"APPLICABLE", "NOT_APPLICABLE"}:
+        raise SkillRegressionError(f"{label}.mode is unsupported")
+    req = exact(value["requirements"], REQ_FIELDS, f"{label}.requirements")
+    strings(req["steps"], f"{label}.requirements.steps", sorted_unique=False, empty=True)
+    for field in ("outputs", "safety_rules", "not_for"):
+        strings(req[field], f"{label}.requirements.{field}", sorted_unique=True, empty=True)
+    expected = exact(value["expected"], {"baseline", "candidate"}, f"{label}.expected")
+    if expected["baseline"] not in OUTCOMES or expected["candidate"] not in OUTCOMES:
+        raise SkillRegressionError(f"{label}.expected contains an unsupported outcome")
+    if value["mode"] == "NOT_APPLICABLE":
+        if not req["not_for"] or req["steps"] or req["outputs"] or req["safety_rules"]:
+            raise SkillRegressionError(f"{label} NOT_APPLICABLE requirements mismatch")
+        if expected != {"baseline": "NOT_APPLICABLE", "candidate": "NOT_APPLICABLE"}:
+            raise SkillRegressionError(f"{label} NOT_APPLICABLE expected outcomes mismatch")
+    elif req["not_for"] or not any(req[k] for k in ("steps", "outputs", "safety_rules")):
+        raise SkillRegressionError(f"{label} APPLICABLE requirements mismatch")
+    return value
+
+
+def validate_dataset(value: Any) -> dict[str, Any]:
+    value = exact(value, DATASET_FIELDS, "regression dataset")
+    if value["schema_version"] != DATASET_SCHEMA:
+        raise SkillRegressionError("regression dataset schema_version mismatch")
+    for field in ("dataset_id", "skill_id", "baseline_snapshot_id", "candidate_snapshot_id", "rollback_id"):
+        safe_id(value[field], f"regression dataset.{field}")
+    if value["baseline_snapshot_id"] == value["candidate_snapshot_id"]:
+        raise SkillRegressionError("baseline and candidate snapshot ids must differ")
+    strings(value["outcome_bundle_ids"], "regression dataset.outcome_bundle_ids", sorted_unique=True)
+    if value["outcome_bundle_ids"] != V1_OUTCOMES:
+        raise SkillRegressionError("regression dataset must reference the immutable v1 outcome corpus")
+    if value["execution_scope"] != EXECUTION_SCOPE:
+        raise SkillRegressionError("regression dataset execution_scope mismatch")
+
+    fixtures = value["fixture_set"]
+    if not isinstance(fixtures, list) or len(fixtures) < 4:
+        raise SkillRegressionError("regression dataset requires at least four fixtures")
+    previous, kinds, modes = "", set(), set()
+    for index, fixture in enumerate(fixtures):
+        validate_fixture(fixture, f"fixture_set[{index}]")
+        if fixture["fixture_id"] <= previous:
+            raise SkillRegressionError("fixture_set must be uniquely sorted by fixture_id")
+        previous = fixture["fixture_id"]
+        kinds.add(fixture["kind"])
+        modes.add(fixture["mode"])
+    if kinds != {"FUNCTIONAL", "SAFETY"} or modes != {"APPLICABLE", "NOT_APPLICABLE"}:
+        raise SkillRegressionError("fixture_set lacks required variation")
+
+    thresholds = exact(value["thresholds"], set(V1_THRESHOLDS), "dataset.thresholds")
+    if thresholds != V1_THRESHOLDS:
+        raise SkillRegressionError("dataset thresholds must match the immutable v1 policy")
+    if value["external_execution_performed"] is not False:
+        raise SkillRegressionError("regression dataset must not claim external execution")
+    if value["promotion_eligibility"] != PROMOTION:
+        raise SkillRegressionError("regression dataset is never promotion eligible")
+    supplied = digest(value["dataset_fingerprint"], "regression dataset.dataset_fingerprint")
+    if supplied != sha256_value(material(value, "dataset_fingerprint")):
+        raise SkillRegressionError("regression dataset fingerprint mismatch")
+    reject_private_keys(value, "regression dataset")
+    return value
+
+
+def validate_result(value: Any) -> dict[str, Any]:
+    value = exact(value, RESULT_FIELDS, "regression result")
+    if value["schema_version"] != RESULT_SCHEMA:
+        raise SkillRegressionError("regression result schema_version mismatch")
+    safe_id(value["result_id"], "regression result.result_id")
+    safe_id(value["dataset_id"], "regression result.dataset_id")
+    for field in (
+        "dataset_fingerprint", "baseline_snapshot_fingerprint",
+        "candidate_snapshot_fingerprint", "rollback_fingerprint",
+    ):
+        digest(value[field], f"regression result.{field}")
+    rows = value["fixture_results"]
+    if not isinstance(rows, list) or not rows:
+        raise SkillRegressionError("regression result.fixture_results must be non-empty")
+    previous = ""
+    for index, row in enumerate(rows):
+        exact(row, ROW_FIELDS, f"fixture_results[{index}]")
+        safe_id(row["fixture_id"], f"fixture_results[{index}].fixture_id")
+        if row["fixture_id"] <= previous:
+            raise SkillRegressionError("fixture_results must be uniquely sorted")
+        previous = row["fixture_id"]
+        if row["baseline"] not in OUTCOMES or row["candidate"] not in OUTCOMES:
+            raise SkillRegressionError("fixture result contains unsupported outcome")
+        if any(not isinstance(row[f], bool) for f in ("regression", "improvement", "safety_failure")):
+            raise SkillRegressionError("fixture result flags must be boolean")
+    summary = exact(value["summary"], SUMMARY_FIELDS, "regression result.summary")
+    for field in SUMMARY_FIELDS - {"candidate_pass_rate"}:
+        if isinstance(summary[field], bool) or not isinstance(summary[field], int) or summary[field] < 0:
+            raise SkillRegressionError(f"regression result.summary.{field} is invalid")
+    rate = summary["candidate_pass_rate"]
+    if isinstance(rate, bool) or not isinstance(rate, (int, float)) or not 0 <= float(rate) <= 1:
+        raise SkillRegressionError("regression result.summary.candidate_pass_rate is invalid")
+    if value["recommendation"] not in {"RESEARCH_READY", "REJECT_CANDIDATE"}:
+        raise SkillRegressionError("regression result recommendation mismatch")
+    if value["promotion_eligibility"] != PROMOTION:
+        raise SkillRegressionError("regression result is never promotion eligible")
+    supplied = digest(value["result_fingerprint"], "regression result.result_fingerprint")
+    if supplied != sha256_value(material(value, "result_fingerprint")):
+        raise SkillRegressionError("regression result fingerprint mismatch")
+    reject_private_keys(value, "regression result")
+    return value

--- a/tests/test_skill_regression.py
+++ b/tests/test_skill_regression.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+
+from skill_regression.corpus import artifact_paths, load_artifacts, verify_all
+from skill_regression.models import (
+    SkillRegressionError,
+    evaluate_dataset,
+    fingerprint_material,
+    load_json,
+    pretty_json,
+    sha256_file,
+    sha256_value,
+)
+
+
+class SkillRegressionTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.repo_root = Path(__file__).resolve().parents[1]
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.root = Path(self.tempdir.name)
+        shutil.copytree(self.repo_root / "skill_regression", self.root / "skill_regression")
+        shutil.copytree(
+            self.repo_root / "outcome_evidence" / "examples",
+            self.root / "outcome_evidence" / "examples",
+        )
+
+    def tearDown(self) -> None:
+        self.tempdir.cleanup()
+
+    def write_json(self, path: Path, value: object) -> None:
+        path.write_text(pretty_json(value), encoding="utf-8")
+
+    def refingerprint(self, value: dict, field: str) -> None:
+        value[field] = sha256_value(fingerprint_material(value, field))
+
+    def test_verify_committed_dataset(self) -> None:
+        summary = verify_all(self.root)
+        self.assertEqual(summary["recommendation"], "RESEARCH_READY")
+        self.assertEqual(summary["promotion_eligibility"], "NOT_ELIGIBLE")
+        self.assertEqual(summary["regressions"], 0)
+        self.assertEqual(summary["improvements"], 2)
+        self.assertEqual(summary["safety_failures"], 0)
+        self.assertEqual(summary["candidate_pass_rate"], 1.0)
+
+    def test_evaluation_is_deterministic(self) -> None:
+        artifacts = load_artifacts(self.root)
+        first = evaluate_dataset(artifacts["baseline"], artifacts["candidate"], artifacts["rollback"], artifacts["dataset"])
+        second = evaluate_dataset(artifacts["baseline"], artifacts["candidate"], artifacts["rollback"], artifacts["dataset"])
+        self.assertEqual(first, second)
+        self.assertEqual(first, artifacts["result"])
+
+    def test_baseline_content_mutation_is_rejected(self) -> None:
+        path = self.root / "skill_regression/snapshots/feature-build/baseline.md"
+        path.write_text(path.read_text(encoding="utf-8") + "\nmutation\n", encoding="utf-8")
+        with self.assertRaisesRegex(SkillRegressionError, "content digest mismatch"):
+            verify_all(self.root)
+
+    def test_candidate_contract_regression_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["candidate"]
+        candidate = load_json(path)
+        candidate["contract"]["ordered_steps"].remove("handoff-writer")
+        self.refingerprint(candidate, "snapshot_fingerprint")
+        self.write_json(path, candidate)
+        with self.assertRaisesRegex(SkillRegressionError, "expected outcomes"):
+            verify_all(self.root)
+
+    def test_rollback_restore_digest_mismatch_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["rollback"]
+        rollback = load_json(path)
+        rollback["restore_content_sha256"] = "0" * 64
+        self.refingerprint(rollback, "rollback_fingerprint")
+        self.write_json(path, rollback)
+        with self.assertRaisesRegex(SkillRegressionError, "rollback restore digest mismatch"):
+            verify_all(self.root)
+
+    def test_threshold_weakening_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["dataset"]
+        dataset = load_json(path)
+        dataset["thresholds"]["maximum_regressions"] = 1
+        self.refingerprint(dataset, "dataset_fingerprint")
+        self.write_json(path, dataset)
+        with self.assertRaisesRegex(SkillRegressionError, "immutable v1 policy"):
+            verify_all(self.root)
+
+    def test_promotion_eligibility_cannot_be_enabled(self) -> None:
+        path = artifact_paths(self.root)["candidate"]
+        candidate = load_json(path)
+        candidate["promotion_eligibility"] = "ELIGIBLE"
+        self.refingerprint(candidate, "snapshot_fingerprint")
+        self.write_json(path, candidate)
+        with self.assertRaisesRegex(SkillRegressionError, "never promotion eligible"):
+            verify_all(self.root)
+
+    def test_external_mutation_claim_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["baseline"]
+        baseline = load_json(path)
+        baseline["external_mutation_performed"] = True
+        self.refingerprint(baseline, "snapshot_fingerprint")
+        self.write_json(path, baseline)
+        with self.assertRaisesRegex(SkillRegressionError, "must not claim external mutation"):
+            verify_all(self.root)
+
+    def test_snapshot_path_escape_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["candidate"]
+        candidate = load_json(path)
+        candidate["content_path"] = "../candidate.md"
+        candidate["source"]["path"] = "../candidate.md"
+        self.refingerprint(candidate, "snapshot_fingerprint")
+        self.write_json(path, candidate)
+        with self.assertRaisesRegex(SkillRegressionError, "repository-relative|must stay inside"):
+            verify_all(self.root)
+
+    def test_duplicate_fixture_id_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["dataset"]
+        dataset = load_json(path)
+        dataset["fixture_set"][1]["fixture_id"] = dataset["fixture_set"][0]["fixture_id"]
+        self.refingerprint(dataset, "dataset_fingerprint")
+        self.write_json(path, dataset)
+        with self.assertRaisesRegex(SkillRegressionError, "uniquely sorted"):
+            verify_all(self.root)
+
+    def test_result_mutation_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["result"]
+        result = load_json(path)
+        result["summary"]["improvements"] = 99
+        self.write_json(path, result)
+        with self.assertRaisesRegex(SkillRegressionError, "result fingerprint mismatch"):
+            verify_all(self.root)
+
+    def test_verify_is_read_only(self) -> None:
+        before = {
+            path.relative_to(self.root).as_posix(): sha256_file(path)
+            for path in sorted((self.root / "skill_regression").rglob("*"))
+            if path.is_file()
+        }
+        verify_all(self.root)
+        after = {
+            path.relative_to(self.root).as_posix(): sha256_file(path)
+            for path in sorted((self.root / "skill_regression").rglob("*"))
+            if path.is_file()
+        }
+        self.assertEqual(before, after)
+
+    def test_source_content_digest_mismatch_is_rejected(self) -> None:
+        path = artifact_paths(self.root)["baseline"]
+        baseline = load_json(path)
+        baseline["source"]["source_content_sha256"] = "f" * 64
+        self.refingerprint(baseline, "snapshot_fingerprint")
+        self.write_json(path, baseline)
+        with self.assertRaisesRegex(SkillRegressionError, "source and snapshot content digests must match"):
+            verify_all(self.root)
+
+    def test_missing_referenced_outcome_bundle_is_rejected(self) -> None:
+        path = self.root / "outcome_evidence/examples/success.json"
+        path.unlink()
+        with self.assertRaisesRegex(SkillRegressionError, "missing referenced outcome bundle"):
+            verify_all(self.root)
+
+    def test_dataset_with_private_field_fails_closed(self) -> None:
+        path = artifact_paths(self.root)["dataset"]
+        dataset = load_json(path)
+        dataset["fixture_set"][0]["requirements"]["prompt"] = "forbidden"
+        self.refingerprint(dataset, "dataset_fingerprint")
+        self.write_json(path, dataset)
+        with self.assertRaisesRegex(SkillRegressionError, "unknown fields|forbidden private field"):
+            verify_all(self.root)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Add the baseline/candidate comparison, deterministic regression fixtures, immutable thresholds, and rollback snapshot required by the readiness work preceding `RTS-FRZ-000007 Outcome Learning and Skill Promotion`.

This PR is research infrastructure only. It does not promote, publish, retire, or mutate a Skill and does not write to RTS-Skills or any adjacent repository.

## Pinned baseline

- repository: `nobutakayamauchi/RTS-Skills-`
- commit: `66991529519795e62d61874d6a6197ae14e01967`
- path: `rts-skills/bundles/feature-build.md`
- content copied locally and protected by SHA-256 and snapshot fingerprint

## Candidate fixture

The local candidate adds a rollback-snapshot preparation step, an immutable rollback output, and explicit human-approval/rollback safety rules. It remains `promotion_eligibility: NOT_ELIGIBLE`.

## Regression dataset

The dataset references the three governed outcome bundles from `outcome_evidence/` and evaluates six fixed fixtures:

- standard feature-build compatibility
- rollback-ready feature build
- promotion authority boundary
- adjacent-repository boundary
- tiny one-step non-applicability
- urgent break/fix non-applicability

Immutable thresholds:

- regressions: `0`
- safety failures: `0`
- minimum improvements: `2`
- candidate applicable pass rate: `1.0`
- rollback snapshot: required

The deterministic committed result is:

- recommendation: `RESEARCH_READY`
- promotion eligibility: `NOT_ELIGIBLE`
- regressions: `0`
- improvements: `2`
- safety failures: `0`

`RESEARCH_READY` is not a promotion decision and does not authorize Implementation Preflight.

## Safety boundaries

- no network/provider/subprocess/shell execution
- no publish/deploy/send/schedule
- no external or adjacent-repository mutation
- no prompts, secrets, credentials, customer data, provider payloads, or private repository bodies
- no FREEZER status, authority, Assessment, or Preflight change
- no threshold weakening

## Validation

Locally verified:

- `python -m skill_regression.cli verify`
- 15 focused mutation, integrity, path, privacy, rollback, threshold, outcome-link, determinism, and read-only tests

Repository CI must additionally run all existing FREEZER, Asset Manifest, Loop Core, Execution Controller, Outcome Evidence, stale-index, full unit-test, and Unicode checks.