### PR TITLE
Define the internal evidence-report product specification

### DIFF
--- a/.github/workflows/evidence-report-productization-spec-tests.yml
+++ b/.github/workflows/evidence-report-productization-spec-tests.yml
@@ -1,0 +1,82 @@
+name: Evidence Report Productization Spec Tests
+
+on:
+  pull_request:
+    paths:
+      - "proof_engine_pilot/report_productization_spec.py"
+      - "proof_engine_pilot/report_productization_spec_cli.py"
+      - "proof_engine_pilot/productization_specs/round_0001/**"
+      - "pilot_runs/reconnect_pilot_p3/evidence_report_internal_product_spec_checkpoint_0016.json"
+      - "tests/test_proof_engine_report_productization_spec.py"
+      - ".github/workflows/evidence-report-productization-spec-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "proof_engine_pilot/report_productization_spec.py"
+      - "proof_engine_pilot/report_productization_spec_cli.py"
+      - "proof_engine_pilot/productization_specs/round_0001/**"
+      - "pilot_runs/reconnect_pilot_p3/evidence_report_internal_product_spec_checkpoint_0016.json"
+      - "tests/test_proof_engine_report_productization_spec.py"
+      - ".github/workflows/evidence-report-productization-spec-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Verify approved productization source
+        run: python -B -m proof_engine_pilot.report_productization_review_cli verify
+      - name: Verify internal product specification
+        run: |
+          python -B -m proof_engine_pilot.report_productization_spec_cli verify
+          python -B -m proof_engine_pilot.report_productization_spec_cli summary > /tmp/product-spec-summary.json
+          python -B -m proof_engine_pilot.report_productization_spec_cli spec > /tmp/product-spec.json
+          python -B -m proof_engine_pilot.report_productization_spec_cli acceptance > /tmp/acceptance-contract.json
+          python -B -m proof_engine_pilot.report_productization_spec_cli review-template > /tmp/pilot-review-template.json
+          python -B -m proof_engine_pilot.report_productization_spec_cli render-markdown --output /tmp/product-spec.md
+      - name: Verify state, counts, and authority boundary
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          summary = json.loads(Path('/tmp/product-spec-summary.json').read_text(encoding='utf-8'))
+          spec = json.loads(Path('/tmp/product-spec.json').read_text(encoding='utf-8'))
+          acceptance = json.loads(Path('/tmp/acceptance-contract.json').read_text(encoding='utf-8'))
+          review = json.loads(Path('/tmp/pilot-review-template.json').read_text(encoding='utf-8'))
+          markdown = Path('/tmp/product-spec.md').read_text(encoding='utf-8')
+          assert summary['state'] == 'HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED'
+          assert summary['counts'] == {
+              'required_sections': 9,
+              'workflow_steps': 8,
+              'acceptance_criteria': 15,
+              'commercial_unknowns': 7,
+              'effective_achievement_records_in_source_pack': 16,
+              'withheld_claims_in_source_pack': 5,
+          }
+          assert spec['target']['first_delivery_mode'] == 'OPERATOR_ASSISTED_SINGLE_CASE'
+          assert spec['target']['pricing_status'] == 'UNDECIDED'
+          assert len(acceptance['criteria']) == 15
+          assert acceptance['decision_contract']['decisions'] == []
+          assert review['decision'] is None
+          assert review['pilot_package_build_authorized'] is False
+          for field in (
+              'pricing_authorized',
+              'outreach_authorized',
+              'contract_authorized',
+              'delivery_authorized',
+              'publication_authorized',
+          ):
+              assert review[field] is False
+          assert 'Pilot package build authorized: false' in markdown
+          PY
+      - name: Run focused tests
+        run: |
+          python -B -m unittest discover -s tests -p 'test_proof_engine_report_productization_review.py' -v
+          python -B -m unittest discover -s tests -p 'test_proof_engine_report_productization_spec.py' -v

--- a/pilot_runs/reconnect_pilot_p3/evidence_report_internal_product_spec_checkpoint_0016.json
+++ b/pilot_runs/reconnect_pilot_p3/evidence_report_internal_product_spec_checkpoint_0016.json
@@ -1,0 +1,21 @@
+{
+  "acceptance_contract_complete": true,
+  "acceptance_contract_fingerprint": "54f4cd704e760e7bc8b7641e6724ad0f9b8d3ac129107fefdfb379bae3f4a831",
+  "checkpoint_fingerprint": "a17974e84356ea23a29a957954810710364548637b012bed051e954ba36a4ea2",
+  "checkpoint_id": "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-CHECKPOINT-0016",
+  "contract_action_performed": false,
+  "delivery_performed": false,
+  "external_actions_performed": false,
+  "next_action": "A human reviews the internal product specification and acceptance contract and decides whether to authorize one single-case internal pilot package build.",
+  "outreach_performed": false,
+  "pilot_package_build_authorized": false,
+  "pricing_performed": false,
+  "product_spec_fingerprint": "2c5132b29b68bfcf3bc9dd9b509cc3176f9ebf828aaa33a8bee3fadd9d817e71",
+  "publication_performed": false,
+  "schema_version": "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-CHECKPOINT-V1",
+  "source_productization_checkpoint_fingerprint": "5ec1888f85ca802c023a1fce9c68c69c089a6085b5770b011f25139e97d03dd0",
+  "specification_complete": true,
+  "state": "HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED",
+  "summary_fingerprint": "fbf53edb5244a1a126b85ba229e8ac93165510b1625c69cdf7a61856c12efb33",
+  "target_repository_writes_performed": false
+}

--- a/proof_engine_pilot/productization_specs/round_0001/README.md
+++ b/proof_engine_pilot/productization_specs/round_0001/README.md
@@ -1,0 +1,90 @@
+# Evidence Report Internal Product Specification — Round 0001
+
+The project owner instructed:
+
+> 動きを行う。
+
+This stage converts the approved Template v2 and three revised evidence reports into a bounded internal product specification and acceptance contract.
+
+## Product definition
+
+The first product remains the **Evidence-Backed Achievement Discovery Report**.
+
+The first delivery model is deliberately narrow:
+
+```text
+OPERATOR_ASSISTED_SINGLE_CASE
+```
+
+The intended first user is an AI-assisted solo developer or solo founder whose repository contains useful work but whose external value is difficult to explain.
+
+## Fixed product workflow
+
+1. confirm one exact source boundary;
+2. verify evidence eligibility;
+3. assemble achievement records;
+4. separate human, AI-tool, collaborator, and inherited contribution;
+5. retain unsupported claims as withheld;
+6. render all nine report sections;
+7. perform factuality and privacy review;
+8. stop at a separate human delivery/release decision.
+
+## Deliverable contract
+
+Each package must provide deterministic JSON and reader-facing Markdown with these sections:
+
+1. executive summary;
+2. repository scope;
+3. methodology;
+4. evidence inventory;
+5. effective achievement records;
+6. human and AI contribution map;
+7. withheld or unsupported claims;
+8. limitations;
+9. human review decision.
+
+## Acceptance contract
+
+Fifteen criteria cover:
+
+- exact source binding;
+- evidence eligibility;
+- report completeness;
+- claim factuality;
+- withheld-claim retention;
+- contribution separation;
+- privacy and metadata-only handling;
+- deterministic reconstruction;
+- human authority;
+- reader usability;
+- fail-closed behavior;
+- rollback;
+- product scope.
+
+Any failed criterion blocks acceptance. Human criteria require an explicit human record. Partial acceptance is not allowed.
+
+## Commercial unknowns retained
+
+The following remain unresolved rather than silently invented:
+
+- first paying buyer;
+- price and billing model;
+- sales channel;
+- service-level commitment;
+- customer data intake policy;
+- legal terms;
+- external delivery format.
+
+## Authority boundary
+
+```text
+INTERNAL_PRODUCTIZATION_SPECIFICATION_COMPLETE
+HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED
+NOT_PRICED
+NOT_DELIVERED
+NOT_PUBLISHED
+```
+
+This stage does not authorize or perform pilot-package building, pricing, outreach, contracting, delivery, publication, provider execution, automatic approval, automatic rewriting, or target-repository writes.
+
+The next bounded decision is whether to authorize one single-case internal pilot package build.

--- a/proof_engine_pilot/productization_specs/round_0001/acceptance_contract.json
+++ b/proof_engine_pilot/productization_specs/round_0001/acceptance_contract.json
@@ -1,0 +1,177 @@
+{
+  "acceptance_target": "SINGLE_CASE_INTERNAL_PILOT_PACKAGE",
+  "authority": {
+    "automatic_approval_authorized": false,
+    "automatic_rewrite_authorized": false,
+    "contract_authorized": false,
+    "delivery_authorized": false,
+    "external_execution_authorized": false,
+    "outreach_authorized": false,
+    "pilot_package_build_authorized": false,
+    "pricing_authorized": false,
+    "publication_authorized": false,
+    "target_repository_write_authorized": false
+  },
+  "completion_rule": {
+    "all_automated_criteria_must_pass": true,
+    "all_human_criteria_require_explicit_record": true,
+    "any_failure_blocks_acceptance": true,
+    "partial_acceptance_allowed": false
+  },
+  "contract_fingerprint": "54f4cd704e760e7bc8b7641e6724ad0f9b8d3ac129107fefdfb379bae3f4a831",
+  "contract_id": "PROOF-ENGINE-EVIDENCE-REPORT-ACCEPTANCE-CONTRACT-0001",
+  "criteria": [
+    {
+      "category": "SOURCE_BOUNDARY",
+      "check": "The package binds one exact repository snapshot and one allowed source mode.",
+      "criterion_id": "ACC-001",
+      "required_result": "PASS",
+      "verification": "AUTOMATED"
+    },
+    {
+      "category": "SOURCE_BOUNDARY",
+      "check": "Unmerged, unselected, drifted, or unsupported evidence is excluded from completed-achievement support.",
+      "criterion_id": "ACC-002",
+      "required_result": "PASS",
+      "verification": "AUTOMATED_AND_HUMAN"
+    },
+    {
+      "category": "REPORT_COMPLETENESS",
+      "check": "JSON and Markdown contain all nine required sections in the required order.",
+      "criterion_id": "ACC-003",
+      "required_result": "PASS",
+      "verification": "AUTOMATED"
+    },
+    {
+      "category": "REPORT_COMPLETENESS",
+      "check": "Every effective achievement record contains the required reader, evidence, contribution, and lineage fields.",
+      "criterion_id": "ACC-004",
+      "required_result": "PASS",
+      "verification": "AUTOMATED"
+    },
+    {
+      "category": "FACTUALITY",
+      "check": "Every positive claim is bounded by its cited evidence and factuality note.",
+      "criterion_id": "ACC-005",
+      "required_result": "PASS",
+      "verification": "HUMAN"
+    },
+    {
+      "category": "FACTUALITY",
+      "check": "Unsupported claims remain withheld with an explicit reason.",
+      "criterion_id": "ACC-006",
+      "required_result": "PASS",
+      "verification": "AUTOMATED_AND_HUMAN"
+    },
+    {
+      "category": "CONTRIBUTION",
+      "check": "Human, AI-tool, collaborator, and inherited contribution remain separated.",
+      "criterion_id": "ACC-007",
+      "required_result": "PASS",
+      "verification": "AUTOMATED_AND_HUMAN"
+    },
+    {
+      "category": "PRIVACY",
+      "check": "Private repositories use metadata-only mode and no private payload is copied.",
+      "criterion_id": "ACC-008",
+      "required_result": "PASS",
+      "verification": "AUTOMATED_AND_HUMAN"
+    },
+    {
+      "category": "PRIVACY",
+      "check": "Credentials and prohibited sensitive or third-party personal data are absent.",
+      "criterion_id": "ACC-009",
+      "required_result": "PASS",
+      "verification": "HUMAN"
+    },
+    {
+      "category": "DETERMINISM",
+      "check": "Identical accepted inputs reproduce identical pre-decision JSON and Markdown fingerprints.",
+      "criterion_id": "ACC-010",
+      "required_result": "PASS",
+      "verification": "AUTOMATED"
+    },
+    {
+      "category": "HUMAN_AUTHORITY",
+      "check": "No approval, pricing, outreach, contract, delivery, publication, or external execution decision is manufactured.",
+      "criterion_id": "ACC-011",
+      "required_result": "PASS",
+      "verification": "AUTOMATED"
+    },
+    {
+      "category": "USABILITY",
+      "check": "A reviewer can identify verified value, evidence strength, limitations, withheld claims, and the required decision without reading the full repository history.",
+      "criterion_id": "ACC-012",
+      "required_result": "PASS",
+      "verification": "HUMAN"
+    },
+    {
+      "category": "FAIL_CLOSED",
+      "check": "Unknown fields, source drift, authority widening, missing sections, and withheld-claim deletion fail closed.",
+      "criterion_id": "ACC-013",
+      "required_result": "PASS",
+      "verification": "AUTOMATED"
+    },
+    {
+      "category": "ROLLBACK",
+      "check": "The package can be frozen at the declared rollback anchor without mutating prior approved evidence or review records.",
+      "criterion_id": "ACC-014",
+      "required_result": "PASS",
+      "verification": "AUTOMATED_AND_HUMAN"
+    },
+    {
+      "category": "SCOPE",
+      "check": "The stage remains a single-case internal pilot-package decision and does not enter pricing, sales, contracting, delivery, publication, or customer intake.",
+      "criterion_id": "ACC-015",
+      "required_result": "PASS",
+      "verification": "AUTOMATED_AND_HUMAN"
+    }
+  ],
+  "decision_contract": {
+    "allowed_decisions": [
+      "APPROVE_PILOT_PACKAGE_BUILD",
+      "REVISE",
+      "REJECT",
+      "REDACT",
+      "EXPIRE",
+      "FREEZE"
+    ],
+    "decisions": [],
+    "human_decision_required": true,
+    "required_fields": [
+      "decision",
+      "reviewer_identity",
+      "reviewed_spec_fingerprint",
+      "reviewed_acceptance_contract_fingerprint",
+      "criteria_results",
+      "privacy_confirmed",
+      "authority_boundary_confirmed",
+      "pilot_package_build_authorized"
+    ]
+  },
+  "required_artifacts": [
+    "source-bound input manifest",
+    "deterministic report JSON",
+    "reader-facing report Markdown",
+    "evidence and withheld-claim inventory",
+    "human review packet",
+    "verification summary",
+    "rollback record"
+  ],
+  "schema_version": "PROOF-ENGINE-EVIDENCE-REPORT-ACCEPTANCE-CONTRACT-V1",
+  "source": {
+    "product_spec_fingerprint": "2c5132b29b68bfcf3bc9dd9b509cc3176f9ebf828aaa33a8bee3fadd9d817e71",
+    "productization_checkpoint_fingerprint": "5ec1888f85ca802c023a1fce9c68c69c089a6085b5770b011f25139e97d03dd0",
+    "reviewed_pack_fingerprint": "c95360f6ef1376914261eac574757ceb99f7f25c998b7be5752436200375f1bb",
+    "reviewed_template_fingerprint": "579d086788e636317cd61392fc3af97de468ff27c9ba478e962a973bd91ad4f6"
+  },
+  "terminal": {
+    "contract_status": "NOT_STARTED",
+    "delivery_status": "NOT_DELIVERED",
+    "next_action": "A human reviews the internal product specification and acceptance contract and decides whether to authorize one single-case internal pilot package build.",
+    "outreach_status": "NOT_STARTED",
+    "pricing_status": "NOT_PRICED",
+    "publication_status": "NOT_PUBLISHED",
+    "state": "HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED"
+  }
+}

--- a/proof_engine_pilot/productization_specs/round_0001/build_contract.json
+++ b/proof_engine_pilot/productization_specs/round_0001/build_contract.json
@@ -1,0 +1,61 @@
+{
+  "authority": {
+    "automatic_approval_authorized": false,
+    "automatic_rewrite_authorized": false,
+    "contract_authorized": false,
+    "delivery_authorized": false,
+    "external_execution_authorized": false,
+    "outreach_authorized": false,
+    "pricing_authorized": false,
+    "publication_authorized": false,
+    "target_repository_write_authorized": false
+  },
+  "contract_fingerprint": "deeb524430c9cc905c55e31fc0321da1bedd665dc0d55e0cf459913622122f26",
+  "contract_id": "PROOF-ENGINE-EVIDENCE-REPORT-PRODUCT-SPEC-BUILD-CONTRACT-0001",
+  "human_authorization": {
+    "identity": "nobutakayamauchi",
+    "identity_source": "CURRENT_CHAT_EXPLICIT_ACTION_INSTRUCTION",
+    "instruction": "動きを行う。",
+    "role": "PROJECT_OWNER",
+    "type": "HUMAN"
+  },
+  "principles": [
+    "single-case operator-assisted first delivery",
+    "exact source binding",
+    "nine-section report completeness",
+    "evidence-bounded claims",
+    "human and AI contribution separation",
+    "withheld-claim retention",
+    "metadata-only private-repository mode",
+    "human-gated consequential action",
+    "fail-closed deterministic verification"
+  ],
+  "required_outputs": [
+    "deterministic internal product specification",
+    "deterministic acceptance contract",
+    "reader-facing internal Markdown",
+    "human pilot-package build review template",
+    "verification summary and checkpoint"
+  ],
+  "schema_version": "PROOF-ENGINE-EVIDENCE-REPORT-PRODUCT-SPEC-BUILD-CONTRACT-V1",
+  "scope": "INTERNAL_PRODUCTIZATION_SPECIFICATION_AND_ACCEPTANCE_CONTRACT",
+  "source": {
+    "productization_checkpoint_fingerprint": "5ec1888f85ca802c023a1fce9c68c69c089a6085b5770b011f25139e97d03dd0",
+    "productization_decision_fingerprint": "010f5a2d39e712b181ed227fe62cdb61680db890898a43994543833e3c27efd9",
+    "reviewed_pack_fingerprint": "c95360f6ef1376914261eac574757ceb99f7f25c998b7be5752436200375f1bb",
+    "reviewed_report_fingerprints": {
+      "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-2": "a644d21ccf98cbdadf810c2e5294776d22376995a69c5abd76b29e4066e864dc",
+      "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-3": "48ef70f2a24842851fbfd2c19e30b360835a1a5248181090a91694dbd9ac395e",
+      "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-4": "d9b2b656fff3961ea249519776604d316a58b90d8f7f7dd29151ef969a63496c"
+    },
+    "reviewed_template_fingerprint": "579d086788e636317cd61392fc3af97de468ff27c9ba478e962a973bd91ad4f6"
+  },
+  "terminal": {
+    "contract_status": "NOT_STARTED",
+    "delivery_status": "NOT_DELIVERED",
+    "outreach_status": "NOT_STARTED",
+    "pricing_status": "NOT_PRICED",
+    "publication_status": "NOT_PUBLISHED",
+    "state": "HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED"
+  }
+}

--- a/proof_engine_pilot/productization_specs/round_0001/product_specification.json
+++ b/proof_engine_pilot/productization_specs/round_0001/product_specification.json
@@ -1,0 +1,209 @@
+{
+  "authority": {
+    "automatic_approval_authorized": false,
+    "automatic_rewrite_authorized": false,
+    "contract_authorized": false,
+    "delivery_authorized": false,
+    "external_execution_authorized": false,
+    "outreach_authorized": false,
+    "pricing_authorized": false,
+    "publication_authorized": false,
+    "target_repository_write_authorized": false
+  },
+  "commercial_unknowns": [
+    "first paying buyer",
+    "price and billing model",
+    "sales channel",
+    "service-level commitment",
+    "customer data intake policy",
+    "legal terms",
+    "external delivery format"
+  ],
+  "deliverable_contract": {
+    "delivery_status": "NOT_DELIVERED",
+    "draft_state": "HUMAN_DELIVERY_REVIEW_REQUIRED",
+    "format": [
+      "DETERMINISTIC_JSON",
+      "READER_FACING_MARKDOWN"
+    ],
+    "publication_status": "NOT_PUBLISHED",
+    "required_record_fields": [
+      "candidate_id",
+      "reader_summary",
+      "record_kind",
+      "value_interpretation",
+      "evidence_strength",
+      "evidence_prs",
+      "evidence_boundary",
+      "contribution_map",
+      "lineage"
+    ],
+    "required_sections": [
+      "executive_summary",
+      "repository_scope",
+      "methodology",
+      "evidence_inventory",
+      "effective_achievement_records",
+      "human_and_ai_contribution_map",
+      "withheld_or_unsupported_claims",
+      "limitations",
+      "human_review_decision"
+    ]
+  },
+  "failure_and_rollback": {
+    "fail_closed_conditions": [
+      "source fingerprint drift",
+      "unknown schema field",
+      "missing required section",
+      "duplicate candidate identity",
+      "unsupported authority widening",
+      "manufactured human approval",
+      "withheld claim deletion",
+      "private source mode widening",
+      "non-deterministic regeneration"
+    ],
+    "rollback_anchor": "83fe498c618b18b82f88d020879e6c5e55fa3bc0",
+    "rollback_effect": "Freeze this specification stage without changing the reviewed Template v2, productization decision, or prior evidence records."
+  },
+  "human_authorization": {
+    "identity": "nobutakayamauchi",
+    "identity_source": "CURRENT_CHAT_EXPLICIT_ACTION_INSTRUCTION",
+    "instruction": "動きを行う。",
+    "role": "PROJECT_OWNER",
+    "type": "HUMAN"
+  },
+  "identity": {
+    "product_family": "Proof Engine",
+    "product_type": "HUMAN_REVIEWED_INTERNAL_REPORT_SERVICE_SPECIFICATION",
+    "specification_status": "INTERNAL_ONLY",
+    "working_name": "Evidence-Backed Achievement Discovery Report"
+  },
+  "input_contract": {
+    "allowed_source_modes": [
+      "READ_ONLY_SNAPSHOT",
+      "READ_ONLY_METADATA_SNAPSHOT"
+    ],
+    "automatic_multi_repository_ingestion": false,
+    "private_payload_copying": false,
+    "required": [
+      "one explicitly selected repository snapshot",
+      "repository identity and visibility",
+      "fixed source reference",
+      "eligible merged evidence references",
+      "reviewed achievement records",
+      "withheld or unsupported claims",
+      "human and AI contribution records"
+    ]
+  },
+  "non_goals": [
+    "pricing or sales execution",
+    "automatic outreach",
+    "automatic publication",
+    "contract acceptance",
+    "customer-data ingestion",
+    "arbitrary-repository generalization",
+    "human ranking",
+    "outcome or revenue guarantee"
+  ],
+  "operator_model": {
+    "operator_may": [
+      "select an approved fixed source boundary",
+      "run deterministic generation and verification",
+      "prepare internal drafts",
+      "request human review"
+    ],
+    "operator_may_not": [
+      "manufacture a human decision",
+      "change evidence eligibility to improve the story",
+      "copy excluded private payload",
+      "price, contact, contract, deliver, or publish without a later explicit gate"
+    ],
+    "wip_limit": 1
+  },
+  "privacy_and_security": {
+    "credentials_prohibited": true,
+    "default_visibility": "SOURCE_BOUND",
+    "health_legal_financial_location_data_prohibited_without_separate_review": true,
+    "metadata_only_mode_required_for_private_repositories": true,
+    "third_party_personal_data_copying_prohibited": true
+  },
+  "quality_policy": {
+    "contribution": "Human, AI-tool, collaborator, and inherited contribution must remain separately represented.",
+    "determinism": "Accepted identical inputs reproduce identical pre-decision JSON and Markdown fingerprints.",
+    "evidence": "Missing, unmerged, drifted, private-payload, or unsupported material cannot support a completed-achievement claim.",
+    "factuality": "Every positive claim must remain within the exact selected evidence boundary.",
+    "usability": "A reader must understand verified value, evidence strength, limitations, and required human action without reading the full repository history.",
+    "withheld_claims": "Unsupported claims remain visible with reasons and cannot be silently dropped."
+  },
+  "schema_version": "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-V1",
+  "source": {
+    "build_contract_fingerprint": "deeb524430c9cc905c55e31fc0321da1bedd665dc0d55e0cf459913622122f26",
+    "effective_achievement_record_count": 16,
+    "productization_checkpoint_fingerprint": "5ec1888f85ca802c023a1fce9c68c69c089a6085b5770b011f25139e97d03dd0",
+    "productization_decision_fingerprint": "010f5a2d39e712b181ed227fe62cdb61680db890898a43994543833e3c27efd9",
+    "reviewed_pack_fingerprint": "c95360f6ef1376914261eac574757ceb99f7f25c998b7be5752436200375f1bb",
+    "reviewed_report_fingerprints": {
+      "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-2": "a644d21ccf98cbdadf810c2e5294776d22376995a69c5abd76b29e4066e864dc",
+      "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-3": "48ef70f2a24842851fbfd2c19e30b360835a1a5248181090a91694dbd9ac395e",
+      "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-4": "d9b2b656fff3961ea249519776604d316a58b90d8f7f7dd29151ef969a63496c"
+    },
+    "reviewed_template_fingerprint": "579d086788e636317cd61392fc3af97de468ff27c9ba478e962a973bd91ad4f6",
+    "withheld_claim_count": 5
+  },
+  "spec_fingerprint": "2c5132b29b68bfcf3bc9dd9b509cc3176f9ebf828aaa33a8bee3fadd9d817e71",
+  "spec_id": "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-0001",
+  "target": {
+    "buyer_and_channel_status": "UNDECIDED",
+    "first_delivery_mode": "OPERATOR_ASSISTED_SINGLE_CASE",
+    "pricing_status": "UNDECIDED",
+    "primary_job": "Turn one bounded repository evidence set into a reader-facing report that explains verified outputs, contribution boundaries, unsupported claims, and limitations.",
+    "primary_user": "AI-assisted solo developer or solo founder with repository evidence and weak external value translation."
+  },
+  "terminal": {
+    "next_action": "Review this specification and acceptance contract before authorizing a single-case internal pilot package build.",
+    "next_gate": "HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED",
+    "state": "INTERNAL_PRODUCTIZATION_SPECIFICATION_COMPLETE"
+  },
+  "workflow": [
+    {
+      "human_gate": true,
+      "name": "SOURCE_BOUNDARY_CONFIRMATION",
+      "step": 1
+    },
+    {
+      "human_gate": false,
+      "name": "EVIDENCE_ELIGIBILITY_VERIFICATION",
+      "step": 2
+    },
+    {
+      "human_gate": false,
+      "name": "ACHIEVEMENT_RECORD_ASSEMBLY",
+      "step": 3
+    },
+    {
+      "human_gate": false,
+      "name": "CONTRIBUTION_SEPARATION",
+      "step": 4
+    },
+    {
+      "human_gate": false,
+      "name": "WITHHELD_CLAIM_RETENTION",
+      "step": 5
+    },
+    {
+      "human_gate": false,
+      "name": "NINE_SECTION_REPORT_RENDERING",
+      "step": 6
+    },
+    {
+      "human_gate": true,
+      "name": "FACTUALITY_AND_PRIVACY_REVIEW",
+      "step": 7
+    },
+    {
+      "human_gate": true,
+      "name": "DELIVERY_RELEASE_DECISION",
+      "step": 8
+    }
+  ]
+}

--- a/proof_engine_pilot/report_productization_spec.py
+++ b/proof_engine_pilot/report_productization_spec.py
@@ -1,0 +1,567 @@
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+from typing import Any
+
+from .core import ProofEngineError, fingerprint, load
+from .report_productization_review import verify_productization_review
+from .report_template import REQUIRED_SECTIONS
+
+PACKAGE_DIR = Path(__file__).resolve().parent
+ROOT = PACKAGE_DIR.parent
+SPEC_DIR = PACKAGE_DIR / "productization_specs" / "round_0001"
+BUILD_CONTRACT_PATH = SPEC_DIR / "build_contract.json"
+PRODUCT_SPEC_PATH = SPEC_DIR / "product_specification.json"
+ACCEPTANCE_CONTRACT_PATH = SPEC_DIR / "acceptance_contract.json"
+CHECKPOINT_PATH = (
+    ROOT
+    / "pilot_runs"
+    / "reconnect_pilot_p3"
+    / "evidence_report_internal_product_spec_checkpoint_0016.json"
+)
+
+SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT = (
+    "5ec1888f85ca802c023a1fce9c68c69c089a6085b5770b011f25139e97d03dd0"
+)
+SOURCE_PRODUCTIZATION_DECISION_FINGERPRINT = (
+    "010f5a2d39e712b181ed227fe62cdb61680db890898a43994543833e3c27efd9"
+)
+REVIEWED_TEMPLATE_FINGERPRINT = (
+    "579d086788e636317cd61392fc3af97de468ff27c9ba478e962a973bd91ad4f6"
+)
+REVIEWED_PACK_FINGERPRINT = (
+    "c95360f6ef1376914261eac574757ceb99f7f25c998b7be5752436200375f1bb"
+)
+REVIEWED_REPORT_FINGERPRINTS = {
+    "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-2":
+        "a644d21ccf98cbdadf810c2e5294776d22376995a69c5abd76b29e4066e864dc",
+    "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-3":
+        "48ef70f2a24842851fbfd2c19e30b360835a1a5248181090a91694dbd9ac395e",
+    "PROOF-ENGINE-EVIDENCE-REPORT-DEMO-ROUND-4":
+        "d9b2b656fff3961ea249519776604d316a58b90d8f7f7dd29151ef969a63496c",
+}
+BUILD_CONTRACT_FINGERPRINT = (
+    "deeb524430c9cc905c55e31fc0321da1bedd665dc0d55e0cf459913622122f26"
+)
+PRODUCT_SPEC_FINGERPRINT = (
+    "2c5132b29b68bfcf3bc9dd9b509cc3176f9ebf828aaa33a8bee3fadd9d817e71"
+)
+ACCEPTANCE_CONTRACT_FINGERPRINT = (
+    "54f4cd704e760e7bc8b7641e6724ad0f9b8d3ac129107fefdfb379bae3f4a831"
+)
+SUMMARY_FINGERPRINT = (
+    "fbf53edb5244a1a126b85ba229e8ac93165510b1625c69cdf7a61856c12efb33"
+)
+EXPECTED_STATE = "HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED"
+EXPECTED_HUMAN_AUTHORIZATION = {
+    "type": "HUMAN",
+    "identity": "nobutakayamauchi",
+    "identity_source": "CURRENT_CHAT_EXPLICIT_ACTION_INSTRUCTION",
+    "role": "PROJECT_OWNER",
+    "instruction": "動きを行う。",
+}
+FALSE_AUTHORITY = {
+    "automatic_approval_authorized": False,
+    "automatic_rewrite_authorized": False,
+    "contract_authorized": False,
+    "delivery_authorized": False,
+    "external_execution_authorized": False,
+    "outreach_authorized": False,
+    "pricing_authorized": False,
+    "publication_authorized": False,
+    "target_repository_write_authorized": False,
+}
+REQUIRED_RECORD_FIELDS = [
+    "candidate_id",
+    "reader_summary",
+    "record_kind",
+    "value_interpretation",
+    "evidence_strength",
+    "evidence_prs",
+    "evidence_boundary",
+    "contribution_map",
+    "lineage",
+]
+EXPECTED_CRITERION_IDS = [f"ACC-{number:03d}" for number in range(1, 16)]
+CHECKPOINT_FIELDS = {
+    "schema_version",
+    "checkpoint_id",
+    "source_productization_checkpoint_fingerprint",
+    "product_spec_fingerprint",
+    "acceptance_contract_fingerprint",
+    "summary_fingerprint",
+    "state",
+    "specification_complete",
+    "acceptance_contract_complete",
+    "pilot_package_build_authorized",
+    "pricing_performed",
+    "outreach_performed",
+    "contract_action_performed",
+    "delivery_performed",
+    "publication_performed",
+    "external_actions_performed",
+    "target_repository_writes_performed",
+    "next_action",
+    "checkpoint_fingerprint",
+}
+
+
+def _verify_fingerprint(value: dict[str, Any], field: str, label: str) -> str:
+    material = copy.deepcopy(value)
+    actual = material.pop(field, None)
+    if actual != fingerprint(material):
+        raise ProofEngineError(f"{label} fingerprint mismatch")
+    return actual
+
+
+def _verify_false_authority(
+    value: Any,
+    *,
+    label: str,
+    include_pilot_build: bool = False,
+) -> dict[str, bool]:
+    expected = copy.deepcopy(FALSE_AUTHORITY)
+    if include_pilot_build:
+        expected["pilot_package_build_authorized"] = False
+    if value != expected:
+        raise ProofEngineError(f"{label} authority widened or fields drifted")
+    return value
+
+
+def verify_product_spec_build_contract(
+    contract: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    value = load(BUILD_CONTRACT_PATH) if contract is None else copy.deepcopy(contract)
+    _verify_fingerprint(value, "contract_fingerprint", "product spec build contract")
+    if value.get("contract_fingerprint") != BUILD_CONTRACT_FINGERPRINT:
+        raise ProofEngineError("product spec build contract deterministic fingerprint mismatch")
+    if value.get("schema_version") != (
+        "PROOF-ENGINE-EVIDENCE-REPORT-PRODUCT-SPEC-BUILD-CONTRACT-V1"
+    ):
+        raise ProofEngineError("product spec build contract schema mismatch")
+    if value.get("contract_id") != (
+        "PROOF-ENGINE-EVIDENCE-REPORT-PRODUCT-SPEC-BUILD-CONTRACT-0001"
+    ):
+        raise ProofEngineError("product spec build contract identity mismatch")
+    if value.get("human_authorization") != EXPECTED_HUMAN_AUTHORIZATION:
+        raise ProofEngineError("product spec build is not bound to the action instruction")
+    if value.get("source") != {
+        "productization_checkpoint_fingerprint":
+            SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT,
+        "productization_decision_fingerprint":
+            SOURCE_PRODUCTIZATION_DECISION_FINGERPRINT,
+        "reviewed_template_fingerprint": REVIEWED_TEMPLATE_FINGERPRINT,
+        "reviewed_pack_fingerprint": REVIEWED_PACK_FINGERPRINT,
+        "reviewed_report_fingerprints": REVIEWED_REPORT_FINGERPRINTS,
+    }:
+        raise ProofEngineError("product spec build source mismatch")
+    if value.get("scope") != (
+        "INTERNAL_PRODUCTIZATION_SPECIFICATION_AND_ACCEPTANCE_CONTRACT"
+    ):
+        raise ProofEngineError("product spec build scope widened")
+    _verify_false_authority(value.get("authority"), label="product spec build contract")
+    if value.get("terminal") != {
+        "state": EXPECTED_STATE,
+        "pricing_status": "NOT_PRICED",
+        "outreach_status": "NOT_STARTED",
+        "contract_status": "NOT_STARTED",
+        "delivery_status": "NOT_DELIVERED",
+        "publication_status": "NOT_PUBLISHED",
+    }:
+        raise ProofEngineError("product spec build terminal boundary mismatch")
+    return value
+
+
+def verify_product_specification(
+    specification: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    value = (
+        load(PRODUCT_SPEC_PATH)
+        if specification is None
+        else copy.deepcopy(specification)
+    )
+    _verify_fingerprint(value, "spec_fingerprint", "internal product specification")
+    if value.get("spec_fingerprint") != PRODUCT_SPEC_FINGERPRINT:
+        raise ProofEngineError("internal product specification deterministic mismatch")
+    if value.get("schema_version") != (
+        "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-V1"
+    ):
+        raise ProofEngineError("internal product specification schema mismatch")
+    source = value.get("source", {})
+    if source != {
+        "productization_checkpoint_fingerprint":
+            SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT,
+        "productization_decision_fingerprint":
+            SOURCE_PRODUCTIZATION_DECISION_FINGERPRINT,
+        "reviewed_template_fingerprint": REVIEWED_TEMPLATE_FINGERPRINT,
+        "reviewed_pack_fingerprint": REVIEWED_PACK_FINGERPRINT,
+        "reviewed_report_fingerprints": REVIEWED_REPORT_FINGERPRINTS,
+        "effective_achievement_record_count": 16,
+        "withheld_claim_count": 5,
+        "build_contract_fingerprint": BUILD_CONTRACT_FINGERPRINT,
+    }:
+        raise ProofEngineError("internal product specification source mismatch")
+    if value.get("human_authorization") != EXPECTED_HUMAN_AUTHORIZATION:
+        raise ProofEngineError("internal product specification authorization mismatch")
+    deliverable = value.get("deliverable_contract", {})
+    if deliverable.get("required_sections") != REQUIRED_SECTIONS:
+        raise ProofEngineError("internal product required sections mismatch")
+    if deliverable.get("required_record_fields") != REQUIRED_RECORD_FIELDS:
+        raise ProofEngineError("internal product record contract mismatch")
+    workflow = value.get("workflow")
+    if (
+        not isinstance(workflow, list)
+        or [item.get("step") for item in workflow] != list(range(1, 9))
+        or [item.get("name") for item in workflow] != [
+            "SOURCE_BOUNDARY_CONFIRMATION",
+            "EVIDENCE_ELIGIBILITY_VERIFICATION",
+            "ACHIEVEMENT_RECORD_ASSEMBLY",
+            "CONTRIBUTION_SEPARATION",
+            "WITHHELD_CLAIM_RETENTION",
+            "NINE_SECTION_REPORT_RENDERING",
+            "FACTUALITY_AND_PRIVACY_REVIEW",
+            "DELIVERY_RELEASE_DECISION",
+        ]
+    ):
+        raise ProofEngineError("internal product workflow mismatch")
+    if value.get("target", {}).get("first_delivery_mode") != (
+        "OPERATOR_ASSISTED_SINGLE_CASE"
+    ):
+        raise ProofEngineError("internal product first delivery mode mismatch")
+    if value.get("target", {}).get("pricing_status") != "UNDECIDED":
+        raise ProofEngineError("internal product pricing decision manufactured")
+    _verify_false_authority(value.get("authority"), label="internal product specification")
+    if value.get("terminal") != {
+        "state": "INTERNAL_PRODUCTIZATION_SPECIFICATION_COMPLETE",
+        "next_gate": EXPECTED_STATE,
+        "next_action": "Review this specification and acceptance contract before authorizing a single-case internal pilot package build.",
+    }:
+        raise ProofEngineError("internal product specification terminal mismatch")
+    return value
+
+
+def verify_acceptance_contract(
+    contract: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    value = (
+        load(ACCEPTANCE_CONTRACT_PATH)
+        if contract is None
+        else copy.deepcopy(contract)
+    )
+    _verify_fingerprint(value, "contract_fingerprint", "acceptance contract")
+    if value.get("contract_fingerprint") != ACCEPTANCE_CONTRACT_FINGERPRINT:
+        raise ProofEngineError("acceptance contract deterministic mismatch")
+    if value.get("schema_version") != (
+        "PROOF-ENGINE-EVIDENCE-REPORT-ACCEPTANCE-CONTRACT-V1"
+    ):
+        raise ProofEngineError("acceptance contract schema mismatch")
+    if value.get("source") != {
+        "product_spec_fingerprint": PRODUCT_SPEC_FINGERPRINT,
+        "productization_checkpoint_fingerprint":
+            SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT,
+        "reviewed_template_fingerprint": REVIEWED_TEMPLATE_FINGERPRINT,
+        "reviewed_pack_fingerprint": REVIEWED_PACK_FINGERPRINT,
+    }:
+        raise ProofEngineError("acceptance contract source mismatch")
+    criteria = value.get("criteria")
+    if (
+        not isinstance(criteria, list)
+        or [item.get("criterion_id") for item in criteria]
+        != EXPECTED_CRITERION_IDS
+        or any(item.get("required_result") != "PASS" for item in criteria)
+    ):
+        raise ProofEngineError("acceptance criteria mismatch")
+    decision = value.get("decision_contract", {})
+    if decision.get("human_decision_required") is not True:
+        raise ProofEngineError("acceptance contract weakened human decision gate")
+    if decision.get("decisions"):
+        raise ProofEngineError("acceptance contract manufactured a decision")
+    if decision.get("allowed_decisions") != [
+        "APPROVE_PILOT_PACKAGE_BUILD",
+        "REVISE",
+        "REJECT",
+        "REDACT",
+        "EXPIRE",
+        "FREEZE",
+    ]:
+        raise ProofEngineError("acceptance contract decisions mismatch")
+    _verify_false_authority(
+        value.get("authority"),
+        label="acceptance contract",
+        include_pilot_build=True,
+    )
+    terminal = value.get("terminal", {})
+    if terminal != {
+        "state": EXPECTED_STATE,
+        "pricing_status": "NOT_PRICED",
+        "outreach_status": "NOT_STARTED",
+        "contract_status": "NOT_STARTED",
+        "delivery_status": "NOT_DELIVERED",
+        "publication_status": "NOT_PUBLISHED",
+        "next_action": "A human reviews the internal product specification and acceptance contract and decides whether to authorize one single-case internal pilot package build.",
+    }:
+        raise ProofEngineError("acceptance contract terminal boundary mismatch")
+    return value
+
+
+def build_internal_productization_spec(
+    *,
+    build_contract: dict[str, Any] | None = None,
+    specification: dict[str, Any] | None = None,
+    acceptance_contract: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    source = verify_productization_review()
+    if source["checkpoint"]["checkpoint_fingerprint"] != (
+        SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT
+    ):
+        raise ProofEngineError("internal product spec source checkpoint drift")
+    if source["decision"]["decision_fingerprint"] != (
+        SOURCE_PRODUCTIZATION_DECISION_FINGERPRINT
+    ):
+        raise ProofEngineError("internal product spec source decision drift")
+    verified_build = verify_product_spec_build_contract(build_contract)
+    verified_spec = verify_product_specification(specification)
+    verified_acceptance = verify_acceptance_contract(acceptance_contract)
+    summary = {
+        "schema_version":
+            "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-SUMMARY-V1",
+        "summary_id":
+            "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-SUMMARY-0001",
+        "source_productization_checkpoint_fingerprint":
+            SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT,
+        "product_spec_fingerprint": verified_spec["spec_fingerprint"],
+        "acceptance_contract_fingerprint":
+            verified_acceptance["contract_fingerprint"],
+        "product_name": verified_spec["identity"]["working_name"],
+        "delivery_mode": verified_spec["target"]["first_delivery_mode"],
+        "counts": {
+            "required_sections":
+                len(verified_spec["deliverable_contract"]["required_sections"]),
+            "workflow_steps": len(verified_spec["workflow"]),
+            "acceptance_criteria": len(verified_acceptance["criteria"]),
+            "commercial_unknowns": len(verified_spec["commercial_unknowns"]),
+            "effective_achievement_records_in_source_pack": 16,
+            "withheld_claims_in_source_pack": 5,
+        },
+        "state": EXPECTED_STATE,
+        "specification_status": "INTERNAL_PRODUCTIZATION_SPECIFICATION_COMPLETE",
+        "pricing_status": "NOT_PRICED",
+        "outreach_status": "NOT_STARTED",
+        "contract_status": "NOT_STARTED",
+        "delivery_status": "NOT_DELIVERED",
+        "publication_status": "NOT_PUBLISHED",
+        "pilot_package_build_authorized": False,
+        "external_actions_performed": False,
+        "next_action": verified_acceptance["terminal"]["next_action"],
+    }
+    summary["summary_fingerprint"] = fingerprint(summary)
+    return {
+        "source": source,
+        "build_contract": verified_build,
+        "spec": verified_spec,
+        "acceptance": verified_acceptance,
+        "summary": summary,
+    }
+
+
+def build_pilot_package_review_template(
+    bundle: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    value = build_internal_productization_spec() if bundle is None else bundle
+    return {
+        "schema_version":
+            "PROOF-ENGINE-EVIDENCE-REPORT-PILOT-PACKAGE-REVIEW-TEMPLATE-V1",
+        "state": EXPECTED_STATE,
+        "reviewed_spec_fingerprint": value["spec"]["spec_fingerprint"],
+        "reviewed_acceptance_contract_fingerprint":
+            value["acceptance"]["contract_fingerprint"],
+        "criteria_results": [
+            {
+                "criterion_id": item["criterion_id"],
+                "result": None,
+                "evidence": [],
+                "note": "",
+            }
+            for item in value["acceptance"]["criteria"]
+        ],
+        "allowed_decisions":
+            copy.deepcopy(value["acceptance"]["decision_contract"]["allowed_decisions"]),
+        "decision": None,
+        "reviewer_identity": None,
+        "privacy_confirmed": False,
+        "authority_boundary_confirmed": False,
+        "pilot_package_build_authorized": False,
+        "pricing_authorized": False,
+        "outreach_authorized": False,
+        "contract_authorized": False,
+        "delivery_authorized": False,
+        "publication_authorized": False,
+    }
+
+
+def render_internal_productization_markdown(
+    bundle: dict[str, Any] | None = None,
+) -> str:
+    value = build_internal_productization_spec() if bundle is None else bundle
+    spec = value["spec"]
+    acceptance = value["acceptance"]
+    lines = [
+        "# Evidence-Backed Achievement Discovery Report — Internal Product Specification",
+        "",
+        "Status: INTERNAL_PRODUCTIZATION_SPECIFICATION_COMPLETE / HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED",
+        "",
+        "## Product",
+        "",
+        f"- Name: {spec['identity']['working_name']}",
+        f"- Product family: {spec['identity']['product_family']}",
+        f"- First delivery mode: {spec['target']['first_delivery_mode']}",
+        f"- Primary user: {spec['target']['primary_user']}",
+        f"- Primary job: {spec['target']['primary_job']}",
+        "",
+        "## Fixed input boundary",
+        "",
+    ]
+    lines.extend(f"- {item}" for item in spec["input_contract"]["required"])
+    lines.extend(["", "## Workflow", ""])
+    lines.extend(
+        f"{item['step']}. {item['name']} — human gate: "
+        f"{str(item['human_gate']).lower()}"
+        for item in spec["workflow"]
+    )
+    lines.extend(["", "## Deliverable", ""])
+    lines.extend(
+        f"- Section: {item}"
+        for item in spec["deliverable_contract"]["required_sections"]
+    )
+    lines.extend(["", "## Acceptance contract", ""])
+    lines.extend(
+        f"- {item['criterion_id']} / {item['category']}: {item['check']} "
+        f"({item['verification']})"
+        for item in acceptance["criteria"]
+    )
+    lines.extend(["", "## Commercial unknowns", ""])
+    lines.extend(f"- {item}" for item in spec["commercial_unknowns"])
+    lines.extend([
+        "",
+        "## Authority boundary",
+        "",
+        "- Pilot package build authorized: false",
+        "- Pricing authorized: false",
+        "- Outreach authorized: false",
+        "- Contract authorized: false",
+        "- Delivery authorized: false",
+        "- Publication authorized: false",
+        "- External execution authorized: false",
+        "- Automatic approval authorized: false",
+        "- Automatic rewriting authorized: false",
+        "",
+        "## Next human gate",
+        "",
+        acceptance["terminal"]["next_action"],
+        "",
+    ])
+    return "\n".join(lines)
+
+
+def verify_internal_productization_spec(
+    *,
+    build_contract: dict[str, Any] | None = None,
+    specification: dict[str, Any] | None = None,
+    acceptance_contract: dict[str, Any] | None = None,
+    checkpoint: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    bundle = build_internal_productization_spec(
+        build_contract=build_contract,
+        specification=specification,
+        acceptance_contract=acceptance_contract,
+    )
+    summary = bundle["summary"]
+    _verify_fingerprint(
+        summary,
+        "summary_fingerprint",
+        "internal product specification summary",
+    )
+    if summary["summary_fingerprint"] != SUMMARY_FINGERPRINT:
+        raise ProofEngineError("internal product summary deterministic mismatch")
+    if summary["counts"] != {
+        "required_sections": 9,
+        "workflow_steps": 8,
+        "acceptance_criteria": 15,
+        "commercial_unknowns": 7,
+        "effective_achievement_records_in_source_pack": 16,
+        "withheld_claims_in_source_pack": 5,
+    }:
+        raise ProofEngineError("internal product specification counts mismatch")
+    if (
+        summary["state"],
+        summary["pricing_status"],
+        summary["outreach_status"],
+        summary["contract_status"],
+        summary["delivery_status"],
+        summary["publication_status"],
+        summary["pilot_package_build_authorized"],
+        summary["external_actions_performed"],
+    ) != (
+        EXPECTED_STATE,
+        "NOT_PRICED",
+        "NOT_STARTED",
+        "NOT_STARTED",
+        "NOT_DELIVERED",
+        "NOT_PUBLISHED",
+        False,
+        False,
+    ):
+        raise ProofEngineError("internal product specification boundary widened")
+
+    cp = load(CHECKPOINT_PATH) if checkpoint is None else copy.deepcopy(checkpoint)
+    if set(cp) != CHECKPOINT_FIELDS:
+        raise ProofEngineError("internal product spec checkpoint fields mismatch")
+    _verify_fingerprint(
+        cp,
+        "checkpoint_fingerprint",
+        "internal product specification checkpoint",
+    )
+    expected = {
+        "schema_version":
+            "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-CHECKPOINT-V1",
+        "checkpoint_id":
+            "PROOF-ENGINE-EVIDENCE-REPORT-INTERNAL-PRODUCT-SPEC-CHECKPOINT-0016",
+        "source_productization_checkpoint_fingerprint":
+            SOURCE_PRODUCTIZATION_CHECKPOINT_FINGERPRINT,
+        "product_spec_fingerprint": PRODUCT_SPEC_FINGERPRINT,
+        "acceptance_contract_fingerprint": ACCEPTANCE_CONTRACT_FINGERPRINT,
+        "summary_fingerprint": SUMMARY_FINGERPRINT,
+        "state": EXPECTED_STATE,
+        "specification_complete": True,
+        "acceptance_contract_complete": True,
+        "pilot_package_build_authorized": False,
+        "next_action": summary["next_action"],
+    }
+    for field, expected_value in expected.items():
+        if cp[field] != expected_value:
+            raise ProofEngineError(f"internal product spec checkpoint mismatch: {field}")
+    for field in (
+        "pricing_performed",
+        "outreach_performed",
+        "contract_action_performed",
+        "delivery_performed",
+        "publication_performed",
+        "external_actions_performed",
+        "target_repository_writes_performed",
+    ):
+        if cp[field] is not False:
+            raise ProofEngineError(
+                f"internal product spec checkpoint exceeded boundary: {field}"
+            )
+    review_template = build_pilot_package_review_template(bundle)
+    if review_template["decision"] is not None:
+        raise ProofEngineError("pilot package review template manufactured a decision")
+    markdown = render_internal_productization_markdown(bundle)
+    return {
+        **bundle,
+        "checkpoint": cp,
+        "review_template": review_template,
+        "markdown": markdown,
+        "markdown_fingerprint": fingerprint(markdown),
+    }

--- a/proof_engine_pilot/report_productization_spec_cli.py
+++ b/proof_engine_pilot/report_productization_spec_cli.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from .core import ProofEngineError
+from .report_productization_spec import verify_internal_productization_spec
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Verify the internal evidence-report product specification"
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+    sub.add_parser("verify")
+    sub.add_parser("summary")
+    sub.add_parser("spec")
+    sub.add_parser("acceptance")
+    sub.add_parser("review-template")
+    render = sub.add_parser("render-markdown")
+    render.add_argument("--output")
+    return parser
+
+
+def _write_or_print(value: str, output: str | None) -> None:
+    if output:
+        Path(output).write_text(value, encoding="utf-8")
+    else:
+        print(value)
+
+
+def main(argv=None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        bundle = verify_internal_productization_spec()
+        if args.command == "verify":
+            print("Evidence report internal product specification passed")
+        elif args.command == "summary":
+            print(json.dumps(bundle["summary"], ensure_ascii=False, sort_keys=True, indent=2))
+        elif args.command == "spec":
+            print(json.dumps(bundle["spec"], ensure_ascii=False, sort_keys=True, indent=2))
+        elif args.command == "acceptance":
+            print(json.dumps(bundle["acceptance"], ensure_ascii=False, sort_keys=True, indent=2))
+        elif args.command == "review-template":
+            print(json.dumps(bundle["review_template"], ensure_ascii=False, sort_keys=True, indent=2))
+        else:
+            _write_or_print(bundle["markdown"] + "\n", args.output)
+    except ProofEngineError as exc:
+        print(f"evidence report internal product specification failed closed: {exc}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_proof_engine_report_productization_spec.py
+++ b/tests/test_proof_engine_report_productization_spec.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import copy
+import unittest
+
+from proof_engine_pilot.core import ProofEngineError, fingerprint
+from proof_engine_pilot.report_productization_spec import (
+    build_internal_productization_spec,
+    build_pilot_package_review_template,
+    verify_acceptance_contract,
+    verify_internal_productization_spec,
+    verify_product_spec_build_contract,
+    verify_product_specification,
+)
+from proof_engine_pilot.report_productization_spec_cli import build_parser
+
+
+def resign(value: dict, field: str) -> dict:
+    result = copy.deepcopy(value)
+    result[field] = fingerprint({key: item for key, item in result.items() if key != field})
+    return result
+
+
+class InternalProductSpecificationTests(unittest.TestCase):
+    def test_specification_verifies_and_stops_at_human_gate(self):
+        bundle = verify_internal_productization_spec()
+        self.assertEqual(
+            bundle["summary"]["state"],
+            "HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED",
+        )
+        self.assertEqual(bundle["summary"]["counts"], {
+            "required_sections": 9,
+            "workflow_steps": 8,
+            "acceptance_criteria": 15,
+            "commercial_unknowns": 7,
+            "effective_achievement_records_in_source_pack": 16,
+            "withheld_claims_in_source_pack": 5,
+        })
+        self.assertEqual(
+            bundle["spec"]["target"]["first_delivery_mode"],
+            "OPERATOR_ASSISTED_SINGLE_CASE",
+        )
+        self.assertEqual(bundle["spec"]["target"]["pricing_status"], "UNDECIDED")
+        self.assertFalse(bundle["summary"]["pilot_package_build_authorized"])
+        self.assertFalse(bundle["summary"]["external_actions_performed"])
+        self.assertIn("Pilot package build authorized: false", bundle["markdown"])
+
+    def test_build_contract_fails_closed_on_authority_widening_when_resigned(self):
+        contract = copy.deepcopy(build_internal_productization_spec()["build_contract"])
+        contract["authority"]["pricing_authorized"] = True
+        with self.assertRaises(ProofEngineError):
+            verify_product_spec_build_contract(resign(contract, "contract_fingerprint"))
+
+    def test_spec_fails_closed_on_manufactured_pricing_when_resigned(self):
+        specification = copy.deepcopy(build_internal_productization_spec()["spec"])
+        specification["target"]["pricing_status"] = "PRICED"
+        with self.assertRaises(ProofEngineError):
+            verify_product_specification(resign(specification, "spec_fingerprint"))
+
+    def test_acceptance_fails_closed_on_manufactured_human_decision(self):
+        contract = copy.deepcopy(build_internal_productization_spec()["acceptance"])
+        contract["decision_contract"]["decisions"] = [{"decision": "APPROVE_PILOT_PACKAGE_BUILD"}]
+        with self.assertRaises(ProofEngineError):
+            verify_acceptance_contract(resign(contract, "contract_fingerprint"))
+
+    def test_acceptance_fails_closed_on_missing_criterion(self):
+        contract = copy.deepcopy(build_internal_productization_spec()["acceptance"])
+        contract["criteria"].pop()
+        with self.assertRaises(ProofEngineError):
+            verify_acceptance_contract(resign(contract, "contract_fingerprint"))
+
+    def test_checkpoint_fails_closed_on_unknown_field(self):
+        checkpoint = copy.deepcopy(verify_internal_productization_spec()["checkpoint"])
+        checkpoint["unknown"] = False
+        with self.assertRaises(ProofEngineError):
+            verify_internal_productization_spec(
+                checkpoint=resign(checkpoint, "checkpoint_fingerprint")
+            )
+
+    def test_checkpoint_fails_closed_on_external_action(self):
+        checkpoint = copy.deepcopy(verify_internal_productization_spec()["checkpoint"])
+        checkpoint["publication_performed"] = True
+        with self.assertRaises(ProofEngineError):
+            verify_internal_productization_spec(
+                checkpoint=resign(checkpoint, "checkpoint_fingerprint")
+            )
+
+    def test_review_template_does_not_manufacture_decision(self):
+        template = build_pilot_package_review_template()
+        self.assertIsNone(template["decision"])
+        self.assertIsNone(template["reviewer_identity"])
+        self.assertFalse(template["pilot_package_build_authorized"])
+        self.assertFalse(template["pricing_authorized"])
+        self.assertFalse(template["delivery_authorized"])
+        self.assertEqual(len(template["criteria_results"]), 15)
+
+    def test_cli_has_no_build_price_publish_or_delivery_command(self):
+        parser = build_parser()
+        choices = parser._subparsers._group_actions[0].choices
+        self.assertEqual(
+            set(choices),
+            {"verify", "summary", "spec", "acceptance", "review-template", "render-markdown"},
+        )
+        for forbidden in (
+            "build",
+            "approve",
+            "price",
+            "outreach",
+            "contract",
+            "deliver",
+            "publish",
+        ):
+            self.assertNotIn(forbidden, choices)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Human instruction

Record the project owner's explicit instruction:

> 動きを行う。

## Scope

Build the bounded internal productization specification and acceptance contract authorized by the merged productization review.

The first delivery model is fixed as:

```text
OPERATOR_ASSISTED_SINGLE_CASE
```

The product remains the `Evidence-Backed Achievement Discovery Report` for an AI-assisted solo developer or solo founder with bounded repository evidence.

## Product contract

- one exact repository snapshot;
- read-only or metadata-only source mode;
- eight-step operator-assisted workflow;
- deterministic JSON and reader-facing Markdown;
- all nine required report sections;
- contribution separation;
- withheld-claim retention;
- WIP=1;
- fail-closed reconstruction and rollback.

## Acceptance contract

Fifteen acceptance criteria cover source binding, report completeness, factuality, contribution, privacy, determinism, human authority, usability, fail-closed behavior, rollback, and scope.

Any failed criterion blocks acceptance. Human criteria require explicit human records. Partial acceptance is prohibited.

## Authority boundary

```text
INTERNAL_PRODUCTIZATION_SPECIFICATION_COMPLETE
HUMAN_PILOT_PACKAGE_BUILD_REVIEW_REQUIRED
NOT_PRICED
NOT_DELIVERED
NOT_PUBLISHED
```

No pilot-package build, pricing, outreach, contracting, delivery, publication, external execution, automatic approval, automatic rewriting, or target-repository write is authorized or performed.

## Validation

- deterministic build-contract, product-specification, acceptance-contract, summary, and checkpoint fingerprints;
- fail closed on re-signed authority widening;
- fail closed on manufactured pricing or human approval;
- fail closed on missing acceptance criteria;
- fail closed on unknown checkpoint fields or external-action state;
- dedicated CI plus existing Proof Engine regression workflows.