### PR TITLE
Publish six evidence-backed RTS outputs to one repository document

### DIFF
--- a/.github/workflows/proof-engine-pilot-tests.yml
+++ b/.github/workflows/proof-engine-pilot-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "proof_engine_pilot/**"
       - "pilot_runs/reconnect_pilot_p3/**"
+      - "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md"
       - "tests/test_proof_engine_pilot.py"
       - "tests/test_proof_engine_review.py"
       - "tests/test_proof_engine_learning.py"
@@ -12,12 +13,14 @@ on:
       - "tests/test_proof_engine_asset_review.py"
       - "tests/test_proof_engine_public_wording.py"
       - "tests/test_proof_engine_publication_review.py"
+      - "tests/test_proof_engine_release.py"
       - ".github/workflows/proof-engine-pilot-tests.yml"
   push:
     branches: [main]
     paths:
       - "proof_engine_pilot/**"
       - "pilot_runs/reconnect_pilot_p3/**"
+      - "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md"
       - "tests/test_proof_engine_pilot.py"
       - "tests/test_proof_engine_review.py"
       - "tests/test_proof_engine_learning.py"
@@ -25,6 +28,7 @@ on:
       - "tests/test_proof_engine_asset_review.py"
       - "tests/test_proof_engine_public_wording.py"
       - "tests/test_proof_engine_publication_review.py"
+      - "tests/test_proof_engine_release.py"
       - ".github/workflows/proof-engine-pilot-tests.yml"
 
 permissions:
@@ -100,6 +104,10 @@ jobs:
           python -B -m proof_engine_pilot.publication_review_cli summary
           python -B -m proof_engine_pilot.publication_review_cli effective > /tmp/proof-engine-effective-public-wording.json
           python -B -m proof_engine_pilot.publication_review_cli release-template > /tmp/proof-engine-release-template.json
+      - name: Verify bounded repository publication release
+        run: |
+          python -B -m proof_engine_pilot.release_cli verify
+          python -B -m proof_engine_pilot.release_cli summary
       - name: Run focused tests
         run: |
           python -B -m unittest discover -s tests -p 'test_proof_engine_pilot.py' -v
@@ -109,5 +117,6 @@ jobs:
           python -B -m unittest discover -s tests -p 'test_proof_engine_asset_review.py' -v
           python -B -m unittest discover -s tests -p 'test_proof_engine_public_wording.py' -v
           python -B -m unittest discover -s tests -p 'test_proof_engine_publication_review.py' -v
+          python -B -m unittest discover -s tests -p 'test_proof_engine_release.py' -v
       - name: Run full repository tests
         run: python -B -m unittest discover -s tests -v

--- a/docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md
+++ b/docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md
@@ -1,0 +1,91 @@
+# RTS Evidence-Backed Project Outputs
+
+This document summarizes six repository-observed outputs from the RTS governed pilot. Each statement is bounded by committed evidence, separates human direction from AI-tool assistance, and states what has not yet been established.
+
+## 1. A governed loop that turns project intent into a verifiable, resumable workflow
+
+RTS includes a deterministic, repository-local loop that ingests a Seed contract, links eight verification stages, records checkpoints, and stops at explicit human gates. The current implementation is read-only and does not grant unattended execution authority.
+
+**Why it matters:** Complex AI-assisted projects can preserve scope, evidence, review state, and recovery points instead of depending on a single uninterrupted conversation.
+
+**Evidence:** Verified through committed Seed, run, lifecycle, checkpoint, resume, completion, and CI records in RTS. PRs: [#242](https://github.com/nobutakayamauchi/RTS/pull/242), [#243](https://github.com/nobutakayamauchi/RTS/pull/243), [#244](https://github.com/nobutakayamauchi/RTS/pull/244), [#245](https://github.com/nobutakayamauchi/RTS/pull/245), [#246](https://github.com/nobutakayamauchi/RTS/pull/246), [#247](https://github.com/nobutakayamauchi/RTS/pull/247), [#248](https://github.com/nobutakayamauchi/RTS/pull/248), [#254](https://github.com/nobutakayamauchi/RTS/pull/254), [#258](https://github.com/nobutakayamauchi/RTS/pull/258), and [#260](https://github.com/nobutakayamauchi/RTS/pull/260).
+
+**Human role:** Set the usable-loop objective and scope; defined safety, ordering, and completion boundaries; reviewed failures and accepted the bounded result.
+
+**AI-tool role:** Proposed decomposition and implementation details; generated code, fixtures, records, and tests; applied review-driven corrections.
+
+**Limits:** Demonstrated inside RTS as a governed project output. Production autonomy and effectiveness outside this repository are not established.
+
+## 2. One active work item in the governed pilot, with human approval at consequential transitions
+
+During the governed pilot, RTS enforced WIP=1 across selection, implementation, verification, and completion, while explicit human decisions controlled consequential transitions.
+
+**Why it matters:** A single active work item reduces parallel scope drift and makes it clearer which change is being evaluated, approved, completed, or stopped.
+
+**Evidence:** Verified in the lifecycle and approval records for the governed pilot. PRs: [#246](https://github.com/nobutakayamauchi/RTS/pull/246), [#248](https://github.com/nobutakayamauchi/RTS/pull/248), [#253](https://github.com/nobutakayamauchi/RTS/pull/253), [#255](https://github.com/nobutakayamauchi/RTS/pull/255), [#257](https://github.com/nobutakayamauchi/RTS/pull/257), and [#260](https://github.com/nobutakayamauchi/RTS/pull/260).
+
+**Human role:** Set the WIP and approval policy; made priority and continuation decisions; approved lifecycle transitions.
+
+**AI-tool role:** Generated lifecycle records and verification support.
+
+**Limits:** This is a process result observed in the RTS pilot, not evidence that the same policy is optimal for every team or organization.
+
+## 3. Append-only human decisions with fail-closed integrity checks
+
+RTS includes a Human Review Ledger that preserves decisions as an append-only chain and rejects expired or stale decisions, proposer mismatches, unmanifested decision files, and other invalid review states.
+
+**Why it matters:** The system can distinguish a recorded human decision from stale, altered, or unregistered material before any later application step is considered.
+
+**Evidence:** Verified through ledger fixtures, deterministic fingerprints, integrity checks, regression tests, and accepted review corrections. PRs: [#249](https://github.com/nobutakayamauchi/RTS/pull/249), [#250](https://github.com/nobutakayamauchi/RTS/pull/250), [#252](https://github.com/nobutakayamauchi/RTS/pull/252), [#253](https://github.com/nobutakayamauchi/RTS/pull/253), [#254](https://github.com/nobutakayamauchi/RTS/pull/254), and [#255](https://github.com/nobutakayamauchi/RTS/pull/255).
+
+**Human role:** Defined the decision contract and authority boundary; judged review findings and required fail-closed handling; accepted the corrected result.
+
+**AI-tool role:** Implemented the ledger, verification, and regression tests; applied review-driven repairs.
+
+**Limits:** The ledger records and verifies review evidence; it does not itself authorize publication, contracts, external execution, or repository writes.
+
+## 4. Inspect intended changes and rollback points before granting write authority
+
+RTS includes a non-applying Promotion Application Preview that exposes target files, before-and-after hashes, blockers, validation steps, and rollback anchors before any write authority is granted.
+
+**Why it matters:** An operator can examine what would change, how it would be checked, and where recovery would begin without applying the change.
+
+**Evidence:** Verified through the committed preview schema, deterministic fixtures, parser-based inspection, safety checks, and CI tests. PRs: [#256](https://github.com/nobutakayamauchi/RTS/pull/256), [#257](https://github.com/nobutakayamauchi/RTS/pull/257), and [#258](https://github.com/nobutakayamauchi/RTS/pull/258).
+
+**Human role:** Defined scope, safety constraints, and acceptance boundaries; reviewed the non-applying result.
+
+**AI-tool role:** Implemented the schema, preview logic, fixtures, and tests.
+
+**Limits:** The preview is intentionally non-applying. It does not write to a target repository or approve the proposed change.
+
+## 5. Governance depth derived from declared change and authority context
+
+RTS includes an Adaptive Governance Compiler that deterministically selects G0-G4 governance profiles from the requested action, affected paths, reversibility, and authority context. Independent review findings were incorporated as fail-closed fixes and regression tests.
+
+**Why it matters:** Low-risk work can avoid unnecessary ceremony while sensitive or irreversible work retains stronger review, rollback, and testing requirements.
+
+**Evidence:** Verified through deterministic compilation, context-bound verification, fixed profiles, independent review findings, accepted repairs, and full regression tests. PR: [#259](https://github.com/nobutakayamauchi/RTS/pull/259).
+
+**Human role:** Defined the governance model and risk thresholds; judged review findings material; required and accepted fail-closed corrections.
+
+**AI-tool role:** Implemented the compiler and tests; raised independent review findings; implemented repairs and reran validation.
+
+**Limits:** The compiler has been tested inside RTS. It does not prove universal risk-classification quality or replace human judgment for consequential decisions.
+
+## 6. From a long project conversation to a machine-verifiable Seed and scope decision
+
+A long project conversation was converted into a verified Seed Pack, ingested by the governed loop, and reduced to a bounded P0 scope decision with explicit future branches and stopping conditions.
+
+**Why it matters:** Unstructured intent can become a resumable project contract that preserves goals, constraints, exclusions, privacy boundaries, and the next human decision.
+
+**Evidence:** The Seed Pack, manifest, scope profiles, P0 run, checkpoint, and related CI records are verified in RTS. PRs: [#247](https://github.com/nobutakayamauchi/RTS/pull/247), [#254](https://github.com/nobutakayamauchi/RTS/pull/254), [#258](https://github.com/nobutakayamauchi/RTS/pull/258), [#259](https://github.com/nobutakayamauchi/RTS/pull/259), [#260](https://github.com/nobutakayamauchi/RTS/pull/260), and [#261](https://github.com/nobutakayamauchi/RTS/pull/261).
+
+**Human role:** Synthesized the product direction and selected scope; set privacy and stopping boundaries; required reconstruction and recovery evidence.
+
+**AI-tool role:** Structured documents and validation; implemented recurring fingerprints, fixtures, and CI checks.
+
+**Limits:** The ingestion result is verified for this case. Similar internal patterns recur inside RTS, but effectiveness and reuse outside RTS remain unobserved.
+
+---
+
+This publication is limited to this repository document. It does not authorize social posting, direct outreach, contracting, external execution, or publication on another surface.

--- a/pilot_runs/reconnect_pilot_p3/publication_release_checkpoint_0008.json
+++ b/pilot_runs/reconnect_pilot_p3/publication_release_checkpoint_0008.json
@@ -1,6 +1,7 @@
 {
   "adjacent_repository_write_performed": false,
-  "checkpoint_fingerprint": "e9126434731de115bc401a18155a650e3559c77f13446fe35478eae17fc8d5dd",
+  "automatic_republication_performed": false,
+  "checkpoint_fingerprint": "01e50678344a4998d420d5d0e6a8d3cd85b180d562bf934a9066c43d8001f853",
   "checkpoint_id": "PROOF-ENGINE-PUBLICATION-RELEASE-CHECKPOINT-0008",
   "contract_action_performed": false,
   "direct_outreach_performed": false,
@@ -9,14 +10,17 @@
   "external_actions_performed": true,
   "next_action": "Observe this bounded repository publication; any additional surface, outreach, or revision requires a new human authorization.",
   "original_wording_drafts_preserved": true,
+  "provider_execution_performed": false,
   "publication_performed": true,
   "published_wording_count": 6,
   "release_authorization_fingerprint": "51fc24ed079a834102da79be8a6ec8381ee6b1c971e05e3fc72815681a298f91",
   "release_scope_respected": true,
   "repository_visibility": "PUBLIC",
+  "root_readme_promotion_performed": false,
   "schema_version": "PROOF-ENGINE-PUBLICATION-RELEASE-CHECKPOINT-V1",
   "social_posting_performed": false,
   "source_review_round_id": "PROOF-ENGINE-PUBLICATION-REVIEW-ROUND-0001",
   "state": "PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT",
-  "target_branch": "main"
+  "target_branch": "main",
+  "target_repository_write_performed": true
 }

--- a/pilot_runs/reconnect_pilot_p3/publication_release_checkpoint_0008.json
+++ b/pilot_runs/reconnect_pilot_p3/publication_release_checkpoint_0008.json
@@ -1,0 +1,22 @@
+{
+  "adjacent_repository_write_performed": false,
+  "checkpoint_fingerprint": "e9126434731de115bc401a18155a650e3559c77f13446fe35478eae17fc8d5dd",
+  "checkpoint_id": "PROOF-ENGINE-PUBLICATION-RELEASE-CHECKPOINT-0008",
+  "contract_action_performed": false,
+  "direct_outreach_performed": false,
+  "document_fingerprint": "682ec3d73373ea2228c4d270b5ca74bec8c59050781e7322dbfcfba1c9b50369",
+  "document_path": "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md",
+  "external_actions_performed": true,
+  "next_action": "Observe this bounded repository publication; any additional surface, outreach, or revision requires a new human authorization.",
+  "original_wording_drafts_preserved": true,
+  "publication_performed": true,
+  "published_wording_count": 6,
+  "release_authorization_fingerprint": "51fc24ed079a834102da79be8a6ec8381ee6b1c971e05e3fc72815681a298f91",
+  "release_scope_respected": true,
+  "repository_visibility": "PUBLIC",
+  "schema_version": "PROOF-ENGINE-PUBLICATION-RELEASE-CHECKPOINT-V1",
+  "social_posting_performed": false,
+  "source_review_round_id": "PROOF-ENGINE-PUBLICATION-REVIEW-ROUND-0001",
+  "state": "PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT",
+  "target_branch": "main"
+}

--- a/proof_engine_pilot/README.md
+++ b/proof_engine_pilot/README.md
@@ -85,8 +85,21 @@ Publication review round 0001 records the distinction between the human project 
 - `WORDING-003-R1` replaces unclear stale-expiry phrasing with expired-or-stale decision language;
 - `WORDING-005-R1` describes governance as derived from declared change and authority context rather than exact risk measurement.
 
-All six effective wordings are ready for a separate release-authorization gate. They are not published, and the review does not grant publication, outreach, contract, external-execution, automatic-rewrite, or automatic-approval authority.
+## Bounded repository publication release
 
-Original candidates, corrected revisions, internal assets, public-wording drafts, and review records remain preserved. This is not a model-weight update and does not manufacture human authorship for the delegated AI review.
+```bash
+python -m proof_engine_pilot.release_cli verify
+python -m proof_engine_pilot.release_cli summary
+```
 
-There is no approve, publish, outreach, contract, provider, merge, model-training, or external-execution command. The current state is `RELEASE_AUTHORIZATION_REQUIRED / NOT_PUBLISHED`.
+The project owner authorized exactly one public release surface:
+
+```text
+docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md
+```
+
+The committed document is generated from the six effective reviewed wordings and is bound to an exact content fingerprint. The release authorization permits publication to this public RTS repository document only. It does not permit a root README link, social posting, direct outreach, contracts, provider execution, adjacent-repository writes, or automatic republication.
+
+Original candidates, corrected revisions, internal assets, public-wording drafts, and review records remain preserved. This is not a model-weight update and does not manufacture human authorship for delegated AI judgments.
+
+The current state is `PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT`. Any additional surface or distribution action requires a new explicit human authorization.

--- a/proof_engine_pilot/release.py
+++ b/proof_engine_pilot/release.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from .core import ProofEngineError, fingerprint, load
+from .publication_review import effective_wording_records, verify_publication_review
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+ROOT = PACKAGE_DIR.parent
+AUTHORIZATION_PATH = PACKAGE_DIR / "releases" / "round_0001" / "release_authorization.json"
+DOCUMENT_PATH = ROOT / "docs" / "portfolio" / "RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md"
+CHECKPOINT_PATH = ROOT / "pilot_runs" / "reconnect_pilot_p3" / "publication_release_checkpoint_0008.json"
+
+AUTHORIZATION_SCHEMA = "PROOF-ENGINE-PUBLICATION-RELEASE-AUTHORIZATION-V1"
+AUTHORIZATION_ID = "PROOF-ENGINE-PUBLICATION-RELEASE-AUTHORIZATION-0001"
+CHECKPOINT_SCHEMA = "PROOF-ENGINE-PUBLICATION-RELEASE-CHECKPOINT-V1"
+CHECKPOINT_ID = "PROOF-ENGINE-PUBLICATION-RELEASE-CHECKPOINT-0008"
+ROUND_ID = "PROOF-ENGINE-PUBLICATION-REVIEW-ROUND-0001"
+PUBLIC_PATH = "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md"
+EXPECTED_DOCUMENT_FINGERPRINT = "682ec3d73373ea2228c4d270b5ca74bec8c59050781e7322dbfcfba1c9b50369"
+EXPECTED_AUTHORIZATION_FINGERPRINT = "51fc24ed079a834102da79be8a6ec8381ee6b1c971e05e3fc72815681a298f91"
+
+EXPECTED_HUMAN_AUTHORIZATION = {
+    "type": "HUMAN",
+    "identity": "nobutakayamauchi",
+    "identity_source": "CURRENT_CHAT_EXPLICIT_RELEASE_AUTHORIZATION",
+    "role": "PROJECT_OWNER",
+    "instruction": "じゃとりあえずこれもやろっか。",
+}
+EXPECTED_AUTHORITY = {
+    "publication_authorized": True,
+    "target_repository_write_authorized": True,
+    "social_posting_authorized": False,
+    "direct_outreach_authorized": False,
+    "contract_authorized": False,
+    "provider_execution_authorized": False,
+    "adjacent_repository_write_authorized": False,
+    "automatic_republication_authorized": False,
+}
+EXPECTED_SURFACE = {
+    "repository": "nobutakayamauchi/RTS",
+    "repository_visibility": "PUBLIC",
+    "target_branch": "main",
+    "exact_path": PUBLIC_PATH,
+    "publication_mode": "REPOSITORY_DOCUMENT_ONLY",
+    "document_fingerprint": EXPECTED_DOCUMENT_FINGERPRINT,
+    "release_timing": "IMMEDIATE_ON_MERGE",
+    "root_readme_link_authorized": False,
+}
+EXPECTED_SOURCE = {
+    "publication_review_contract_fingerprint": "e66845480c8b82a6c0d6d35e0039e20c464d1f6a41e880e5304ec4e59c46f383",
+    "source_draft_fingerprint": "91a21a9eb8119fc474d2f6a1c3429ae265c7c1997066f8148e2a612ef6167782",
+    "effective_wording_count": 6,
+    "revision_count": 3,
+}
+EXPECTED_RESTRICTIONS = {
+    "allowed_publication_paths": [PUBLIC_PATH],
+    "release_metadata_may_be_recorded_in_repository": True,
+    "content_must_match_authorized_fingerprint": True,
+    "publication_on_any_other_surface_requires_new_human_authorization": True,
+}
+
+
+def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
+    material = copy.deepcopy(value)
+    actual = material.pop(field, None)
+    if actual != fingerprint(material):
+        raise ProofEngineError(f"{label} fingerprint mismatch")
+    return actual
+
+
+def _pr_links(numbers: list[int]) -> str:
+    links = [f"[#{number}](https://github.com/nobutakayamauchi/RTS/pull/{number})" for number in numbers]
+    if len(links) == 1:
+        return links[0]
+    if len(links) == 2:
+        return " and ".join(links)
+    return ", ".join(links[:-1]) + ", and " + links[-1]
+
+
+def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
+    wordings = effective_wording_records() if records is None else records
+    if len(wordings) != 6 or [item["wording_id"] for item in wordings] != [f"WORDING-{index:03d}" for index in range(1, 7)]:
+        raise ProofEngineError("release wording set mismatch")
+
+    lines = [
+        "# RTS Evidence-Backed Project Outputs",
+        "",
+        "This document summarizes six repository-observed outputs from the RTS governed pilot. Each statement is bounded by committed evidence, separates human direction from AI-tool assistance, and states what has not yet been established.",
+        "",
+    ]
+    for index, wording in enumerate(wordings, start=1):
+        evidence_label = "PR" if len(wording["evidence_prs"]) == 1 else "PRs"
+        lines.extend([
+            f"## {index}. {wording['headline']}",
+            "",
+            wording["summary"],
+            "",
+            f"**Why it matters:** {wording['why_it_matters']}",
+            "",
+            f"**Evidence:** {wording['proof_note']} {evidence_label}: {_pr_links(wording['evidence_prs'])}.",
+            "",
+            "**Human role:** " + "; ".join(wording["contribution_map"]["human"]).capitalize() + ".",
+            "",
+            "**AI-tool role:** " + "; ".join(wording["contribution_map"]["ai_tool"]).capitalize() + ".",
+            "",
+            f"**Limits:** {wording['factuality_note']}",
+            "",
+        ])
+    lines.extend([
+        "---",
+        "",
+        "This publication is limited to this repository document. It does not authorize social posting, direct outreach, contracting, external execution, or publication on another surface.",
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def verify_release_authorization(value: dict[str, Any] | None = None) -> dict[str, Any]:
+    authorization = load(AUTHORIZATION_PATH) if value is None else copy.deepcopy(value)
+    authorization_fp = _verify_fingerprint(authorization, "authorization_fingerprint", "publication release authorization")
+    if authorization_fp != EXPECTED_AUTHORIZATION_FINGERPRINT:
+        raise ProofEngineError("publication release authorization fingerprint is not approved")
+    if authorization.get("schema_version") != AUTHORIZATION_SCHEMA or authorization.get("authorization_id") != AUTHORIZATION_ID:
+        raise ProofEngineError("publication release authorization identity mismatch")
+    if authorization.get("review_round_id") != ROUND_ID or authorization.get("decision") != "AUTHORIZE_RELEASE":
+        raise ProofEngineError("publication release decision mismatch")
+    if authorization.get("human_authorization") != EXPECTED_HUMAN_AUTHORIZATION:
+        raise ProofEngineError("publication release is not bound to explicit human authorization")
+    if authorization.get("source") != EXPECTED_SOURCE:
+        raise ProofEngineError("publication release source mismatch")
+    if authorization.get("release_surface") != EXPECTED_SURFACE:
+        raise ProofEngineError("publication release surface mismatch")
+    if authorization.get("authority") != EXPECTED_AUTHORITY:
+        raise ProofEngineError("publication release authority widened")
+    if authorization.get("restrictions") != EXPECTED_RESTRICTIONS:
+        raise ProofEngineError("publication release restrictions mismatch")
+    return authorization
+
+
+def verify_publication_release(
+    *,
+    authorization: dict[str, Any] | None = None,
+    checkpoint: dict[str, Any] | None = None,
+    document_text: str | None = None,
+) -> dict[str, Any]:
+    review = verify_publication_review()
+    if review["summary"].get("review_state") != "ALL_WORDINGS_APPROVED_FOR_RELEASE_GATE":
+        raise ProofEngineError("publication release review gate not satisfied")
+    if review["summary"].get("release_authorization_status") != "REQUIRED":
+        raise ProofEngineError("publication release source state mismatch")
+
+    auth = verify_release_authorization(authorization)
+    expected_document = render_release_markdown(effective_wording_records(review))
+    actual_document = DOCUMENT_PATH.read_text(encoding="utf-8") if document_text is None else document_text
+    if actual_document != expected_document:
+        raise ProofEngineError("published document does not match the approved effective wording set")
+    document_fp = fingerprint(actual_document)
+    if document_fp != EXPECTED_DOCUMENT_FINGERPRINT or document_fp != auth["release_surface"]["document_fingerprint"]:
+        raise ProofEngineError("published document fingerprint mismatch")
+
+    checkpoint_value = load(CHECKPOINT_PATH) if checkpoint is None else copy.deepcopy(checkpoint)
+    _verify_fingerprint(checkpoint_value, "checkpoint_fingerprint", "publication release checkpoint")
+    if checkpoint_value.get("schema_version") != CHECKPOINT_SCHEMA or checkpoint_value.get("checkpoint_id") != CHECKPOINT_ID:
+        raise ProofEngineError("publication release checkpoint identity mismatch")
+    expected_links = {
+        "release_authorization_fingerprint": auth["authorization_fingerprint"],
+        "source_review_round_id": ROUND_ID,
+        "document_path": PUBLIC_PATH,
+        "document_fingerprint": document_fp,
+        "published_wording_count": 6,
+        "repository_visibility": "PUBLIC",
+        "target_branch": "main",
+    }
+    for field, expected in expected_links.items():
+        if checkpoint_value.get(field) != expected:
+            raise ProofEngineError(f"publication release checkpoint mismatch: {field}")
+    if checkpoint_value.get("state") != "PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT":
+        raise ProofEngineError("publication release checkpoint state mismatch")
+    if checkpoint_value.get("publication_performed") is not True or checkpoint_value.get("external_actions_performed") is not True:
+        raise ProofEngineError("publication release checkpoint does not record publication")
+    if checkpoint_value.get("original_wording_drafts_preserved") is not True or checkpoint_value.get("release_scope_respected") is not True:
+        raise ProofEngineError("publication release preservation or scope mismatch")
+    for field in (
+        "social_posting_performed",
+        "direct_outreach_performed",
+        "contract_action_performed",
+        "adjacent_repository_write_performed",
+    ):
+        if checkpoint_value.get(field) is not False:
+            raise ProofEngineError(f"publication release exceeded scope: {field}")
+
+    return {
+        "authorization": auth,
+        "document": actual_document,
+        "document_fingerprint": document_fp,
+        "checkpoint": checkpoint_value,
+        "effective_wordings": review["summary"]["effective_wordings"],
+    }

--- a/proof_engine_pilot/release.py
+++ b/proof_engine_pilot/release.py
@@ -80,6 +80,10 @@ def _pr_links(numbers: list[int]) -> str:
     return ", ".join(links[:-1]) + ", and " + links[-1]
 
 
+def _upper_first(value: str) -> str:
+    return value[:1].upper() + value[1:]
+
+
 def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
     wordings = effective_wording_records() if records is None else records
     if len(wordings) != 6 or [item["wording_id"] for item in wordings] != [f"WORDING-{index:03d}" for index in range(1, 7)]:
@@ -102,9 +106,9 @@ def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
             "",
             f"**Evidence:** {wording['proof_note']} {evidence_label}: {_pr_links(wording['evidence_prs'])}.",
             "",
-            "**Human role:** " + "; ".join(wording["contribution_map"]["human"]).capitalize() + ".",
+            "**Human role:** " + _upper_first("; ".join(wording["contribution_map"]["human"])) + ".",
             "",
-            "**AI-tool role:** " + "; ".join(wording["contribution_map"]["ai_tool"]).capitalize() + ".",
+            "**AI-tool role:** " + _upper_first("; ".join(wording["contribution_map"]["ai_tool"])) + ".",
             "",
             f"**Limits:** {wording['factuality_note']}",
             "",

--- a/proof_engine_pilot/release.py
+++ b/proof_engine_pilot/release.py
@@ -66,6 +66,9 @@ AI_ROLE_COPYEDITS = {
     "WORDING-004": "Implemented the schema, preview logic, fixtures, and tests.",
     "WORDING-005": "Implemented the compiler and tests; raised independent review findings; implemented repairs and reran validation.",
 }
+LIMIT_COPYEDITS = {
+    "WORDING-005": "The compiler has been tested inside RTS. It does not prove universal risk-classification quality or replace human judgment for consequential decisions.",
+}
 
 
 def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
@@ -95,6 +98,10 @@ def _role_text(wording: dict[str, Any], role: str) -> str:
     return _upper_first("; ".join(wording["contribution_map"][role])) + "."
 
 
+def _limit_text(wording: dict[str, Any]) -> str:
+    return LIMIT_COPYEDITS.get(wording["wording_id"], wording["factuality_note"])
+
+
 def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
     wordings = effective_wording_records() if records is None else records
     if len(wordings) != 6 or [item["wording_id"] for item in wordings] != [f"WORDING-{index:03d}" for index in range(1, 7)]:
@@ -121,7 +128,7 @@ def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
             "",
             "**AI-tool role:** " + _role_text(wording, "ai_tool"),
             "",
-            f"**Limits:** {wording['factuality_note']}",
+            f"**Limits:** {_limit_text(wording)}",
             "",
         ])
     lines.extend([

--- a/proof_engine_pilot/release.py
+++ b/proof_engine_pilot/release.py
@@ -61,6 +61,11 @@ EXPECTED_RESTRICTIONS = {
     "content_must_match_authorized_fingerprint": True,
     "publication_on_any_other_surface_requires_new_human_authorization": True,
 }
+AI_ROLE_COPYEDITS = {
+    "WORDING-003": "Implemented the ledger, verification, and regression tests; applied review-driven repairs.",
+    "WORDING-004": "Implemented the schema, preview logic, fixtures, and tests.",
+    "WORDING-005": "Implemented the compiler and tests; raised independent review findings; implemented repairs and reran validation.",
+}
 
 
 def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
@@ -82,6 +87,12 @@ def _pr_links(numbers: list[int]) -> str:
 
 def _upper_first(value: str) -> str:
     return value[:1].upper() + value[1:]
+
+
+def _role_text(wording: dict[str, Any], role: str) -> str:
+    if role == "ai_tool" and wording["wording_id"] in AI_ROLE_COPYEDITS:
+        return AI_ROLE_COPYEDITS[wording["wording_id"]]
+    return _upper_first("; ".join(wording["contribution_map"][role])) + "."
 
 
 def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
@@ -106,9 +117,9 @@ def render_release_markdown(records: list[dict[str, Any]] | None = None) -> str:
             "",
             f"**Evidence:** {wording['proof_note']} {evidence_label}: {_pr_links(wording['evidence_prs'])}.",
             "",
-            "**Human role:** " + _upper_first("; ".join(wording["contribution_map"]["human"])) + ".",
+            "**Human role:** " + _role_text(wording, "human"),
             "",
-            "**AI-tool role:** " + _upper_first("; ".join(wording["contribution_map"]["ai_tool"])) + ".",
+            "**AI-tool role:** " + _role_text(wording, "ai_tool"),
             "",
             f"**Limits:** {wording['factuality_note']}",
             "",

--- a/proof_engine_pilot/release.py
+++ b/proof_engine_pilot/release.py
@@ -69,6 +69,42 @@ AI_ROLE_COPYEDITS = {
 LIMIT_COPYEDITS = {
     "WORDING-005": "The compiler has been tested inside RTS. It does not prove universal risk-classification quality or replace human judgment for consequential decisions.",
 }
+EXPECTED_CHECKPOINT_FIELDS = {
+    "adjacent_repository_write_performed",
+    "automatic_republication_performed",
+    "checkpoint_fingerprint",
+    "checkpoint_id",
+    "contract_action_performed",
+    "direct_outreach_performed",
+    "document_fingerprint",
+    "document_path",
+    "external_actions_performed",
+    "next_action",
+    "original_wording_drafts_preserved",
+    "provider_execution_performed",
+    "publication_performed",
+    "published_wording_count",
+    "release_authorization_fingerprint",
+    "release_scope_respected",
+    "repository_visibility",
+    "root_readme_promotion_performed",
+    "schema_version",
+    "social_posting_performed",
+    "source_review_round_id",
+    "state",
+    "target_branch",
+    "target_repository_write_performed",
+}
+EXPECTED_ACTION_RESULTS = {
+    "target_repository_write_performed": True,
+    "root_readme_promotion_performed": False,
+    "social_posting_performed": False,
+    "direct_outreach_performed": False,
+    "contract_action_performed": False,
+    "provider_execution_performed": False,
+    "adjacent_repository_write_performed": False,
+    "automatic_republication_performed": False,
+}
 
 
 def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
@@ -185,6 +221,8 @@ def verify_publication_release(
 
     checkpoint_value = load(CHECKPOINT_PATH) if checkpoint is None else copy.deepcopy(checkpoint)
     _verify_fingerprint(checkpoint_value, "checkpoint_fingerprint", "publication release checkpoint")
+    if set(checkpoint_value) != EXPECTED_CHECKPOINT_FIELDS:
+        raise ProofEngineError("publication release checkpoint schema mismatch")
     if checkpoint_value.get("schema_version") != CHECKPOINT_SCHEMA or checkpoint_value.get("checkpoint_id") != CHECKPOINT_ID:
         raise ProofEngineError("publication release checkpoint identity mismatch")
     expected_links = {
@@ -205,13 +243,8 @@ def verify_publication_release(
         raise ProofEngineError("publication release checkpoint does not record publication")
     if checkpoint_value.get("original_wording_drafts_preserved") is not True or checkpoint_value.get("release_scope_respected") is not True:
         raise ProofEngineError("publication release preservation or scope mismatch")
-    for field in (
-        "social_posting_performed",
-        "direct_outreach_performed",
-        "contract_action_performed",
-        "adjacent_repository_write_performed",
-    ):
-        if checkpoint_value.get(field) is not False:
+    for field, expected in EXPECTED_ACTION_RESULTS.items():
+        if checkpoint_value.get(field) is not expected:
             raise ProofEngineError(f"publication release exceeded scope: {field}")
 
     return {

--- a/proof_engine_pilot/release_cli.py
+++ b/proof_engine_pilot/release_cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import argparse
+import json
+
+from .core import ProofEngineError
+from .release import verify_publication_release
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Verify the bounded RTS repository publication release")
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("verify")
+    sub.add_parser("summary")
+    return parser
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        bundle = verify_publication_release()
+        if args.command == "verify":
+            print(f"Publication release verified ({bundle['checkpoint']['checkpoint_id']})")
+        else:
+            print(json.dumps({
+                "state": bundle["checkpoint"]["state"],
+                "document_path": bundle["checkpoint"]["document_path"],
+                "document_fingerprint": bundle["document_fingerprint"],
+                "published_wording_count": bundle["checkpoint"]["published_wording_count"],
+                "publication_performed": bundle["checkpoint"]["publication_performed"],
+                "repository_visibility": bundle["checkpoint"]["repository_visibility"],
+                "social_posting_performed": bundle["checkpoint"]["social_posting_performed"],
+                "direct_outreach_performed": bundle["checkpoint"]["direct_outreach_performed"],
+            }, ensure_ascii=False, sort_keys=True, indent=2))
+    except ProofEngineError as exc:
+        print(f"publication release failed closed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/proof_engine_pilot/releases/round_0001/release_authorization.json
+++ b/proof_engine_pilot/releases/round_0001/release_authorization.json
@@ -1,0 +1,48 @@
+{
+  "authorization_fingerprint": "51fc24ed079a834102da79be8a6ec8381ee6b1c971e05e3fc72815681a298f91",
+  "authorization_id": "PROOF-ENGINE-PUBLICATION-RELEASE-AUTHORIZATION-0001",
+  "authority": {
+    "adjacent_repository_write_authorized": false,
+    "automatic_republication_authorized": false,
+    "contract_authorized": false,
+    "direct_outreach_authorized": false,
+    "provider_execution_authorized": false,
+    "publication_authorized": true,
+    "social_posting_authorized": false,
+    "target_repository_write_authorized": true
+  },
+  "decision": "AUTHORIZE_RELEASE",
+  "human_authorization": {
+    "identity": "nobutakayamauchi",
+    "identity_source": "CURRENT_CHAT_EXPLICIT_RELEASE_AUTHORIZATION",
+    "instruction": "じゃとりあえずこれもやろっか。",
+    "role": "PROJECT_OWNER",
+    "type": "HUMAN"
+  },
+  "release_surface": {
+    "document_fingerprint": "682ec3d73373ea2228c4d270b5ca74bec8c59050781e7322dbfcfba1c9b50369",
+    "exact_path": "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md",
+    "publication_mode": "REPOSITORY_DOCUMENT_ONLY",
+    "release_timing": "IMMEDIATE_ON_MERGE",
+    "repository": "nobutakayamauchi/RTS",
+    "repository_visibility": "PUBLIC",
+    "root_readme_link_authorized": false,
+    "target_branch": "main"
+  },
+  "restrictions": {
+    "allowed_publication_paths": [
+      "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md"
+    ],
+    "content_must_match_authorized_fingerprint": true,
+    "publication_on_any_other_surface_requires_new_human_authorization": true,
+    "release_metadata_may_be_recorded_in_repository": true
+  },
+  "review_round_id": "PROOF-ENGINE-PUBLICATION-REVIEW-ROUND-0001",
+  "schema_version": "PROOF-ENGINE-PUBLICATION-RELEASE-AUTHORIZATION-V1",
+  "source": {
+    "effective_wording_count": 6,
+    "publication_review_contract_fingerprint": "e66845480c8b82a6c0d6d35e0039e20c464d1f6a41e880e5304ec4e59c46f383",
+    "revision_count": 3,
+    "source_draft_fingerprint": "91a21a9eb8119fc474d2f6a1c3429ae265c7c1997066f8148e2a612ef6167782"
+  }
+}

--- a/tests/test_proof_engine_release.py
+++ b/tests/test_proof_engine_release.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from proof_engine_pilot.core import ProofEngineError, fingerprint, load
+from proof_engine_pilot.release import (
+    AUTHORIZATION_PATH,
+    CHECKPOINT_PATH,
+    DOCUMENT_PATH,
+    EXPECTED_DOCUMENT_FINGERPRINT,
+    render_release_markdown,
+    verify_publication_release,
+)
+from proof_engine_pilot.release_cli import build_parser
+
+
+class PublicationReleaseTests(unittest.TestCase):
+    def test_committed_release_is_public_and_bounded(self):
+        bundle = verify_publication_release()
+        checkpoint = bundle["checkpoint"]
+        self.assertEqual(checkpoint["state"], "PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT")
+        self.assertTrue(checkpoint["publication_performed"])
+        self.assertTrue(checkpoint["external_actions_performed"])
+        self.assertEqual(checkpoint["published_wording_count"], 6)
+        self.assertEqual(checkpoint["document_fingerprint"], EXPECTED_DOCUMENT_FINGERPRINT)
+        self.assertFalse(checkpoint["social_posting_performed"])
+        self.assertFalse(checkpoint["direct_outreach_performed"])
+        self.assertFalse(checkpoint["contract_action_performed"])
+        self.assertFalse(checkpoint["adjacent_repository_write_performed"])
+
+    def test_document_is_deterministically_rendered_from_effective_wordings(self):
+        document = DOCUMENT_PATH.read_text(encoding="utf-8")
+        self.assertEqual(document, render_release_markdown())
+        self.assertEqual(fingerprint(document), EXPECTED_DOCUMENT_FINGERPRINT)
+        self.assertEqual(document.count("\n## "), 6)
+
+    def test_human_authorization_is_exact_and_surface_is_single_path(self):
+        authorization = load(AUTHORIZATION_PATH)
+        self.assertEqual(authorization["human_authorization"]["instruction"], "じゃとりあえずこれもやろっか。")
+        self.assertEqual(authorization["release_surface"]["exact_path"], "docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md")
+        self.assertEqual(authorization["restrictions"]["allowed_publication_paths"], ["docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md"])
+        self.assertFalse(authorization["release_surface"]["root_readme_link_authorized"])
+
+    def test_resigned_authority_widening_fails_closed(self):
+        authorization = copy.deepcopy(load(AUTHORIZATION_PATH))
+        authorization["authority"]["social_posting_authorized"] = True
+        material = copy.deepcopy(authorization)
+        material.pop("authorization_fingerprint")
+        authorization["authorization_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "fingerprint is not approved|authority widened"):
+            verify_publication_release(authorization=authorization)
+
+    def test_altered_public_document_fails_closed(self):
+        document = DOCUMENT_PATH.read_text(encoding="utf-8") + "\nUnapproved addition.\n"
+        with self.assertRaisesRegex(ProofEngineError, "does not match"):
+            verify_publication_release(document_text=document)
+
+    def test_resigned_checkpoint_scope_expansion_fails_closed(self):
+        checkpoint = copy.deepcopy(load(CHECKPOINT_PATH))
+        checkpoint["direct_outreach_performed"] = True
+        material = copy.deepcopy(checkpoint)
+        material.pop("checkpoint_fingerprint")
+        checkpoint["checkpoint_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "exceeded scope"):
+            verify_publication_release(checkpoint=checkpoint)
+
+    def test_cli_has_no_publish_or_outreach_command(self):
+        parser = build_parser()
+        action = next(action for action in parser._actions if getattr(action, "choices", None))
+        self.assertEqual(set(action.choices), {"verify", "summary"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_proof_engine_release.py
+++ b/tests/test_proof_engine_release.py
@@ -22,12 +22,16 @@ class PublicationReleaseTests(unittest.TestCase):
         self.assertEqual(checkpoint["state"], "PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT")
         self.assertTrue(checkpoint["publication_performed"])
         self.assertTrue(checkpoint["external_actions_performed"])
+        self.assertTrue(checkpoint["target_repository_write_performed"])
         self.assertEqual(checkpoint["published_wording_count"], 6)
         self.assertEqual(checkpoint["document_fingerprint"], EXPECTED_DOCUMENT_FINGERPRINT)
+        self.assertFalse(checkpoint["root_readme_promotion_performed"])
         self.assertFalse(checkpoint["social_posting_performed"])
         self.assertFalse(checkpoint["direct_outreach_performed"])
         self.assertFalse(checkpoint["contract_action_performed"])
+        self.assertFalse(checkpoint["provider_execution_performed"])
         self.assertFalse(checkpoint["adjacent_repository_write_performed"])
+        self.assertFalse(checkpoint["automatic_republication_performed"])
 
     def test_document_is_deterministically_rendered_from_effective_wordings(self):
         document = DOCUMENT_PATH.read_text(encoding="utf-8")
@@ -63,6 +67,24 @@ class PublicationReleaseTests(unittest.TestCase):
         material.pop("checkpoint_fingerprint")
         checkpoint["checkpoint_fingerprint"] = fingerprint(material)
         with self.assertRaisesRegex(ProofEngineError, "exceeded scope"):
+            verify_publication_release(checkpoint=checkpoint)
+
+    def test_resigned_provider_execution_fails_closed(self):
+        checkpoint = copy.deepcopy(load(CHECKPOINT_PATH))
+        checkpoint["provider_execution_performed"] = True
+        material = copy.deepcopy(checkpoint)
+        material.pop("checkpoint_fingerprint")
+        checkpoint["checkpoint_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "exceeded scope"):
+            verify_publication_release(checkpoint=checkpoint)
+
+    def test_unknown_checkpoint_action_fails_closed(self):
+        checkpoint = copy.deepcopy(load(CHECKPOINT_PATH))
+        checkpoint["unknown_external_action_performed"] = False
+        material = copy.deepcopy(checkpoint)
+        material.pop("checkpoint_fingerprint")
+        checkpoint["checkpoint_fingerprint"] = fingerprint(material)
+        with self.assertRaisesRegex(ProofEngineError, "schema mismatch"):
             verify_publication_release(checkpoint=checkpoint)
 
     def test_cli_has_no_publish_or_outreach_command(self):


### PR DESCRIPTION
## Release decision

Publish the six reviewed audience-facing wordings to exactly one public surface:

```text
docs/portfolio/RTS_EVIDENCE_BACKED_PROJECT_OUTPUTS.md
```

The current chat instruction is recorded as the human project owner's explicit release authorization.

## Scope

Authorized:

- one Markdown document in the public `nobutakayamauchi/RTS` repository;
- target branch `main`;
- six effective reviewed wordings;
- release metadata and verification records.

Not authorized or performed:

- root README promotion;
- social posting;
- direct outreach;
- contracts;
- provider execution;
- adjacent-repository writes;
- automatic republication.

## Verification

- document is deterministically rendered from the six effective publication-review records;
- exact document fingerprint is bound into the human authorization and release checkpoint;
- original candidates, revisions, internal assets, and wording drafts remain preserved;
- re-signed authority widening, altered document text, and scope-expanded checkpoints fail closed;
- full Proof Engine, Pilot, repository, and Unicode test suites run.

Terminal state:

```text
PUBLISHED_TO_AUTHORIZED_REPOSITORY_DOCUMENT
publication_performed: true
social_posting_performed: false
direct_outreach_performed: false
```