### PR TITLE
Add review-derived learning data and suggest-only policy

### DIFF
--- a/.github/workflows/proof-engine-pilot-tests.yml
+++ b/.github/workflows/proof-engine-pilot-tests.yml
@@ -7,6 +7,7 @@ on:
       - "pilot_runs/reconnect_pilot_p3/**"
       - "tests/test_proof_engine_pilot.py"
       - "tests/test_proof_engine_review.py"
+      - "tests/test_proof_engine_learning.py"
       - ".github/workflows/proof-engine-pilot-tests.yml"
   push:
     branches: [main]
@@ -15,6 +16,7 @@ on:
       - "pilot_runs/reconnect_pilot_p3/**"
       - "tests/test_proof_engine_pilot.py"
       - "tests/test_proof_engine_review.py"
+      - "tests/test_proof_engine_learning.py"
       - ".github/workflows/proof-engine-pilot-tests.yml"
 
 permissions:
@@ -44,9 +46,15 @@ jobs:
           python -B -m proof_engine_pilot.review_cli verify
           python -B -m proof_engine_pilot.review_cli summary
           python -B -m proof_engine_pilot.review_cli effective > /tmp/proof-engine-effective.json
+      - name: Verify review-derived learning
+        run: |
+          python -B -m proof_engine_pilot.learning_cli verify
+          python -B -m proof_engine_pilot.learning_cli summary
+          python -B -m proof_engine_pilot.learning_cli replay > /tmp/proof-engine-learning-replay.json
       - name: Run focused tests
         run: |
           python -B -m unittest discover -s tests -p 'test_proof_engine_pilot.py' -v
           python -B -m unittest discover -s tests -p 'test_proof_engine_review.py' -v
+          python -B -m unittest discover -s tests -p 'test_proof_engine_learning.py' -v
       - name: Run full repository tests
         run: python -B -m unittest discover -s tests -v

--- a/pilot_runs/reconnect_pilot_p3/learning_checkpoint_0003.json
+++ b/pilot_runs/reconnect_pilot_p3/learning_checkpoint_0003.json
@@ -1,15 +1,15 @@
 {
-  "checkpoint_fingerprint": "6749706f95de3574c2093e9fe8e8b4ef4efa4d2dba59083f9734410e0e953678",
+  "checkpoint_fingerprint": "1b1e224b89b0ae7ccb5ff0998a5d196ae21469919cf78619ceb24401daff5e75",
   "checkpoint_id": "PROOF-ENGINE-LEARNING-CHECKPOINT-0003",
   "dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
   "external_actions_performed": false,
   "model_weight_update_performed": false,
   "next_action": "Run the active learning preflight on candidates generated after PROOF-ENGINE-P3-RUN-0001, then keep the human review gate.",
   "original_records_preserved": true,
-  "policy_fingerprint": "3aa2a723328705710ce158885188d069b8e9425b645030d97ef030ed78e363df",
-  "replay_fingerprint": "60287f65a78c3cafc2740221f03f4db4f3e4dc75a8433093ea4bd14721678ad0",
+  "policy_fingerprint": "c4e81d04b22f1db00d6ed43238b75c9aa855c95e33e595eaf49006c92e6b2176",
+  "replay_fingerprint": "e22d8bed853f44181a6427d79177ab2a6fd35e445f67a650cc4553fc1eaf7202",
   "review_round_id": "PROOF-ENGINE-REVIEW-ROUND-0001",
-  "ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "ruleset_fingerprint": "fad89c35f06b7891b04023dc68d96e2968876e09b8ac29c8d3633961c03cb657",
   "schema_version": "PROOF-ENGINE-LEARNING-CHECKPOINT-V1",
   "state": "LEARNING_DATA_ACTIVE_SUGGEST_ONLY"
 }

--- a/pilot_runs/reconnect_pilot_p3/learning_checkpoint_0003.json
+++ b/pilot_runs/reconnect_pilot_p3/learning_checkpoint_0003.json
@@ -1,0 +1,15 @@
+{
+  "checkpoint_fingerprint": "6749706f95de3574c2093e9fe8e8b4ef4efa4d2dba59083f9734410e0e953678",
+  "checkpoint_id": "PROOF-ENGINE-LEARNING-CHECKPOINT-0003",
+  "dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
+  "external_actions_performed": false,
+  "model_weight_update_performed": false,
+  "next_action": "Run the active learning preflight on candidates generated after PROOF-ENGINE-P3-RUN-0001, then keep the human review gate.",
+  "original_records_preserved": true,
+  "policy_fingerprint": "3aa2a723328705710ce158885188d069b8e9425b645030d97ef030ed78e363df",
+  "replay_fingerprint": "60287f65a78c3cafc2740221f03f4db4f3e4dc75a8433093ea4bd14721678ad0",
+  "review_round_id": "PROOF-ENGINE-REVIEW-ROUND-0001",
+  "ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "schema_version": "PROOF-ENGINE-LEARNING-CHECKPOINT-V1",
+  "state": "LEARNING_DATA_ACTIVE_SUGGEST_ONLY"
+}

--- a/proof_engine_pilot/README.md
+++ b/proof_engine_pilot/README.md
@@ -19,6 +19,17 @@ python -m proof_engine_pilot.review_cli summary
 python -m proof_engine_pilot.review_cli effective
 ```
 
-The original candidate run remains immutable with 12 `REVIEW_REQUIRED` candidates. Human review is appended separately: seven originals are approved, five originals remain preserved with `REVISE` decisions, and five factually corrected revisions are approved.
+## Review-derived learning commands
 
-The effective set is ready only for an internal asset draft. There is no approve, publish, outreach, contract, provider, merge, or external-execution command, and publication remains `NOT_PUBLISHED`.
+```bash
+python -m proof_engine_pilot.learning_cli verify
+python -m proof_engine_pilot.learning_cli summary
+python -m proof_engine_pilot.learning_cli replay
+python -m proof_engine_pilot.learning_cli preflight path/to/future_candidate.json
+```
+
+Round 0001 stores seven accepted originals and five original-to-revision correction pairs as a repository-local learning dataset. Six active rules now provide `SUGGEST_ONLY` factuality and classification preflight for candidate runs after `PROOF-ENGINE-P3-RUN-0001`.
+
+This is not a model-weight update. It does not silently rewrite candidates or manufacture approval. Originals remain append-only, every correction stays linked to its human decision, and all future warnings still terminate at a human review gate.
+
+The effective reviewed set is ready only for an internal asset draft. There is no approve, publish, outreach, contract, provider, merge, model-training, or external-execution command, and publication remains `NOT_PUBLISHED`.

--- a/proof_engine_pilot/learning.py
+++ b/proof_engine_pilot/learning.py
@@ -25,7 +25,7 @@ POLICY_PATH = DATA_DIR / "policy_state.json"
 CHECKPOINT_PATH = ROOT / "pilot_runs" / "reconnect_pilot_p3" / "learning_checkpoint_0003.json"
 
 REQUIRED_FIELDS = {
-    "record_kind", "factuality_note", "contribution_map",
+    "candidate_id", "claim", "record_kind", "factuality_note", "contribution_map",
     "evidence_label", "evidence_prs", "public_disclosure",
 }
 ALLOWED_KINDS = {
@@ -171,7 +171,7 @@ def verify_ruleset(ruleset: dict[str, Any], dataset: dict[str, Any]) -> dict[str
     return ruleset
 
 
-def verify_learning_bundle() -> dict[str, Any]:
+def verify_learning_bundle(checkpoint: dict[str, Any] | None = None) -> dict[str, Any]:
     dataset = verify_dataset(load(DATASET_PATH))
     ruleset = verify_ruleset(load(RULESET_PATH), dataset)
 
@@ -206,7 +206,7 @@ def verify_learning_bundle() -> dict[str, Any]:
     if policy.get("authority") != {**AUTHORITY_FALSE, "external_execution_authorized": False}:
         raise ProofEngineError("learning policy authority mismatch")
 
-    checkpoint = load(CHECKPOINT_PATH)
+    checkpoint = load(CHECKPOINT_PATH) if checkpoint is None else checkpoint
     _verify_fingerprint(checkpoint, "checkpoint_fingerprint", "learning checkpoint")
     links = {
         "dataset_fingerprint": dataset["dataset_fingerprint"],
@@ -221,6 +221,8 @@ def verify_learning_bundle() -> dict[str, Any]:
         raise ProofEngineError("learning checkpoint state mismatch")
     if checkpoint.get("original_records_preserved") is not True or checkpoint.get("model_weight_update_performed") is not False:
         raise ProofEngineError("learning checkpoint preservation mismatch")
+    if checkpoint.get("external_actions_performed") is not False:
+        raise ProofEngineError("learning checkpoint records an unauthorized external action")
     return {"dataset": dataset, "ruleset": ruleset, "replay": replay, "policy": policy, "checkpoint": checkpoint}
 
 
@@ -229,24 +231,36 @@ def preflight_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
     missing = sorted(REQUIRED_FIELDS - set(candidate))
     if missing:
         issues.append({"rule_id": "REVIEW-RULE-002", "code": "MISSING_LEARNING_FIELDS", "detail": ", ".join(missing)})
+
+    candidate_id = candidate.get("candidate_id")
+    if "candidate_id" in candidate and (not isinstance(candidate_id, str) or not candidate_id.strip()):
+        issues.append({"rule_id": "REVIEW-RULE-002", "code": "INVALID_CANDIDATE_ID", "detail": "candidate_id must be a non-empty string."})
+
+    claim = candidate.get("claim")
+    if "claim" in candidate and (not isinstance(claim, str) or not claim.strip()):
+        issues.append({"rule_id": "REVIEW-RULE-001", "code": "INVALID_CLAIM", "detail": "claim must be a non-empty string."})
+
     kind = candidate.get("record_kind")
     if kind is not None and kind not in ALLOWED_KINDS:
         issues.append({"rule_id": "REVIEW-RULE-002", "code": "UNKNOWN_RECORD_KIND", "detail": str(kind)})
-    claim = candidate.get("claim", "")
+
     contribution = candidate.get("contribution_map", {})
     ai_work = contribution.get("ai_tool") if isinstance(contribution, dict) else None
-    if isinstance(claim, str) and ai_work and STRONG_PREFIX.search(claim) and not candidate.get("factuality_note"):
-        issues.append({"rule_id": "REVIEW-RULE-001", "code": "AUTHORSHIP_REQUIRES_FACTUALITY_NOTE", "detail": "Strong direct-action wording is combined with material AI-tool contribution."})
+    if isinstance(claim, str) and ai_work and STRONG_PREFIX.search(claim.strip()):
+        issues.append({"rule_id": "REVIEW-RULE-001", "code": "DIRECT_AUTHORSHIP_REQUIRES_REVIEW", "detail": "Strong direct-action wording is combined with material AI-tool contribution; bound the claim itself to the observed result and supported human actions."})
+
     lower = claim.lower() if isinstance(claim, str) else ""
     if any(term in lower for term in ("reusable", "repeatable", "future projects", "across projects")):
         if candidate.get("record_kind") != "REUSABILITY_SIGNAL" or candidate.get("evidence_label") != "INFERRED":
             issues.append({"rule_id": "REVIEW-RULE-004", "code": "GENERALIZATION_EXCEEDS_EVIDENCE", "detail": "Cross-project reuse remains an INFERRED REUSABILITY_SIGNAL until externally observed."})
+
     disclosure = candidate.get("public_disclosure")
     if disclosure is not None and disclosure not in {"INTERNAL_UNTIL_APPROVED", "INTERNAL_UNTIL_SEPARATE_PUBLICATION_APPROVAL"}:
         issues.append({"rule_id": "REVIEW-RULE-006", "code": "PUBLICATION_BOUNDARY_NOT_EXPLICIT", "detail": "Candidate approval must not imply publication authority."})
+
     return {
         "schema_version": "PROOF-ENGINE-LEARNING-PREFLIGHT-V1",
-        "candidate_id": candidate.get("candidate_id"),
+        "candidate_id": candidate_id,
         "mode": "SUGGEST_ONLY",
         "result": "SUGGEST_REVIEW" if issues else "PASS",
         "issues": issues,

--- a/proof_engine_pilot/learning.py
+++ b/proof_engine_pilot/learning.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+import copy
+import re
+from pathlib import Path
+from typing import Any
+
+from .core import ProofEngineError, fingerprint, load, verify_run
+from .review import (
+    APPROVED_ORIGINAL_IDS,
+    DECISION_INDEX_PATH,
+    REVISED_IDS,
+    REVISIONS_PATH,
+    load_decision_chain,
+    verify_review_round,
+)
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+ROOT = PACKAGE_DIR.parent
+DATA_DIR = PACKAGE_DIR / "learning_data" / "round_0001"
+DATASET_PATH = DATA_DIR / "dataset.json"
+RULESET_PATH = DATA_DIR / "ruleset.json"
+REPLAY_PATH = DATA_DIR / "replay.json"
+POLICY_PATH = DATA_DIR / "policy_state.json"
+CHECKPOINT_PATH = ROOT / "pilot_runs" / "reconnect_pilot_p3" / "learning_checkpoint_0003.json"
+
+REQUIRED_FIELDS = {
+    "record_kind", "factuality_note", "contribution_map",
+    "evidence_label", "evidence_prs", "public_disclosure",
+}
+ALLOWED_KINDS = {
+    "PERSONAL_ACHIEVEMENT", "PROJECT_OUTPUT", "PROCESS_BYPRODUCT",
+    "INTEGRATION_BYPRODUCT", "AUDIT_REMEDIATION_BYPRODUCT", "REUSABILITY_SIGNAL",
+}
+AUTHORITY_FALSE = {
+    "automatic_approval_authorized": False,
+    "automatic_rewrite_authorized": False,
+    "publication_authorized": False,
+}
+STRONG_PREFIX = re.compile(
+    r"^(built|created|designed and implemented|implemented|integrated|resolved|established|decomposed)\b",
+    re.IGNORECASE,
+)
+
+
+def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
+    material = copy.deepcopy(value)
+    actual = material.pop(field, None)
+    if actual != fingerprint(material):
+        raise ProofEngineError(f"{label} fingerprint mismatch")
+    return actual
+
+
+def verify_dataset(dataset: dict[str, Any]) -> dict[str, Any]:
+    _verify_fingerprint(dataset, "dataset_fingerprint", "learning dataset")
+    review = verify_review_round()
+    base = verify_run()
+    revisions = load(REVISIONS_PATH)
+    index = load(DECISION_INDEX_PATH)
+    decisions = load_decision_chain(index)
+    base_by_id = {item["candidate_id"]: item for item in base["candidates"]}
+    revision_by_id = {item["candidate_id"]: item for item in revisions["revisions"]}
+    decision_by_key = {
+        (item["target"]["candidate_id"], item["target"]["candidate_version"], item["decision_type"]): item
+        for item in decisions
+    }
+
+    expected_sources = {
+        "base_run": base["run_fingerprint"],
+        "revision_ledger": revisions["revisions_fingerprint"],
+        "decision_index": index["decision_index_fingerprint"],
+        "review_summary": review["summary_fingerprint"],
+    }
+    if dataset.get("source_fingerprints") != expected_sources:
+        raise ProofEngineError("learning dataset source links mismatch")
+    boundary = dataset.get("usage_boundary")
+    if not isinstance(boundary, dict) or boundary.get("mode") != "REPOSITORY_LOCAL_RULE_LEARNING":
+        raise ProofEngineError("learning dataset usage boundary mismatch")
+    for field in (
+        "model_weight_training_authorized", "automatic_rewrite_authorized",
+        "automatic_approval_authorized", "publication_authorized",
+    ):
+        if boundary.get(field) is not False:
+            raise ProofEngineError(f"learning dataset authority widened: {field}")
+
+    positives = dataset.get("positive_examples")
+    if not isinstance(positives, list) or len(positives) != 7:
+        raise ProofEngineError("learning dataset positive-example count mismatch")
+    seen_positive = set()
+    for item in positives:
+        cid = item.get("candidate_id")
+        if cid not in APPROVED_ORIGINAL_IDS or cid in seen_positive:
+            raise ProofEngineError("learning dataset positive example mismatch")
+        seen_positive.add(cid)
+        candidate = base_by_id[cid]
+        decision = decision_by_key[(cid, 1, "APPROVE")]
+        if item.get("candidate_fingerprint") != candidate["candidate_fingerprint"]:
+            raise ProofEngineError("positive example candidate mismatch")
+        if item.get("decision_fingerprint") != decision["decision_fingerprint"]:
+            raise ProofEngineError("positive example decision mismatch")
+        if item.get("expected_action") != "APPROVE" or item.get("error_labels") != []:
+            raise ProofEngineError("positive example label mismatch")
+    if seen_positive != APPROVED_ORIGINAL_IDS:
+        raise ProofEngineError("positive example set incomplete")
+
+    pairs = dataset.get("correction_pairs")
+    if not isinstance(pairs, list) or len(pairs) != 5:
+        raise ProofEngineError("learning dataset correction-pair count mismatch")
+    seen_revised = set()
+    for pair in pairs:
+        cid = pair.get("candidate_id")
+        if cid not in REVISED_IDS or cid in seen_revised:
+            raise ProofEngineError("learning dataset correction pair mismatch")
+        seen_revised.add(cid)
+        original = base_by_id[cid]
+        revision = revision_by_id[cid]
+        revise = decision_by_key[(cid, 1, "REVISE")]
+        approve = decision_by_key[(cid, 2, "APPROVE")]
+        checks = {
+            "original_fingerprint": original["candidate_fingerprint"],
+            "original_claim": original["claim"],
+            "revise_decision_fingerprint": revise["decision_fingerprint"],
+            "revision_fingerprint": revision["candidate_fingerprint"],
+            "revision_id": revision["revision_id"],
+            "revised_claim": revision["claim"],
+            "record_kind": revision["record_kind"],
+            "factuality_note": revision["factuality_note"],
+            "approval_decision_fingerprint": approve["decision_fingerprint"],
+        }
+        for field, expected in checks.items():
+            if pair.get(field) != expected:
+                raise ProofEngineError(f"learning correction link mismatch: {cid}/{field}")
+        if not pair.get("error_labels"):
+            raise ProofEngineError("learning correction has no error labels")
+    if seen_revised != REVISED_IDS:
+        raise ProofEngineError("learning correction set incomplete")
+
+    if dataset.get("counts") != {
+        "positive_examples": 7,
+        "correction_pairs": 5,
+        "human_decisions_represented": 17,
+    }:
+        raise ProofEngineError("learning dataset counts mismatch")
+    return dataset
+
+
+def verify_ruleset(ruleset: dict[str, Any], dataset: dict[str, Any]) -> dict[str, Any]:
+    _verify_fingerprint(ruleset, "ruleset_fingerprint", "learning ruleset")
+    if ruleset.get("dataset_fingerprint") != dataset["dataset_fingerprint"]:
+        raise ProofEngineError("learning ruleset/dataset mismatch")
+    activation = ruleset.get("activation", {})
+    if activation != {
+        "state": "ACTIVE_FOR_FUTURE_RUNS",
+        "mode": "SUGGEST_ONLY",
+        "applies_after_run_id": "PROOF-ENGINE-P3-RUN-0001",
+        "retroactive_mutation": False,
+    }:
+        raise ProofEngineError("learning ruleset activation mismatch")
+    if set(ruleset.get("required_future_candidate_fields", [])) != REQUIRED_FIELDS:
+        raise ProofEngineError("learning ruleset required fields mismatch")
+    if set(ruleset.get("allowed_record_kinds", [])) != ALLOWED_KINDS:
+        raise ProofEngineError("learning ruleset record kinds mismatch")
+    rules = ruleset.get("rules")
+    if not isinstance(rules, list) or len(rules) != 6:
+        raise ProofEngineError("learning ruleset rule count mismatch")
+    if any(rule.get("state") != "ACTIVE" or rule.get("automatic_application_authorized") is not False for rule in rules):
+        raise ProofEngineError("learning rule authority widened")
+    authority = ruleset.get("authority", {})
+    if authority != {**AUTHORITY_FALSE, "model_weight_training_authorized": False}:
+        raise ProofEngineError("learning ruleset authority mismatch")
+    return ruleset
+
+
+def verify_learning_bundle() -> dict[str, Any]:
+    dataset = verify_dataset(load(DATASET_PATH))
+    ruleset = verify_ruleset(load(RULESET_PATH), dataset)
+
+    replay = load(REPLAY_PATH)
+    _verify_fingerprint(replay, "replay_fingerprint", "learning replay")
+    if replay.get("dataset_fingerprint") != dataset["dataset_fingerprint"] or replay.get("ruleset_fingerprint") != ruleset["ruleset_fingerprint"]:
+        raise ProofEngineError("learning replay link mismatch")
+    if replay.get("result") != "PASS_LEARNING_DATA_REFLECTED":
+        raise ProofEngineError("learning replay result mismatch")
+    if replay.get("counts") != {
+        "positive_examples_preserved": 7,
+        "corrections_learned": 5,
+        "revisions_accepted": 5,
+        "unresolved_examples": 0,
+    }:
+        raise ProofEngineError("learning replay counts mismatch")
+    if replay.get("future_policy", {}).get("base_run_mutated") is not False:
+        raise ProofEngineError("learning replay mutated base run")
+
+    policy = load(POLICY_PATH)
+    _verify_fingerprint(policy, "policy_fingerprint", "learning policy")
+    if policy.get("active_dataset_fingerprint") != dataset["dataset_fingerprint"]:
+        raise ProofEngineError("learning policy dataset mismatch")
+    if policy.get("active_ruleset_fingerprint") != ruleset["ruleset_fingerprint"]:
+        raise ProofEngineError("learning policy ruleset mismatch")
+    if policy.get("latest_replay_fingerprint") != replay["replay_fingerprint"]:
+        raise ProofEngineError("learning policy replay mismatch")
+    if policy.get("state") != "ACTIVE_FOR_FUTURE_RUNS" or policy.get("mode") != "SUGGEST_ONLY":
+        raise ProofEngineError("learning policy activation mismatch")
+    if policy.get("original_records_preserved") is not True or policy.get("model_weight_update_performed") is not False:
+        raise ProofEngineError("learning policy preservation mismatch")
+    if policy.get("authority") != {**AUTHORITY_FALSE, "external_execution_authorized": False}:
+        raise ProofEngineError("learning policy authority mismatch")
+
+    checkpoint = load(CHECKPOINT_PATH)
+    _verify_fingerprint(checkpoint, "checkpoint_fingerprint", "learning checkpoint")
+    links = {
+        "dataset_fingerprint": dataset["dataset_fingerprint"],
+        "ruleset_fingerprint": ruleset["ruleset_fingerprint"],
+        "replay_fingerprint": replay["replay_fingerprint"],
+        "policy_fingerprint": policy["policy_fingerprint"],
+    }
+    for field, expected in links.items():
+        if checkpoint.get(field) != expected:
+            raise ProofEngineError(f"learning checkpoint mismatch: {field}")
+    if checkpoint.get("state") != "LEARNING_DATA_ACTIVE_SUGGEST_ONLY":
+        raise ProofEngineError("learning checkpoint state mismatch")
+    if checkpoint.get("original_records_preserved") is not True or checkpoint.get("model_weight_update_performed") is not False:
+        raise ProofEngineError("learning checkpoint preservation mismatch")
+    return {"dataset": dataset, "ruleset": ruleset, "replay": replay, "policy": policy, "checkpoint": checkpoint}
+
+
+def preflight_candidate(candidate: dict[str, Any]) -> dict[str, Any]:
+    issues = []
+    missing = sorted(REQUIRED_FIELDS - set(candidate))
+    if missing:
+        issues.append({"rule_id": "REVIEW-RULE-002", "code": "MISSING_LEARNING_FIELDS", "detail": ", ".join(missing)})
+    kind = candidate.get("record_kind")
+    if kind is not None and kind not in ALLOWED_KINDS:
+        issues.append({"rule_id": "REVIEW-RULE-002", "code": "UNKNOWN_RECORD_KIND", "detail": str(kind)})
+    claim = candidate.get("claim", "")
+    contribution = candidate.get("contribution_map", {})
+    ai_work = contribution.get("ai_tool") if isinstance(contribution, dict) else None
+    if isinstance(claim, str) and ai_work and STRONG_PREFIX.search(claim) and not candidate.get("factuality_note"):
+        issues.append({"rule_id": "REVIEW-RULE-001", "code": "AUTHORSHIP_REQUIRES_FACTUALITY_NOTE", "detail": "Strong direct-action wording is combined with material AI-tool contribution."})
+    lower = claim.lower() if isinstance(claim, str) else ""
+    if any(term in lower for term in ("reusable", "repeatable", "future projects", "across projects")):
+        if candidate.get("record_kind") != "REUSABILITY_SIGNAL" or candidate.get("evidence_label") != "INFERRED":
+            issues.append({"rule_id": "REVIEW-RULE-004", "code": "GENERALIZATION_EXCEEDS_EVIDENCE", "detail": "Cross-project reuse remains an INFERRED REUSABILITY_SIGNAL until externally observed."})
+    disclosure = candidate.get("public_disclosure")
+    if disclosure is not None and disclosure not in {"INTERNAL_UNTIL_APPROVED", "INTERNAL_UNTIL_SEPARATE_PUBLICATION_APPROVAL"}:
+        issues.append({"rule_id": "REVIEW-RULE-006", "code": "PUBLICATION_BOUNDARY_NOT_EXPLICIT", "detail": "Candidate approval must not imply publication authority."})
+    return {
+        "schema_version": "PROOF-ENGINE-LEARNING-PREFLIGHT-V1",
+        "candidate_id": candidate.get("candidate_id"),
+        "mode": "SUGGEST_ONLY",
+        "result": "SUGGEST_REVIEW" if issues else "PASS",
+        "issues": issues,
+        "authority": {"automatic_rewrite_authorized": False, "automatic_approval_authorized": False},
+    }

--- a/proof_engine_pilot/learning_cli.py
+++ b/proof_engine_pilot/learning_cli.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .core import ProofEngineError, load
+from .learning import preflight_candidate, verify_learning_bundle
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Review-derived learning for future Proof Engine candidate runs")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("verify")
+    sub.add_parser("summary")
+    sub.add_parser("replay")
+    preflight = sub.add_parser("preflight")
+    preflight.add_argument("input", type=Path)
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        bundle = verify_learning_bundle()
+        if args.command == "verify":
+            print(f"Review learning verification passed ({bundle['policy']['policy_id']})")
+        elif args.command == "summary":
+            print(json.dumps({
+                "dataset_id": bundle["dataset"]["dataset_id"],
+                "positive_examples": bundle["dataset"]["counts"]["positive_examples"],
+                "correction_pairs": bundle["dataset"]["counts"]["correction_pairs"],
+                "rules": len(bundle["ruleset"]["rules"]),
+                "state": bundle["policy"]["state"],
+                "mode": bundle["policy"]["mode"],
+                "model_weight_update_performed": bundle["policy"]["model_weight_update_performed"],
+            }, ensure_ascii=False, sort_keys=True, indent=2))
+        elif args.command == "replay":
+            print(json.dumps(bundle["replay"], ensure_ascii=False, sort_keys=True, indent=2))
+        else:
+            print(json.dumps(preflight_candidate(load(args.input)), ensure_ascii=False, sort_keys=True, indent=2))
+    except ProofEngineError as exc:
+        print(f"review learning failed closed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/proof_engine_pilot/learning_data/round_0001/dataset.json
+++ b/proof_engine_pilot/learning_data/round_0001/dataset.json
@@ -1,0 +1,125 @@
+{
+  "correction_pairs": [
+    {
+      "approval_decision_fingerprint": "4ffe6cc495a29ef18541e375fd0643bbeda4d229a35db8a57d6ae6c86d5f5c48",
+      "approval_decision_id": "PROOF-REVIEW-0001-D013",
+      "candidate_id": "ACH-001",
+      "error_labels": [
+        "RESULT_AUTHORSHIP_CONFLATION",
+        "OUTPUT_KIND_OVERSTATEMENT"
+      ],
+      "factuality_note": "The repository history verifies the staged split and resulting boundaries. It does not prove that one person independently derived and implemented the complete decomposition without AI assistance.",
+      "original_claim": "Decomposed a broad governed execution-and-learning initiative into independently verifiable staged integration boundaries.",
+      "original_fingerprint": "31d2e2f2198486a46d21f4a2325eaf5666ddc0e820041b3cb95c10da338c3b5f",
+      "record_kind": "PROCESS_BYPRODUCT",
+      "revise_decision_fingerprint": "578c715ad2c8d7f776024c0955e5953b59403128277d9f09646a2ac4b587353a",
+      "revise_decision_id": "PROOF-REVIEW-0001-D008",
+      "revised_claim": "As a byproduct of the governed development process, the broad execution-and-learning initiative was split into separately verifiable integration boundaries: a read-only orchestrator, an append-only human review ledger, and a non-applying promotion preview.",
+      "revision_fingerprint": "f3efbdd2842e241b9c24ad11b7e8bb9a9c85c9ff3466dec3444e071519cf3acf",
+      "revision_id": "ACH-001-R1"
+    },
+    {
+      "approval_decision_fingerprint": "775f8d2ce2c91bc13d9a8a06e92b5ca363aa3c9d1ce806ab04c225942eba9f51",
+      "approval_decision_id": "PROOF-REVIEW-0001-D014",
+      "candidate_id": "ACH-002",
+      "error_labels": [
+        "DIRECT_AUTHORSHIP_OVERCLAIM",
+        "PROJECT_OUTPUT_MISCLASSIFIED"
+      ],
+      "factuality_note": "The implemented artifact and tests are verified. The wording avoids attributing all architecture and code authorship directly to the human operator.",
+      "original_claim": "Designed and implemented a deterministic repository-local read-only governed loop orchestrator.",
+      "original_fingerprint": "9bb41c8a1bc7e1d87f91e8c2825054ee1a913659a796ad5c8b6bc9dd187e0494",
+      "record_kind": "PROJECT_OUTPUT",
+      "revise_decision_fingerprint": "2847023b7a7af51fc1a9a716a418b3e027e52b0a8ccea2507a4cb75adae31970",
+      "revise_decision_id": "PROOF-REVIEW-0001-D009",
+      "revised_claim": "The repository contains a deterministic, repository-local, read-only governed loop orchestrator produced through AI-assisted development under human-set goals, constraints, acceptance criteria, and approval gates.",
+      "revision_fingerprint": "9e6008f210dff8aebd56cdf6146e8ea49f4e2cbb994a20036f573655914d2734",
+      "revision_id": "ACH-002-R1"
+    },
+    {
+      "approval_decision_fingerprint": "a6bd1e56fbe3c23e597da3e93fa945cfed196a5a4fbc6cab41490e41a6d2e580",
+      "approval_decision_id": "PROOF-REVIEW-0001-D015",
+      "candidate_id": "ACH-007",
+      "error_labels": [
+        "RESULT_AUTHORSHIP_CONFLATION",
+        "INTEGRATION_BYPRODUCT_MISCLASSIFIED"
+      ],
+      "factuality_note": "The eight-stage linkage is verified in the repository. This record describes the resulting integration artifact rather than claiming sole direct implementation by the human operator.",
+      "original_claim": "Integrated eight deterministic verification stages into one governed loop run while preserving read-only authority.",
+      "original_fingerprint": "43bcb215a8a217292f78caaff2e27d9b4b233f1d5400955372037bc447a378a3",
+      "record_kind": "INTEGRATION_BYPRODUCT",
+      "revise_decision_fingerprint": "2ea8e238d9e7d1627335807f0eeba9b7f92582e477e17fb51abeb0a07b2d5088",
+      "revise_decision_id": "PROOF-REVIEW-0001-D010",
+      "revised_claim": "As an integration byproduct of completing the governed loop, one committed loop run links eight deterministic verification stages while retaining read-only authority.",
+      "revision_fingerprint": "be2fc501112a948bca756565e18bd05b081d6afd0581737a3e24130c32504299",
+      "revision_id": "ACH-007-R1"
+    },
+    {
+      "approval_decision_fingerprint": "83a1290eb0794f1de8e124d6651d6ca097cc5682f871d6162171486e39f7a4c0",
+      "approval_decision_id": "PROOF-REVIEW-0001-D016",
+      "candidate_id": "ACH-010",
+      "error_labels": [
+        "DISCOVERY_AND_REMEDIATION_AUTHORSHIP_OVERCLAIM",
+        "AUDIT_BYPRODUCT_MISCLASSIFIED"
+      ],
+      "factuality_note": "The review findings, fixes, tests, and acceptance are evidenced by the pull request. This is an audit-remediation byproduct, not proof that the human operator personally discovered or coded every correction.",
+      "original_claim": "Resolved independent review findings that could have allowed under-governed G0 classification or weaker re-signed plans.",
+      "original_fingerprint": "8bf814b14a14019c85092f28268bd903e6a9f25075925b73aab82bdcd5dc37d8",
+      "record_kind": "AUDIT_REMEDIATION_BYPRODUCT",
+      "revise_decision_fingerprint": "3505d989d8b40d57918742cc067c3c3f941eb8e2f9844241388f4003ae4af7da",
+      "revise_decision_id": "PROOF-REVIEW-0001-D011",
+      "revised_claim": "Independent review of the Adaptive Governance Compiler identified under-governed G0 classification and context-rebinding risks; the AI-assisted development process then incorporated fixes and regression tests accepted through human review.",
+      "revision_fingerprint": "097804e888fbaf83c98fe8b9bfc04f8f63180ff284bbc988613a7c3f6e10aca5",
+      "revision_id": "ACH-010-R1"
+    },
+    {
+      "approval_decision_fingerprint": "022c05779f434b890c39151b3735a861a05c4169bfe34d126ead5a50ccfaa324",
+      "approval_decision_id": "PROOF-REVIEW-0001-D017",
+      "candidate_id": "ACH-012",
+      "error_labels": [
+        "UNSUPPORTED_GENERALIZATION",
+        "REUSABILITY_OVERCLAIM"
+      ],
+      "factuality_note": "Repeated use inside RTS is verified. General reusability and reduced failure rates outside this repository remain unverified, so the record is classified as a signal rather than a completed reusable asset.",
+      "original_claim": "Established a repeatable pattern of exact fingerprints, stale-state detection, CI verification, review correction, and completion records across multiple governed components.",
+      "original_fingerprint": "42ef649cf4e586f7c6309f0725655570f46667451039ce5ef44b06cc504ec2b6",
+      "record_kind": "REUSABILITY_SIGNAL",
+      "revise_decision_fingerprint": "a0b780ed35ec46e57e8d304fe61ecb5f89ce0f5a460cdf7e4a66809dc9dbe9aa",
+      "revise_decision_id": "PROOF-REVIEW-0001-D012",
+      "revised_claim": "Across several RTS components, the project repeatedly used exact fingerprints, stale-state checks, CI verification, review remediation, and completion records. This is evidence of a potentially reusable development pattern, not yet proof of reuse outside RTS.",
+      "revision_fingerprint": "978dd444f2809052550b24dc2e46cace974115c4f973555424676d68bd694cd2",
+      "revision_id": "ACH-012-R1"
+    }
+  ],
+  "counts": {
+    "correction_pairs": 5,
+    "human_decisions_represented": 17,
+    "positive_examples": 7
+  },
+  "dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
+  "dataset_id": "PROOF-ENGINE-LEARNING-DATASET-0001",
+  "positive_examples": [
+    {"candidate_fingerprint":"c6e999358ea8bf32452025244c8bf67af9b0615a62644b2895ba0e817c9d6c02","candidate_id":"ACH-003","decision_fingerprint":"4f6844e6567b3cd777f39b8106e05c5d2944e9a1cd9c42f652461e7c081c6178","decision_id":"PROOF-REVIEW-0001-D001","error_labels":[],"expected_action":"APPROVE"},
+    {"candidate_fingerprint":"88d64152c140ae27abc314982cbaf7d4f03073de4696e823030be6b4b5ea506a","candidate_id":"ACH-004","decision_fingerprint":"0235a64dc4364bcceea7a210bed457727a80669bd0ecba6670e18a81c1468a6f","decision_id":"PROOF-REVIEW-0001-D002","error_labels":[],"expected_action":"APPROVE"},
+    {"candidate_fingerprint":"7946c9d5ad60f039da1b7696ab1de03c6dd35502fc47c9db1fcbfde76d8ed3c2","candidate_id":"ACH-005","decision_fingerprint":"6a48ccf42e119df2c93c77b3668ab095c885294ce11b16dc1c69a65f260ac100","decision_id":"PROOF-REVIEW-0001-D003","error_labels":[],"expected_action":"APPROVE"},
+    {"candidate_fingerprint":"1c61cf7f44150cc2cd783e1c15f44e1f58918a6495c059459b1f044001a211c6","candidate_id":"ACH-006","decision_fingerprint":"d34173d63152b33f2e14d929d55229ecde41f3eb5bfaa5add07f02ba35e90ba6","decision_id":"PROOF-REVIEW-0001-D004","error_labels":[],"expected_action":"APPROVE"},
+    {"candidate_fingerprint":"b43a812c99d7c7c8f1472ccd6855ed768fc88d76aec28b82a813c486b4cd7291","candidate_id":"ACH-008","decision_fingerprint":"f7231ed9d51ab2655afc40da8417865fb4ee359c9fd614416a1429736792dcbb","decision_id":"PROOF-REVIEW-0001-D005","error_labels":[],"expected_action":"APPROVE"},
+    {"candidate_fingerprint":"2c8cc1cb6b4a10cd6535e9291615abb4015e7c9b02c9f0f9d28ec90dc8f17799","candidate_id":"ACH-009","decision_fingerprint":"c4010f4f558999db78a4f0ebade80bcc3fbdcc0c0bafa99eeb4336379c7742bd","decision_id":"PROOF-REVIEW-0001-D006","error_labels":[],"expected_action":"APPROVE"},
+    {"candidate_fingerprint":"c4f710c49bd66accd9c01cad65637336371cf98e25d1479f2614eba57d0e3af6","candidate_id":"ACH-011","decision_fingerprint":"02fd0570807ad82c953f1cdae3cf987fa32411772bc765580d2c3ee0b1593dc8","decision_id":"PROOF-REVIEW-0001-D007","error_labels":[],"expected_action":"APPROVE"}
+  ],
+  "schema_version": "PROOF-ENGINE-REVIEW-LEARNING-DATASET-V1",
+  "source_fingerprints": {
+    "base_run": "0935b4b594b3d80a0d38fe2cb95dc9a90eed82ba8591a7251cd4ef1dde9d7ee1",
+    "decision_index": "efcd75558bff03abd881067d66923fd0dc3232d54631410ef509af5a27f8a7ba",
+    "review_summary": "eb58b8e4ffcdbebd143574109ffa99b9afd02adbeedf71e3aa1466ace48731d4",
+    "revision_ledger": "67d96b51e13df9d29b898404f26f85d1a0746573b591280f83818d4e06241606"
+  },
+  "source_review_round_id": "PROOF-ENGINE-REVIEW-ROUND-0001",
+  "usage_boundary": {
+    "automatic_approval_authorized": false,
+    "automatic_rewrite_authorized": false,
+    "mode": "REPOSITORY_LOCAL_RULE_LEARNING",
+    "model_weight_training_authorized": false,
+    "publication_authorized": false
+  }
+}

--- a/proof_engine_pilot/learning_data/round_0001/policy_state.json
+++ b/proof_engine_pilot/learning_data/round_0001/policy_state.json
@@ -1,18 +1,18 @@
 {
   "active_dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
-  "active_ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "active_ruleset_fingerprint": "fad89c35f06b7891b04023dc68d96e2968876e09b8ac29c8d3633961c03cb657",
   "authority": {
     "automatic_approval_authorized": false,
     "automatic_rewrite_authorized": false,
     "external_execution_authorized": false,
     "publication_authorized": false
   },
-  "latest_replay_fingerprint": "60287f65a78c3cafc2740221f03f4db4f3e4dc75a8433093ea4bd14721678ad0",
+  "latest_replay_fingerprint": "e22d8bed853f44181a6427d79177ab2a6fd35e445f67a650cc4553fc1eaf7202",
   "mode": "SUGGEST_ONLY",
   "model_weight_update_performed": false,
   "next_action": "Use the active ruleset as a pre-review factuality and classification check for the next candidate-generation run.",
   "original_records_preserved": true,
-  "policy_fingerprint": "3aa2a723328705710ce158885188d069b8e9425b645030d97ef030ed78e363df",
+  "policy_fingerprint": "c4e81d04b22f1db00d6ed43238b75c9aa855c95e33e595eaf49006c92e6b2176",
   "policy_id": "PROOF-ENGINE-LEARNING-POLICY-0001",
   "schema_version": "PROOF-ENGINE-LEARNING-POLICY-STATE-V1",
   "state": "ACTIVE_FOR_FUTURE_RUNS"

--- a/proof_engine_pilot/learning_data/round_0001/policy_state.json
+++ b/proof_engine_pilot/learning_data/round_0001/policy_state.json
@@ -1,0 +1,19 @@
+{
+  "active_dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
+  "active_ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "authority": {
+    "automatic_approval_authorized": false,
+    "automatic_rewrite_authorized": false,
+    "external_execution_authorized": false,
+    "publication_authorized": false
+  },
+  "latest_replay_fingerprint": "60287f65a78c3cafc2740221f03f4db4f3e4dc75a8433093ea4bd14721678ad0",
+  "mode": "SUGGEST_ONLY",
+  "model_weight_update_performed": false,
+  "next_action": "Use the active ruleset as a pre-review factuality and classification check for the next candidate-generation run.",
+  "original_records_preserved": true,
+  "policy_fingerprint": "3aa2a723328705710ce158885188d069b8e9425b645030d97ef030ed78e363df",
+  "policy_id": "PROOF-ENGINE-LEARNING-POLICY-0001",
+  "schema_version": "PROOF-ENGINE-LEARNING-POLICY-STATE-V1",
+  "state": "ACTIVE_FOR_FUTURE_RUNS"
+}

--- a/proof_engine_pilot/learning_data/round_0001/replay.json
+++ b/proof_engine_pilot/learning_data/round_0001/replay.json
@@ -1,0 +1,19 @@
+{
+  "counts": {
+    "corrections_learned": 5,
+    "positive_examples_preserved": 7,
+    "revisions_accepted": 5,
+    "unresolved_examples": 0
+  },
+  "dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
+  "future_policy": {
+    "base_run_mutated": false,
+    "mode": "SUGGEST_ONLY",
+    "state": "ACTIVE_FOR_FUTURE_RUNS"
+  },
+  "replay_fingerprint": "60287f65a78c3cafc2740221f03f4db4f3e4dc75a8433093ea4bd14721678ad0",
+  "replay_id": "PROOF-ENGINE-LEARNING-REPLAY-0001",
+  "result": "PASS_LEARNING_DATA_REFLECTED",
+  "ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "schema_version": "PROOF-ENGINE-REVIEW-LEARNING-REPLAY-V1"
+}

--- a/proof_engine_pilot/learning_data/round_0001/replay.json
+++ b/proof_engine_pilot/learning_data/round_0001/replay.json
@@ -11,9 +11,9 @@
     "mode": "SUGGEST_ONLY",
     "state": "ACTIVE_FOR_FUTURE_RUNS"
   },
-  "replay_fingerprint": "60287f65a78c3cafc2740221f03f4db4f3e4dc75a8433093ea4bd14721678ad0",
+  "replay_fingerprint": "e22d8bed853f44181a6427d79177ab2a6fd35e445f67a650cc4553fc1eaf7202",
   "replay_id": "PROOF-ENGINE-LEARNING-REPLAY-0001",
   "result": "PASS_LEARNING_DATA_REFLECTED",
-  "ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "ruleset_fingerprint": "fad89c35f06b7891b04023dc68d96e2968876e09b8ac29c8d3633961c03cb657",
   "schema_version": "PROOF-ENGINE-REVIEW-LEARNING-REPLAY-V1"
 }

--- a/proof_engine_pilot/learning_data/round_0001/ruleset.json
+++ b/proof_engine_pilot/learning_data/round_0001/ruleset.json
@@ -21,6 +21,8 @@
   },
   "dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
   "required_future_candidate_fields": [
+    "candidate_id",
+    "claim",
     "record_kind",
     "factuality_note",
     "contribution_map",
@@ -29,14 +31,56 @@
     "public_disclosure"
   ],
   "rules": [
-    {"automatic_application_authorized":false,"category":"AUTHORSHIP_ATTRIBUTION","instruction":"Separate the observed repository result from direct personal authorship. When AI or tools implemented material parts, describe the project output and list the human's supported decisions, constraints, review, and approval separately.","rule_id":"REVIEW-RULE-001","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010"],"state":"ACTIVE"},
-    {"automatic_application_authorized":false,"category":"ARTIFACT_KIND","instruction":"Classify the record as a personal achievement, project output, process byproduct, integration byproduct, audit-remediation byproduct, or reusability signal instead of treating every result as a personal achievement.","rule_id":"REVIEW-RULE-002","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010","ACH-012"],"state":"ACTIVE"},
-    {"automatic_application_authorized":false,"category":"CONTRIBUTION_SEPARATION","instruction":"Keep human, AI-tool, collaborator, and inherited contributions separate. Do not collapse AI-assisted implementation into a direct human implementation claim.","rule_id":"REVIEW-RULE-003","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010"],"state":"ACTIVE"},
-    {"automatic_application_authorized":false,"category":"GENERALIZATION_SCOPE","instruction":"Do not generalize beyond the evidence boundary. Repeated use inside RTS is a reusability signal until reuse outside RTS is observed.","rule_id":"REVIEW-RULE-004","source_candidate_ids":["ACH-012"],"state":"ACTIVE"},
-    {"automatic_application_authorized":false,"category":"APPEND_ONLY_CORRECTION","instruction":"Preserve original candidates and append REVISE decisions plus versioned corrections. Never silently overwrite the reviewed source record.","rule_id":"REVIEW-RULE-005","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010","ACH-012"],"state":"ACTIVE"},
-    {"automatic_application_authorized":false,"category":"AUTHORITY_BOUNDARY","instruction":"Candidate approval authorizes internal draft use only. Publication, outreach, contracts, external execution, and model-weight training require separate human authority.","rule_id":"REVIEW-RULE-006","source_candidate_ids":["ACH-001","ACH-002","ACH-003","ACH-004","ACH-005","ACH-006","ACH-007","ACH-008","ACH-009","ACH-010","ACH-011","ACH-012"],"state":"ACTIVE"}
+    {
+      "automatic_application_authorized": false,
+      "category": "AUTHORSHIP_ATTRIBUTION",
+      "instruction": "Separate the observed repository result from direct personal authorship. When AI or tools implemented material parts, describe the project output and list the human's supported decisions, constraints, review, and approval separately.",
+      "rule_id": "REVIEW-RULE-001",
+      "source_candidate_ids": ["ACH-001", "ACH-002", "ACH-007", "ACH-010"],
+      "state": "ACTIVE"
+    },
+    {
+      "automatic_application_authorized": false,
+      "category": "ARTIFACT_KIND",
+      "instruction": "Classify the record as a personal achievement, project output, process byproduct, integration byproduct, audit-remediation byproduct, or reusability signal instead of treating every result as a personal achievement.",
+      "rule_id": "REVIEW-RULE-002",
+      "source_candidate_ids": ["ACH-001", "ACH-002", "ACH-007", "ACH-010", "ACH-012"],
+      "state": "ACTIVE"
+    },
+    {
+      "automatic_application_authorized": false,
+      "category": "CONTRIBUTION_SEPARATION",
+      "instruction": "Keep human, AI-tool, collaborator, and inherited contributions separate. Do not collapse AI-assisted implementation into a direct human implementation claim.",
+      "rule_id": "REVIEW-RULE-003",
+      "source_candidate_ids": ["ACH-001", "ACH-002", "ACH-007", "ACH-010"],
+      "state": "ACTIVE"
+    },
+    {
+      "automatic_application_authorized": false,
+      "category": "GENERALIZATION_SCOPE",
+      "instruction": "Do not generalize beyond the evidence boundary. Repeated use inside RTS is a reusability signal until reuse outside RTS is observed.",
+      "rule_id": "REVIEW-RULE-004",
+      "source_candidate_ids": ["ACH-012"],
+      "state": "ACTIVE"
+    },
+    {
+      "automatic_application_authorized": false,
+      "category": "APPEND_ONLY_CORRECTION",
+      "instruction": "Preserve original candidates and append REVISE decisions plus versioned corrections. Never silently overwrite the reviewed source record.",
+      "rule_id": "REVIEW-RULE-005",
+      "source_candidate_ids": ["ACH-001", "ACH-002", "ACH-007", "ACH-010", "ACH-012"],
+      "state": "ACTIVE"
+    },
+    {
+      "automatic_application_authorized": false,
+      "category": "AUTHORITY_BOUNDARY",
+      "instruction": "Candidate approval authorizes internal draft use only. Publication, outreach, contracts, external execution, and model-weight training require separate human authority.",
+      "rule_id": "REVIEW-RULE-006",
+      "source_candidate_ids": ["ACH-001", "ACH-002", "ACH-003", "ACH-004", "ACH-005", "ACH-006", "ACH-007", "ACH-008", "ACH-009", "ACH-010", "ACH-011", "ACH-012"],
+      "state": "ACTIVE"
+    }
   ],
-  "ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "ruleset_fingerprint": "fad89c35f06b7891b04023dc68d96e2968876e09b8ac29c8d3633961c03cb657",
   "ruleset_id": "PROOF-ENGINE-LEARNING-RULESET-0001",
   "schema_version": "PROOF-ENGINE-REVIEW-LEARNING-RULESET-V1"
 }

--- a/proof_engine_pilot/learning_data/round_0001/ruleset.json
+++ b/proof_engine_pilot/learning_data/round_0001/ruleset.json
@@ -1,0 +1,42 @@
+{
+  "activation": {
+    "applies_after_run_id": "PROOF-ENGINE-P3-RUN-0001",
+    "mode": "SUGGEST_ONLY",
+    "retroactive_mutation": false,
+    "state": "ACTIVE_FOR_FUTURE_RUNS"
+  },
+  "allowed_record_kinds": [
+    "PERSONAL_ACHIEVEMENT",
+    "PROJECT_OUTPUT",
+    "PROCESS_BYPRODUCT",
+    "INTEGRATION_BYPRODUCT",
+    "AUDIT_REMEDIATION_BYPRODUCT",
+    "REUSABILITY_SIGNAL"
+  ],
+  "authority": {
+    "automatic_approval_authorized": false,
+    "automatic_rewrite_authorized": false,
+    "model_weight_training_authorized": false,
+    "publication_authorized": false
+  },
+  "dataset_fingerprint": "ae897a05bef32209a81d54ff6da99334a82483bd57964fea07284d6571d82f79",
+  "required_future_candidate_fields": [
+    "record_kind",
+    "factuality_note",
+    "contribution_map",
+    "evidence_label",
+    "evidence_prs",
+    "public_disclosure"
+  ],
+  "rules": [
+    {"automatic_application_authorized":false,"category":"AUTHORSHIP_ATTRIBUTION","instruction":"Separate the observed repository result from direct personal authorship. When AI or tools implemented material parts, describe the project output and list the human's supported decisions, constraints, review, and approval separately.","rule_id":"REVIEW-RULE-001","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010"],"state":"ACTIVE"},
+    {"automatic_application_authorized":false,"category":"ARTIFACT_KIND","instruction":"Classify the record as a personal achievement, project output, process byproduct, integration byproduct, audit-remediation byproduct, or reusability signal instead of treating every result as a personal achievement.","rule_id":"REVIEW-RULE-002","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010","ACH-012"],"state":"ACTIVE"},
+    {"automatic_application_authorized":false,"category":"CONTRIBUTION_SEPARATION","instruction":"Keep human, AI-tool, collaborator, and inherited contributions separate. Do not collapse AI-assisted implementation into a direct human implementation claim.","rule_id":"REVIEW-RULE-003","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010"],"state":"ACTIVE"},
+    {"automatic_application_authorized":false,"category":"GENERALIZATION_SCOPE","instruction":"Do not generalize beyond the evidence boundary. Repeated use inside RTS is a reusability signal until reuse outside RTS is observed.","rule_id":"REVIEW-RULE-004","source_candidate_ids":["ACH-012"],"state":"ACTIVE"},
+    {"automatic_application_authorized":false,"category":"APPEND_ONLY_CORRECTION","instruction":"Preserve original candidates and append REVISE decisions plus versioned corrections. Never silently overwrite the reviewed source record.","rule_id":"REVIEW-RULE-005","source_candidate_ids":["ACH-001","ACH-002","ACH-007","ACH-010","ACH-012"],"state":"ACTIVE"},
+    {"automatic_application_authorized":false,"category":"AUTHORITY_BOUNDARY","instruction":"Candidate approval authorizes internal draft use only. Publication, outreach, contracts, external execution, and model-weight training require separate human authority.","rule_id":"REVIEW-RULE-006","source_candidate_ids":["ACH-001","ACH-002","ACH-003","ACH-004","ACH-005","ACH-006","ACH-007","ACH-008","ACH-009","ACH-010","ACH-011","ACH-012"],"state":"ACTIVE"}
+  ],
+  "ruleset_fingerprint": "c8c495009dcab4431d5490b70d577c87ab700c77c4a8a72667f1291b65df64ac",
+  "ruleset_id": "PROOF-ENGINE-LEARNING-RULESET-0001",
+  "schema_version": "PROOF-ENGINE-REVIEW-LEARNING-RULESET-V1"
+}

--- a/tests/test_proof_engine_learning.py
+++ b/tests/test_proof_engine_learning.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+
+from proof_engine_pilot.learning import preflight_candidate, verify_learning_bundle
+from proof_engine_pilot.learning_cli import build_parser
+
+
+class ReviewLearningTests(unittest.TestCase):
+    def test_committed_learning_bundle_is_verified(self):
+        bundle = verify_learning_bundle()
+        self.assertEqual(bundle["dataset"]["counts"], {
+            "positive_examples": 7,
+            "correction_pairs": 5,
+            "human_decisions_represented": 17,
+        })
+        self.assertEqual(bundle["policy"]["state"], "ACTIVE_FOR_FUTURE_RUNS")
+        self.assertEqual(bundle["policy"]["mode"], "SUGGEST_ONLY")
+        self.assertFalse(bundle["policy"]["model_weight_update_performed"])
+        self.assertTrue(bundle["policy"]["original_records_preserved"])
+
+    def test_factually_bounded_revision_passes_preflight(self):
+        candidate = {
+            "candidate_id": "ACH-NEXT",
+            "claim": "Inside RTS, the project repeatedly used the pattern; this is a potential reuse signal.",
+            "record_kind": "REUSABILITY_SIGNAL",
+            "factuality_note": "External reuse is not yet observed.",
+            "contribution_map": {"human": ["set thresholds"], "ai_tool": ["implemented checks"], "collaborator": []},
+            "evidence_label": "INFERRED",
+            "evidence_prs": [264],
+            "public_disclosure": "INTERNAL_UNTIL_SEPARATE_PUBLICATION_APPROVAL",
+        }
+        self.assertEqual(preflight_candidate(candidate)["result"], "PASS")
+
+    def test_authorship_overclaim_is_suggested_for_review(self):
+        candidate = {
+            "candidate_id": "ACH-NEXT",
+            "claim": "Built the complete system.",
+            "record_kind": "PERSONAL_ACHIEVEMENT",
+            "contribution_map": {"human": ["approved"], "ai_tool": ["implemented code"], "collaborator": []},
+            "evidence_label": "VERIFIED",
+            "evidence_prs": [264],
+            "public_disclosure": "INTERNAL_UNTIL_APPROVED",
+        }
+        result = preflight_candidate(candidate)
+        codes = {item["code"] for item in result["issues"]}
+        self.assertEqual(result["result"], "SUGGEST_REVIEW")
+        self.assertIn("MISSING_LEARNING_FIELDS", codes)
+        self.assertIn("AUTHORSHIP_REQUIRES_FACTUALITY_NOTE", codes)
+
+    def test_cross_project_generalization_is_downgraded(self):
+        candidate = {
+            "candidate_id": "ACH-NEXT",
+            "claim": "Established a repeatable pattern across future projects.",
+            "record_kind": "PERSONAL_ACHIEVEMENT",
+            "factuality_note": "Observed only inside RTS.",
+            "contribution_map": {"human": ["set policy"], "ai_tool": ["implemented"], "collaborator": []},
+            "evidence_label": "VERIFIED",
+            "evidence_prs": [264],
+            "public_disclosure": "INTERNAL_UNTIL_APPROVED",
+        }
+        result = preflight_candidate(candidate)
+        self.assertIn("GENERALIZATION_EXCEEDS_EVIDENCE", {item["code"] for item in result["issues"]})
+
+    def test_cli_has_no_apply_or_approve_command(self):
+        parser = build_parser()
+        action = next(action for action in parser._actions if getattr(action, "choices", None))
+        self.assertEqual(set(action.choices), {"verify", "summary", "replay", "preflight"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_proof_engine_learning.py
+++ b/tests/test_proof_engine_learning.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import copy
 import unittest
 
-from proof_engine_pilot.learning import preflight_candidate, verify_learning_bundle
+from proof_engine_pilot.core import ProofEngineError, fingerprint, load
+from proof_engine_pilot.learning import CHECKPOINT_PATH, preflight_candidate, verify_learning_bundle
 from proof_engine_pilot.learning_cli import build_parser
 
 
@@ -18,6 +20,16 @@ class ReviewLearningTests(unittest.TestCase):
         self.assertEqual(bundle["policy"]["mode"], "SUGGEST_ONLY")
         self.assertFalse(bundle["policy"]["model_weight_update_performed"])
         self.assertTrue(bundle["policy"]["original_records_preserved"])
+        self.assertFalse(bundle["checkpoint"]["external_actions_performed"])
+
+    def test_checkpoint_external_action_fails_closed(self):
+        checkpoint = copy.deepcopy(load(CHECKPOINT_PATH))
+        checkpoint["external_actions_performed"] = True
+        material = copy.deepcopy(checkpoint)
+        material.pop("checkpoint_fingerprint")
+        checkpoint["checkpoint_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "unauthorized external action"):
+            verify_learning_bundle(checkpoint=checkpoint)
 
     def test_factually_bounded_revision_passes_preflight(self):
         candidate = {
@@ -31,6 +43,34 @@ class ReviewLearningTests(unittest.TestCase):
             "public_disclosure": "INTERNAL_UNTIL_SEPARATE_PUBLICATION_APPROVAL",
         }
         self.assertEqual(preflight_candidate(candidate)["result"], "PASS")
+
+    def test_missing_core_identity_and_claim_require_review(self):
+        candidate = {
+            "record_kind": "PROJECT_OUTPUT",
+            "factuality_note": "Repository result only.",
+            "contribution_map": {"human": ["approved"], "ai_tool": ["implemented"], "collaborator": []},
+            "evidence_label": "VERIFIED",
+            "evidence_prs": [264],
+            "public_disclosure": "INTERNAL_UNTIL_APPROVED",
+        }
+        result = preflight_candidate(candidate)
+        self.assertEqual(result["result"], "SUGGEST_REVIEW")
+        self.assertIn("MISSING_LEARNING_FIELDS", {item["code"] for item in result["issues"]})
+
+    def test_empty_core_identity_and_claim_require_review(self):
+        candidate = {
+            "candidate_id": "",
+            "claim": " ",
+            "record_kind": "PROJECT_OUTPUT",
+            "factuality_note": "Repository result only.",
+            "contribution_map": {"human": ["approved"], "ai_tool": ["implemented"], "collaborator": []},
+            "evidence_label": "VERIFIED",
+            "evidence_prs": [264],
+            "public_disclosure": "INTERNAL_UNTIL_APPROVED",
+        }
+        codes = {item["code"] for item in preflight_candidate(candidate)["issues"]}
+        self.assertIn("INVALID_CANDIDATE_ID", codes)
+        self.assertIn("INVALID_CLAIM", codes)
 
     def test_authorship_overclaim_is_suggested_for_review(self):
         candidate = {
@@ -46,7 +86,21 @@ class ReviewLearningTests(unittest.TestCase):
         codes = {item["code"] for item in result["issues"]}
         self.assertEqual(result["result"], "SUGGEST_REVIEW")
         self.assertIn("MISSING_LEARNING_FIELDS", codes)
-        self.assertIn("AUTHORSHIP_REQUIRES_FACTUALITY_NOTE", codes)
+        self.assertIn("DIRECT_AUTHORSHIP_REQUIRES_REVIEW", codes)
+
+    def test_factuality_note_does_not_bypass_authorship_review(self):
+        candidate = {
+            "candidate_id": "ACH-NEXT",
+            "claim": "Built the complete system.",
+            "record_kind": "PERSONAL_ACHIEVEMENT",
+            "factuality_note": "The AI implemented all code.",
+            "contribution_map": {"human": ["approved"], "ai_tool": ["implemented all code"], "collaborator": []},
+            "evidence_label": "VERIFIED",
+            "evidence_prs": [264],
+            "public_disclosure": "INTERNAL_UNTIL_APPROVED",
+        }
+        result = preflight_candidate(candidate)
+        self.assertIn("DIRECT_AUTHORSHIP_REQUIRES_REVIEW", {item["code"] for item in result["issues"]})
 
     def test_cross_project_generalization_is_downgraded(self):
         candidate = {


### PR DESCRIPTION
## Purpose

Turn review round 0001 into repository-local learning data and reflect it into future Proof Engine candidate review without changing model weights or silently rewriting records.

## Learning data

- 7 positive approved examples
- 5 original-to-revision correction pairs
- 17 human decisions represented
- exact links to the immutable base run, revision ledger, decision index, and review summary

## Active rules

1. separate observed result from direct personal authorship;
2. classify personal achievements, project outputs, byproducts, and reusability signals;
3. keep human, AI-tool, collaborator, and inherited contributions separate;
4. block unsupported cross-project generalization;
5. preserve append-only correction lineage;
6. keep publication and consequential authority behind separate human gates.

## Reflection

The policy is active only for candidate runs after `PROOF-ENGINE-P3-RUN-0001` and operates in `SUGGEST_ONLY` mode. A deterministic preflight reports factuality, classification, authorship, generalization, and publication-boundary warnings.

There is no automatic rewrite, approval, publication, external execution, or model-weight training.

## Validation

- verify dataset fingerprints against the original review artifacts;
- verify ruleset, replay, policy state, and checkpoint links;
- focused learning tests;
- existing candidate and append-only review tests;
- full repository test suite;
- Unicode Guard.