### PR TITLE
Generate six audience-facing drafts and stop at publication review

### DIFF
--- a/.github/workflows/proof-engine-pilot-tests.yml
+++ b/.github/workflows/proof-engine-pilot-tests.yml
@@ -10,6 +10,7 @@ on:
       - "tests/test_proof_engine_learning.py"
       - "tests/test_proof_engine_asset_draft.py"
       - "tests/test_proof_engine_asset_review.py"
+      - "tests/test_proof_engine_public_wording.py"
       - ".github/workflows/proof-engine-pilot-tests.yml"
   push:
     branches: [main]
@@ -21,6 +22,7 @@ on:
       - "tests/test_proof_engine_learning.py"
       - "tests/test_proof_engine_asset_draft.py"
       - "tests/test_proof_engine_asset_review.py"
+      - "tests/test_proof_engine_public_wording.py"
       - ".github/workflows/proof-engine-pilot-tests.yml"
 
 permissions:
@@ -73,6 +75,23 @@ jobs:
           python -B -m proof_engine_pilot.asset_review_cli verify
           python -B -m proof_engine_pilot.asset_review_cli summary
           python -B -m proof_engine_pilot.asset_review_cli effective > /tmp/proof-engine-reviewed-assets.json
+      - name: Verify audience-facing wording draft
+        run: |
+          python -B -m proof_engine_pilot.public_wording_cli verify
+          python -B -m proof_engine_pilot.public_wording_cli summary
+          python -B -m proof_engine_pilot.public_wording_cli review-template > /tmp/proof-engine-publication-review-template.json
+          python -B -m proof_engine_pilot.public_wording_cli generate --output /tmp/proof-engine-public-wording.json
+          python -B -m proof_engine_pilot.public_wording_cli render-markdown --output /tmp/proof-engine-public-wording.md
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          from proof_engine_pilot.core import fingerprint
+          draft = json.loads(Path('/tmp/proof-engine-public-wording.json').read_text(encoding='utf-8'))
+          manifest = json.loads(Path('proof_engine_pilot/wording/round_0001/public_wording_manifest.json').read_text(encoding='utf-8'))
+          markdown = Path('/tmp/proof-engine-public-wording.md').read_text(encoding='utf-8')
+          assert draft['draft_fingerprint'] == manifest['expected_draft_fingerprint']
+          assert fingerprint(markdown) == manifest['expected_markdown_fingerprint']
+          PY
       - name: Run focused tests
         run: |
           python -B -m unittest discover -s tests -p 'test_proof_engine_pilot.py' -v
@@ -80,5 +99,6 @@ jobs:
           python -B -m unittest discover -s tests -p 'test_proof_engine_learning.py' -v
           python -B -m unittest discover -s tests -p 'test_proof_engine_asset_draft.py' -v
           python -B -m unittest discover -s tests -p 'test_proof_engine_asset_review.py' -v
+          python -B -m unittest discover -s tests -p 'test_proof_engine_public_wording.py' -v
       - name: Run full repository tests
         run: python -B -m unittest discover -s tests -v

--- a/pilot_runs/reconnect_pilot_p3/public_wording_checkpoint_0006.json
+++ b/pilot_runs/reconnect_pilot_p3/public_wording_checkpoint_0006.json
@@ -1,0 +1,15 @@
+{
+  "checkpoint_fingerprint": "3b2f8518458fb753bcdcc0b41320cd391c27d8227546e99ecc7f427c94f21bd3",
+  "checkpoint_id": "PROOF-ENGINE-PUBLIC-WORDING-CHECKPOINT-0006",
+  "draft_fingerprint": "91a21a9eb8119fc474d2f6a1c3429ae265c7c1997066f8148e2a612ef6167782",
+  "external_actions_performed": false,
+  "manifest_fingerprint": "c27a22e8ac727d11512a06c4e27030de14ca9e6774d97efb94dd8e378f863056",
+  "markdown_fingerprint": "08c642b73c6caadcf5eb823ebf2abf7e45e06304ff96fdac3b447bc2e71fc337",
+  "next_action": "Review the six audience-facing drafts and record append-only publication decisions; do not publish without separate explicit authority.",
+  "original_internal_assets_preserved": true,
+  "publication_performed": false,
+  "schema_version": "PROOF-ENGINE-PUBLIC-WORDING-CHECKPOINT-V1",
+  "source_asset_review_summary_fingerprint": "d640a781fdbda40dd281f4406a910f2e34d490cedb61834e5882e6de5809a91e",
+  "state": "PUBLICATION_REVIEW_REQUIRED",
+  "wording_count": 6
+}

--- a/proof_engine_pilot/README.md
+++ b/proof_engine_pilot/README.md
@@ -56,8 +56,20 @@ python -m proof_engine_pilot.asset_review_cli summary
 python -m proof_engine_pilot.asset_review_cli effective
 ```
 
-All six internal assets were reviewed against factuality, contribution separation, non-overlap, privacy, and internal-source readiness. They are approved only as sources for the next public-wording draft stage. The approval does not authorize publication, outreach, contracts, external execution, or automatic rewriting.
+All six internal assets were reviewed against factuality, contribution separation, non-overlap, privacy, and internal-source readiness. They are approved only as sources for the public-wording draft stage.
 
-Original candidates, corrected candidate revisions, and generated internal assets remain preserved. This is not a model-weight update and does not manufacture approval.
+## Audience-facing wording draft commands
 
-There is no approve, publish, outreach, contract, provider, merge, model-training, or external-execution command. Publication remains `NOT_PUBLISHED`; the next stage may generate audience-facing wording drafts but must stop at a separate publication review gate.
+```bash
+python -m proof_engine_pilot.public_wording_cli generate
+python -m proof_engine_pilot.public_wording_cli render-markdown
+python -m proof_engine_pilot.public_wording_cli verify
+python -m proof_engine_pilot.public_wording_cli summary
+python -m proof_engine_pilot.public_wording_cli review-template
+```
+
+The six approved internal sources are translated into English audience-facing wording with a headline, summary, value explanation, evidence note, human and AI-tool attribution, and explicit limits. Every draft passes the active review-learning preflight and remains `PUBLICATION_REVIEW_REQUIRED / NOT_PUBLISHED`.
+
+Original candidates, corrected revisions, internal assets, and human decisions remain preserved. This is not a model-weight update and does not manufacture approval.
+
+There is no approve, publish, outreach, contract, provider, merge, model-training, or external-execution command. Publication requires a separate append-only human decision and remains unauthorized in this stage.

--- a/proof_engine_pilot/public_wording.py
+++ b/proof_engine_pilot/public_wording.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from .asset_review import verify_asset_review
+from .core import ProofEngineError, fingerprint, load
+from .learning import preflight_candidate
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+ROOT = PACKAGE_DIR.parent
+MANIFEST_PATH = PACKAGE_DIR / "wording" / "round_0001" / "public_wording_manifest.json"
+CHECKPOINT_PATH = ROOT / "pilot_runs" / "reconnect_pilot_p3" / "public_wording_checkpoint_0006.json"
+
+EXPECTED_AUTHORITY = {
+    "automatic_approval_authorized": False,
+    "automatic_rewrite_authorized": False,
+    "contract_authorized": False,
+    "external_execution_authorized": False,
+    "outreach_authorized": False,
+    "publication_authorized": False,
+}
+
+WORDING_BLUEPRINTS = [
+    {
+        "wording_id": "WORDING-001",
+        "asset_id": "ASSET-001",
+        "headline": "A governed loop that turns project intent into a verifiable, resumable workflow",
+        "summary": "RTS includes a deterministic, repository-local loop that ingests a Seed contract, links eight verification stages, records checkpoints, and stops at explicit human gates. The current implementation is read-only and does not grant unattended execution authority.",
+        "why_it_matters": "Complex AI-assisted projects can preserve scope, evidence, review state, and recovery points instead of depending on a single uninterrupted conversation.",
+        "proof_note": "Verified through committed Seed, run, lifecycle, checkpoint, resume, completion, and CI records in RTS.",
+        "limit_note": "Demonstrated inside RTS as a governed project output. Production autonomy and effectiveness outside this repository are not established.",
+        "audiences": ["AI-assisted solo developers", "solo founders", "small technical teams", "project evaluators"],
+    },
+    {
+        "wording_id": "WORDING-002",
+        "asset_id": "ASSET-002",
+        "headline": "One active change, with human approval at consequential transitions",
+        "summary": "During the governed pilot, RTS enforced WIP=1 across selection, implementation, verification, and completion, while explicit human decisions controlled consequential transitions.",
+        "why_it_matters": "A single active work item reduces parallel scope drift and makes it clearer which change is being evaluated, approved, completed, or stopped.",
+        "proof_note": "Verified in the lifecycle and approval records for the governed pilot.",
+        "limit_note": "This is a process result observed in the RTS pilot, not evidence that the same policy is optimal for every team or organization.",
+        "audiences": ["solo developers", "project leads", "small teams", "AI workflow designers"],
+    },
+    {
+        "wording_id": "WORDING-003",
+        "asset_id": "ASSET-003",
+        "headline": "Append-only human decisions with fail-closed integrity checks",
+        "summary": "RTS includes a Human Review Ledger that preserves decisions as an append-only chain and rejects stale expiry, proposer mismatch, unmanifested decision files, and other invalid review states.",
+        "why_it_matters": "The system can distinguish a recorded human decision from stale, altered, or unregistered material before any later application step is considered.",
+        "proof_note": "Verified through ledger fixtures, deterministic fingerprints, integrity checks, regression tests, and accepted review corrections.",
+        "limit_note": "The ledger records and verifies review evidence; it does not itself authorize publication, contracts, external execution, or repository writes.",
+        "audiences": ["AI system builders", "reviewers", "auditors", "small technical teams"],
+    },
+    {
+        "wording_id": "WORDING-004",
+        "asset_id": "ASSET-004",
+        "headline": "Inspect intended changes and rollback points before granting write authority",
+        "summary": "RTS includes a non-applying Promotion Application Preview that exposes target files, before-and-after hashes, blockers, validation steps, and rollback anchors before any write authority is granted.",
+        "why_it_matters": "An operator can examine what would change, how it would be checked, and where recovery would begin without applying the change.",
+        "proof_note": "Verified through the committed preview schema, deterministic fixtures, parser-based inspection, safety checks, and CI tests.",
+        "limit_note": "The preview is intentionally non-applying. It does not write to a target repository or approve the proposed change.",
+        "audiences": ["repository maintainers", "AI-assisted developers", "reviewers", "release operators"],
+    },
+    {
+        "wording_id": "WORDING-005",
+        "asset_id": "ASSET-005",
+        "headline": "Governance depth selected from the exact risk and authority context",
+        "summary": "RTS includes an Adaptive Governance Compiler that deterministically selects G0-G4 governance profiles from the requested action, affected paths, reversibility, and authority context. Independent review findings were incorporated as fail-closed fixes and regression tests.",
+        "why_it_matters": "Low-risk work can avoid unnecessary ceremony while sensitive or irreversible work retains stronger review, rollback, and testing requirements.",
+        "proof_note": "Verified through deterministic compilation, context-bound verification, fixed profiles, independent review findings, accepted repairs, and full regression tests.",
+        "limit_note": "The compiler has been tested inside RTS. It does not prove universal risk classification quality or replace human judgment for consequential decisions.",
+        "audiences": ["AI workflow designers", "technical leads", "repository maintainers", "governance reviewers"],
+    },
+    {
+        "wording_id": "WORDING-006",
+        "asset_id": "ASSET-006",
+        "headline": "From a long project conversation to a machine-verifiable Seed and scope decision",
+        "summary": "A long project conversation was converted into a verified Seed Pack, ingested by the governed loop, and reduced to a bounded P0 scope decision with explicit future branches and stopping conditions.",
+        "why_it_matters": "Unstructured intent can become a resumable project contract that preserves goals, constraints, exclusions, privacy boundaries, and the next human decision.",
+        "proof_note": "The Seed Pack, manifest, scope profiles, P0 run, checkpoint, and related CI records are verified in RTS.",
+        "limit_note": "The ingestion result is verified for this case. Similar internal patterns recur inside RTS, but effectiveness and reuse outside RTS remain unobserved.",
+        "audiences": ["solo founders", "AI-assisted developers", "project planners", "collaborators and evaluators"],
+    },
+]
+
+
+def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
+    material = copy.deepcopy(value)
+    actual = material.pop(field, None)
+    if actual != fingerprint(material):
+        raise ProofEngineError(f"{label} fingerprint mismatch")
+    return actual
+
+
+def build_public_wording_draft() -> dict[str, Any]:
+    review = verify_asset_review()
+    source_assets = {item["asset_id"]: item for item in review["draft"]["assets"]}
+    approvals = {item["asset_id"]: item for item in review["summary"]["effective_assets"]}
+    if set(source_assets) != set(approvals) or len(source_assets) != 6:
+        raise ProofEngineError("public wording source set mismatch")
+
+    wordings = []
+    covered = []
+    for blueprint in WORDING_BLUEPRINTS:
+        asset_id = blueprint["asset_id"]
+        if asset_id not in source_assets or asset_id in covered:
+            raise ProofEngineError("public wording source asset mismatch")
+        source = source_assets[asset_id]
+        approval = approvals[asset_id]
+        if approval["asset_fingerprint"] != source["asset_fingerprint"]:
+            raise ProofEngineError("public wording approval/source mismatch")
+
+        wording = {
+            "wording_id": blueprint["wording_id"],
+            "candidate_id": blueprint["wording_id"],
+            "source_asset": {
+                "asset_id": asset_id,
+                "asset_fingerprint": source["asset_fingerprint"],
+                "approval_decision_id": approval["decision_id"],
+                "approval_decision_fingerprint": approval["decision_fingerprint"],
+            },
+            "language": "en",
+            "headline": blueprint["headline"],
+            "claim": blueprint["summary"],
+            "summary": blueprint["summary"],
+            "why_it_matters": blueprint["why_it_matters"],
+            "proof_note": blueprint["proof_note"],
+            "record_kind": source["record_kind"],
+            "factuality_note": blueprint["limit_note"],
+            "contribution_map": copy.deepcopy(source["contribution_map"]),
+            "evidence_label": source["evidence_label"],
+            "evidence_prs": copy.deepcopy(source["evidence_prs"]),
+            "audiences": copy.deepcopy(blueprint["audiences"]),
+            "public_disclosure": "INTERNAL_UNTIL_SEPARATE_PUBLICATION_APPROVAL",
+            "publication_status": "NOT_PUBLISHED",
+            "review_status": "PUBLICATION_REVIEW_REQUIRED",
+        }
+        wording["wording_fingerprint"] = fingerprint(wording)
+        preflight = preflight_candidate(wording)
+        if preflight["result"] != "PASS":
+            raise ProofEngineError(f"public wording learning preflight failed: {wording['wording_id']}")
+        wordings.append(wording)
+        covered.append(asset_id)
+
+    if covered != [f"ASSET-{index:03d}" for index in range(1, 7)]:
+        raise ProofEngineError("public wording source order mismatch")
+
+    source_fingerprints = review["draft"]["source_fingerprints"]
+    draft = {
+        "schema_version": "PROOF-ENGINE-PUBLIC-WORDING-DRAFT-V1",
+        "draft_id": "PROOF-ENGINE-PUBLIC-WORDING-DRAFT-0001",
+        "source_fingerprints": {
+            "internal_asset_draft": review["draft"]["draft_fingerprint"],
+            "asset_review_summary": review["summary"]["summary_fingerprint"],
+            "asset_review_index": review["summary"]["decision_index_fingerprint"],
+            "learning_policy": source_fingerprints["learning_policy"],
+            "learning_ruleset": source_fingerprints["learning_ruleset"],
+        },
+        "authority": copy.deepcopy(EXPECTED_AUTHORITY),
+        "language": "en",
+        "wording_count": 6,
+        "wordings": wordings,
+        "coverage": {
+            "approved_internal_asset_count": 6,
+            "covered_asset_ids": covered,
+            "duplicates_allowed": False,
+            "all_approved_assets_covered_once": True,
+        },
+        "learning_preflight": {
+            "mode": "SUGGEST_ONLY",
+            "required_result": "PASS",
+            "wording_results": [
+                {"wording_id": item["wording_id"], "result": "PASS", "issues": []}
+                for item in wordings
+            ],
+        },
+        "review_gate": {
+            "state": "PUBLICATION_REVIEW_REQUIRED",
+            "allowed_decisions": ["APPROVE_FOR_PUBLICATION", "REVISE", "REJECT", "REDACT", "EXPIRE"],
+            "decisions": [],
+        },
+        "output": {
+            "state": "READY_FOR_PUBLICATION_REVIEW",
+            "publication_status": "NOT_PUBLISHED",
+            "reason": "Audience-facing wording exists, but publication requires a separate explicit human decision.",
+        },
+        "next_action": "Human reviews the six audience-facing drafts, records append-only publication decisions, and separately authorizes any actual release.",
+    }
+    draft["draft_fingerprint"] = fingerprint(draft)
+    return draft
+
+
+def render_public_wording_markdown(draft: dict[str, Any] | None = None) -> str:
+    value = build_public_wording_draft() if draft is None else draft
+    lines = [
+        "# RTS Evidence-Backed Project Outputs — Publication Draft",
+        "",
+        "> Status: NOT PUBLISHED. These six drafts require a separate human publication decision.",
+        "",
+    ]
+    for index, wording in enumerate(value["wordings"], start=1):
+        lines.extend([
+            f"## {index}. {wording['headline']}",
+            "",
+            wording["summary"],
+            "",
+            f"**Why it matters:** {wording['why_it_matters']}",
+            "",
+            f"**Evidence:** {wording['proof_note']} PR references: "
+            + ", ".join(f"#{number}" for number in wording["evidence_prs"])
+            + ".",
+            "",
+            "**Human role:** " + "; ".join(wording["contribution_map"]["human"]) + ".",
+            "",
+            "**AI-tool role:** " + "; ".join(wording["contribution_map"]["ai_tool"]) + ".",
+            "",
+            f"**Limits:** {wording['factuality_note']}",
+            "",
+        ])
+    lines.extend([
+        "---",
+        "",
+        "Publication, outreach, contracts, external execution, automatic rewriting, and automatic approval remain unauthorized.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def verify_public_wording_draft(
+    draft: dict[str, Any] | None = None,
+    manifest: dict[str, Any] | None = None,
+    checkpoint: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    expected = build_public_wording_draft()
+    candidate = expected if draft is None else copy.deepcopy(draft)
+    _verify_fingerprint(candidate, "draft_fingerprint", "public wording draft")
+    if candidate != expected:
+        raise ProofEngineError("public wording draft does not match deterministic aggregation")
+    if candidate.get("authority") != EXPECTED_AUTHORITY:
+        raise ProofEngineError("public wording authority widened")
+    if candidate.get("wording_count") != 6 or candidate.get("language") != "en":
+        raise ProofEngineError("public wording count or language mismatch")
+    if candidate.get("coverage") != {
+        "approved_internal_asset_count": 6,
+        "covered_asset_ids": [f"ASSET-{index:03d}" for index in range(1, 7)],
+        "duplicates_allowed": False,
+        "all_approved_assets_covered_once": True,
+    }:
+        raise ProofEngineError("public wording coverage mismatch")
+    if candidate.get("review_gate") != {
+        "state": "PUBLICATION_REVIEW_REQUIRED",
+        "allowed_decisions": ["APPROVE_FOR_PUBLICATION", "REVISE", "REJECT", "REDACT", "EXPIRE"],
+        "decisions": [],
+    }:
+        raise ProofEngineError("public wording review gate mismatch")
+    if candidate.get("output") != {
+        "state": "READY_FOR_PUBLICATION_REVIEW",
+        "publication_status": "NOT_PUBLISHED",
+        "reason": "Audience-facing wording exists, but publication requires a separate explicit human decision.",
+    }:
+        raise ProofEngineError("public wording publication boundary mismatch")
+    for wording in candidate["wordings"]:
+        _verify_fingerprint(wording, "wording_fingerprint", f"public wording {wording.get('wording_id')}")
+        if wording.get("publication_status") != "NOT_PUBLISHED" or wording.get("review_status") != "PUBLICATION_REVIEW_REQUIRED":
+            raise ProofEngineError("public wording item publication boundary mismatch")
+        if preflight_candidate(wording)["result"] != "PASS":
+            raise ProofEngineError("public wording item no longer passes learning preflight")
+
+    markdown = render_public_wording_markdown(candidate)
+    markdown_fingerprint = fingerprint(markdown)
+
+    manifest = load(MANIFEST_PATH) if manifest is None else copy.deepcopy(manifest)
+    _verify_fingerprint(manifest, "manifest_fingerprint", "public wording manifest")
+    if manifest != {
+        "schema_version": "PROOF-ENGINE-PUBLIC-WORDING-MANIFEST-V1",
+        "manifest_id": "PROOF-ENGINE-PUBLIC-WORDING-MANIFEST-0001",
+        "draft_id": candidate["draft_id"],
+        "expected_draft_fingerprint": candidate["draft_fingerprint"],
+        "expected_markdown_fingerprint": markdown_fingerprint,
+        "wording_count": 6,
+        "review_state": "PUBLICATION_REVIEW_REQUIRED",
+        "publication_status": "NOT_PUBLISHED",
+        "manifest_fingerprint": manifest["manifest_fingerprint"],
+    }:
+        raise ProofEngineError("public wording manifest mismatch")
+
+    checkpoint = load(CHECKPOINT_PATH) if checkpoint is None else copy.deepcopy(checkpoint)
+    _verify_fingerprint(checkpoint, "checkpoint_fingerprint", "public wording checkpoint")
+    links = {
+        "source_asset_review_summary_fingerprint": candidate["source_fingerprints"]["asset_review_summary"],
+        "draft_fingerprint": candidate["draft_fingerprint"],
+        "markdown_fingerprint": markdown_fingerprint,
+        "manifest_fingerprint": manifest["manifest_fingerprint"],
+    }
+    for field, expected_value in links.items():
+        if checkpoint.get(field) != expected_value:
+            raise ProofEngineError(f"public wording checkpoint mismatch: {field}")
+    if checkpoint.get("schema_version") != "PROOF-ENGINE-PUBLIC-WORDING-CHECKPOINT-V1" or checkpoint.get("checkpoint_id") != "PROOF-ENGINE-PUBLIC-WORDING-CHECKPOINT-0006":
+        raise ProofEngineError("public wording checkpoint identity mismatch")
+    if checkpoint.get("state") != "PUBLICATION_REVIEW_REQUIRED" or checkpoint.get("wording_count") != 6:
+        raise ProofEngineError("public wording checkpoint state mismatch")
+    if checkpoint.get("original_internal_assets_preserved") is not True:
+        raise ProofEngineError("public wording source assets were not preserved")
+    if checkpoint.get("publication_performed") is not False or checkpoint.get("external_actions_performed") is not False:
+        raise ProofEngineError("public wording checkpoint records unauthorized action")
+
+    return {
+        "draft": candidate,
+        "markdown": markdown,
+        "markdown_fingerprint": markdown_fingerprint,
+        "manifest": manifest,
+        "checkpoint": checkpoint,
+    }

--- a/proof_engine_pilot/public_wording_cli.py
+++ b/proof_engine_pilot/public_wording_cli.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .core import ProofEngineError
+from .public_wording import (
+    build_public_wording_draft,
+    render_public_wording_markdown,
+    verify_public_wording_draft,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Audience-facing wording drafts for reviewed Proof Engine assets")
+    sub = parser.add_subparsers(dest="command", required=True)
+    generate = sub.add_parser("generate")
+    generate.add_argument("--output", type=Path)
+    markdown = sub.add_parser("render-markdown")
+    markdown.add_argument("--output", type=Path)
+    sub.add_parser("verify")
+    sub.add_parser("summary")
+    sub.add_parser("review-template")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "generate":
+            value = build_public_wording_draft()
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2) + "\n"
+            if args.output:
+                args.output.write_text(text, encoding="utf-8")
+            else:
+                print(text, end="")
+        elif args.command == "render-markdown":
+            text = render_public_wording_markdown()
+            if args.output:
+                args.output.write_text(text, encoding="utf-8")
+            else:
+                print(text, end="")
+        else:
+            bundle = verify_public_wording_draft()
+            draft = bundle["draft"]
+            if args.command == "verify":
+                print(f"Public wording draft verification passed ({draft['draft_id']})")
+            elif args.command == "summary":
+                print(json.dumps({
+                    "draft_id": draft["draft_id"],
+                    "language": draft["language"],
+                    "wording_count": draft["wording_count"],
+                    "learning_preflight": draft["learning_preflight"]["required_result"],
+                    "review_state": draft["review_gate"]["state"],
+                    "publication_status": draft["output"]["publication_status"],
+                    "markdown_fingerprint": bundle["markdown_fingerprint"],
+                }, ensure_ascii=False, sort_keys=True, indent=2))
+            else:
+                print(json.dumps({
+                    "draft_id": draft["draft_id"],
+                    "allowed_decisions": draft["review_gate"]["allowed_decisions"],
+                    "wording_ids": [item["wording_id"] for item in draft["wordings"]],
+                    "required_fields": ["decision", "rationale", "wording_changes", "redactions", "publication_scope"],
+                    "publication_authorized": False,
+                }, ensure_ascii=False, sort_keys=True, indent=2))
+    except ProofEngineError as exc:
+        print(f"public wording draft failed closed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/proof_engine_pilot/wording/round_0001/public_wording_manifest.json
+++ b/proof_engine_pilot/wording/round_0001/public_wording_manifest.json
@@ -1,0 +1,11 @@
+{
+  "draft_id": "PROOF-ENGINE-PUBLIC-WORDING-DRAFT-0001",
+  "expected_draft_fingerprint": "91a21a9eb8119fc474d2f6a1c3429ae265c7c1997066f8148e2a612ef6167782",
+  "expected_markdown_fingerprint": "08c642b73c6caadcf5eb823ebf2abf7e45e06304ff96fdac3b447bc2e71fc337",
+  "manifest_fingerprint": "c27a22e8ac727d11512a06c4e27030de14ca9e6774d97efb94dd8e378f863056",
+  "manifest_id": "PROOF-ENGINE-PUBLIC-WORDING-MANIFEST-0001",
+  "publication_status": "NOT_PUBLISHED",
+  "review_state": "PUBLICATION_REVIEW_REQUIRED",
+  "schema_version": "PROOF-ENGINE-PUBLIC-WORDING-MANIFEST-V1",
+  "wording_count": 6
+}

--- a/tests/test_proof_engine_public_wording.py
+++ b/tests/test_proof_engine_public_wording.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from proof_engine_pilot.core import ProofEngineError, fingerprint, load
+from proof_engine_pilot.public_wording import (
+    CHECKPOINT_PATH,
+    MANIFEST_PATH,
+    build_public_wording_draft,
+    render_public_wording_markdown,
+    verify_public_wording_draft,
+)
+from proof_engine_pilot.public_wording_cli import build_parser
+
+
+class PublicWordingTests(unittest.TestCase):
+    def test_committed_public_wording_draft_is_verified(self):
+        bundle = verify_public_wording_draft()
+        draft = bundle["draft"]
+        self.assertEqual(draft["wording_count"], 6)
+        self.assertEqual(draft["review_gate"]["state"], "PUBLICATION_REVIEW_REQUIRED")
+        self.assertEqual(draft["output"]["publication_status"], "NOT_PUBLISHED")
+        self.assertEqual(bundle["checkpoint"]["state"], "PUBLICATION_REVIEW_REQUIRED")
+        self.assertFalse(bundle["checkpoint"]["publication_performed"])
+        self.assertFalse(bundle["checkpoint"]["external_actions_performed"])
+
+    def test_all_six_reviewed_assets_are_covered_once(self):
+        draft = build_public_wording_draft()
+        asset_ids = [item["source_asset"]["asset_id"] for item in draft["wordings"]]
+        self.assertEqual(asset_ids, [f"ASSET-{index:03d}" for index in range(1, 7)])
+        self.assertEqual(len(asset_ids), len(set(asset_ids)))
+
+    def test_markdown_is_deterministic_and_not_published(self):
+        bundle = verify_public_wording_draft()
+        markdown = render_public_wording_markdown(bundle["draft"])
+        self.assertEqual(markdown, bundle["markdown"])
+        self.assertIn("Status: NOT PUBLISHED", markdown)
+        self.assertIn("Publication, outreach, contracts", markdown)
+        self.assertEqual(fingerprint(markdown), bundle["manifest"]["expected_markdown_fingerprint"])
+
+    def test_resigned_publication_authority_fails_closed(self):
+        draft = build_public_wording_draft()
+        draft["authority"]["publication_authorized"] = True
+        material = copy.deepcopy(draft)
+        material.pop("draft_fingerprint")
+        draft["draft_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "deterministic aggregation"):
+            verify_public_wording_draft(draft=draft)
+
+    def test_manufactured_review_decision_fails_closed(self):
+        draft = build_public_wording_draft()
+        draft["review_gate"]["decisions"] = [{"decision": "APPROVE_FOR_PUBLICATION"}]
+        material = copy.deepcopy(draft)
+        material.pop("draft_fingerprint")
+        draft["draft_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "deterministic aggregation"):
+            verify_public_wording_draft(draft=draft)
+
+    def test_resigned_published_checkpoint_fails_closed(self):
+        checkpoint = copy.deepcopy(load(CHECKPOINT_PATH))
+        checkpoint["publication_performed"] = True
+        material = copy.deepcopy(checkpoint)
+        material.pop("checkpoint_fingerprint")
+        checkpoint["checkpoint_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "unauthorized action"):
+            verify_public_wording_draft(checkpoint=checkpoint)
+
+    def test_manifest_rejects_wording_count_change(self):
+        manifest = copy.deepcopy(load(MANIFEST_PATH))
+        manifest["wording_count"] = 5
+        material = copy.deepcopy(manifest)
+        material.pop("manifest_fingerprint")
+        manifest["manifest_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "manifest mismatch"):
+            verify_public_wording_draft(manifest=manifest)
+
+    def test_cli_has_no_publish_or_approve_command(self):
+        parser = build_parser()
+        action = next(action for action in parser._actions if getattr(action, "choices", None))
+        self.assertEqual(set(action.choices), {"generate", "render-markdown", "verify", "summary", "review-template"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Purpose

Translate the six human-approved internal sources into audience-facing wording while keeping publication behind a separate explicit human gate.

## Draft structure

Each of the six English drafts includes:

- a reader-facing headline;
- a bounded summary;
- why the result matters;
- an evidence note and exact PR references;
- separate human and AI-tool roles;
- explicit limits and unverified boundaries.

## Safety and authority

- all six source assets remain unchanged;
- every wording passes the active `SUGGEST_ONLY` learning preflight;
- the draft is deterministic and bound to the approved asset-review summary;
- no publication decision is manufactured;
- publication, outreach, contracts, external execution, automatic rewriting, and automatic approval remain unauthorized;
- the terminal state is `PUBLICATION_REVIEW_REQUIRED / NOT_PUBLISHED`.

## Commands

```text
python -m proof_engine_pilot.public_wording_cli generate
python -m proof_engine_pilot.public_wording_cli render-markdown
python -m proof_engine_pilot.public_wording_cli verify
python -m proof_engine_pilot.public_wording_cli summary
python -m proof_engine_pilot.public_wording_cli review-template
```

There is no publish or approve command.

## Validation

- deterministic JSON and Markdown fingerprints;
- six approved internal assets covered exactly once;
- learning preflight remains PASS;
- fail closed on re-signed authority widening, manufactured review decisions, altered Manifest counts, and publication checkpoints;
- existing Proof Engine, review, learning, asset, Pilot, full repository, and Unicode tests.