### PR TITLE
Establish RTS license, origin, and responsible-use boundary v1

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,9 @@ Clarity, ordering, minimal examples, and verification steps.
 Determinism and auditability come first.
 No hidden state. No external telemetry.
 
+### 4) Extensions, integrations, and interoperability
+Forks, adapters, integrations, external tooling, commercial extensions, and research are welcome when they respect the repository license and provenance requirements.
+
 ---
 
 ## Hard constraints (non-negotiable)
@@ -31,6 +34,8 @@ No hidden state. No external telemetry.
 - **No inference beyond evidence**
 - **No fabricated logs**
 - **No destructive history rewrite**
+- **No origin/provenance falsification**
+- **No malicious or intentionally abusive use**
 - **Keep outputs deterministic**
   - Same inputs → same outputs
 
@@ -44,6 +49,7 @@ No hidden state. No external telemetry.
    - file paths
    - before/after diffs
    - reproduction commands (if applicable)
+4. Preserve authorship and provenance where prior RTS work is incorporated.
 
 ---
 
@@ -67,6 +73,8 @@ High-impact areas require review:
 
 ---
 
-## License
+## License and contribution terms
 
-By contributing, you agree your contributions are licensed under the MIT License.
+By contributing, you agree that accepted contributions may be distributed under the repository's current `LICENSE`, the **RTS Responsible Open Use License v1.0**, unless another arrangement is explicitly accepted in writing by the maintainer.
+
+The project welcomes commercial use, joint development, forks, sponsorship, and funding. Attribution/origin falsification and malicious or intentionally abusive use remain outside the license grant.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,49 @@
+RTS RESPONSIBLE OPEN USE LICENSE v1.0
+
+Copyright (c) 2026 Nobutaka Yamauchi
+
+Permission is granted, free of charge, to any person obtaining a copy of RTS and associated documentation (the "Software"), to use, copy, study, modify, merge, publish, distribute, sublicense, and sell copies of the Software, including for commercial purposes, subject to the conditions below.
+
+1. ATTRIBUTION AND ORIGIN
+
+The above copyright notice, this license, and a reasonable notice that the work is derived from or incorporates RTS must be preserved in copies or substantial portions of the Software.
+
+You must not knowingly or materially misrepresent RTS-derived work as having been created entirely independently of RTS when RTS code, documentation, architecture, or other substantial project material was used as a basis.
+
+Good-faith independent development is not restricted by this clause.
+
+2. PROHIBITED MALICIOUS USE
+
+Permission is not granted to use the Software with the intent to cause harm, facilitate unlawful access, fraud, malware deployment, harassment, stalking, coercion, deliberate privacy invasion, credential theft, destructive interference, or other intentionally harmful or abusive conduct.
+
+3. PROHIBITED BAD-FAITH DEPLOYMENT
+
+Permission is not granted where the Software is knowingly deployed, modified, or distributed for a purpose whose primary intended effect is to enable or materially assist harmful or abusive conduct described in Section 2.
+
+4. COMMERCIAL USE
+
+Commercial use is expressly permitted when the conditions of this license are followed. Selling services, integrations, modified versions, support, hosting, or other commercial offerings based on RTS is permitted.
+
+5. CONTRIBUTIONS AND FORKS
+
+Forks, research, experimentation, interoperability work, and collaborative development are welcome. Contributions submitted to the RTS repository are offered under this license unless a contribution explicitly states otherwise and is accepted by the maintainer.
+
+6. NO TRADEMARK OR ENDORSEMENT GRANT
+
+This license does not grant permission to use the RTS name, project identity, or creator identity to imply endorsement, sponsorship, or official status where none exists.
+
+7. TERMINATION
+
+Rights granted under this license terminate automatically for a party that materially violates Sections 1, 2, or 3. Rights may be restored by written permission from the copyright holder or by curing the violation where cure is reasonably possible and the copyright holder accepts the cure.
+
+8. DISCLAIMER
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY ARISING FROM, OUT OF, OR IN CONNECTION WITH THE SOFTWARE OR ITS USE.
+
+9. LICENSE CLASSIFICATION NOTICE
+
+Because this license contains use restrictions, it is not represented as an OSI-approved open-source license. RTS remains publicly inspectable and developed in the open, but licensing claims should use the terms "source-available" or "open development" unless and until an OSI-approved license is adopted.
+
+10. PRIOR VERSIONS
+
+This license governs versions and contributions released under it from the commit that first adds this LICENSE file onward. Earlier releases may remain governed by any terms that applied to them at the time of release. This license does not retroactively revoke rights already granted under an earlier license.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Each block records:
 
 This forms a reconstructable decision state.
 
----
-
 ### 2) State Transition Tracking
 
 RTS tracks transitions between decision states to identify:
@@ -72,8 +70,6 @@ RTS tracks transitions between decision states to identify:
 - which decision altered the trajectory
 
 This enables precise reconstruction after failure.
-
----
 
 ### 3) Append-Only Ledger
 
@@ -136,6 +132,30 @@ RTS is a **structural ledger**.
 
 ---
 
+## Open Development and Use
+
+RTS is developed publicly and its source remains inspectable.
+
+Legitimate use is intentionally broad. Personal use, research, modification, forks, integrations, commercial products and services, collaboration, sponsorship, and funding are welcome.
+
+Three boundaries are non-negotiable:
+
+1. **Do not falsify origin.** If RTS code, documentation, architecture, or substantial project material is used as a basis, do not knowingly present the resulting work as wholly independent of RTS.
+2. **Do not use RTS maliciously.** Intentional harmful or abusive use is outside the license grant.
+3. **Do not deploy RTS in bad faith to materially enable such abuse.**
+
+Independent development is not restricted merely because another project reaches a similar idea.
+
+See:
+
+- License → [`LICENSE`](LICENSE)
+- Attribution / Acceptable Use → [`docs/legal/USE_POLICY.md`](docs/legal/USE_POLICY.md)
+- Public origin chronology → [`docs/genesis/ORIGIN_LEDGER.md`](docs/genesis/ORIGIN_LEDGER.md)
+
+Because the current RTS license includes use restrictions, RTS does **not** claim OSI-approved open-source status. The accurate terms are **source-available** and **open development**.
+
+---
+
 ## Documentation
 
 - Manifest → `docs/manifest.md`
@@ -147,4 +167,8 @@ RTS is a **structural ledger**.
 
 ## License
 
-MIT
+RTS Responsible Open Use License v1.0.
+
+Commercial use is permitted subject to attribution/origin and prohibited-use conditions.
+
+Copyright (c) 2026 Nobutaka Yamauchi.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,6 +16,7 @@ It is a structural integrity and traceability system.
 - Humans provide final judgment.
 - Do not publish secrets or personal data.
 - When uncertain, stop and request review.
+- Do not use RTS with intent to cause harm or materially enable abuse.
 
 ---
 
@@ -29,6 +30,23 @@ The following must never be committed publicly:
 - Data without explicit disclosure rights
 - Internal infrastructure credentials
 - Personal data (GDPR-protected or similar)
+
+---
+
+## Prohibited Security-Abusive Use
+
+The RTS license does not grant permission for intentional harmful or abusive use, including use intended to facilitate:
+
+- unauthorized access;
+- credential theft;
+- malware deployment;
+- fraud;
+- stalking, harassment, or coercion;
+- deliberate privacy invasion;
+- destructive interference with systems or data;
+- comparable bad-faith abuse.
+
+Security research, defensive testing, audit, red-team work, and vulnerability analysis are not prohibited merely because they study harmful techniques; intent, authorization, scope, and actual use matter.
 
 ---
 
@@ -49,6 +67,13 @@ High-impact issues should not be discussed in public threads.
 - Public Issues and PRs must reference evidence links only.
 - High-impact structural changes require Pull Request review.
 - Maintainers may remove violating content without notice.
+- Provenance and authorship records must not be intentionally falsified.
+
+---
+
+## License / Use Boundary
+
+See `LICENSE` and `docs/legal/USE_POLICY.md` for the controlling grant and project-level acceptable-use policy.
 
 ---
 

--- a/docs/core/manifesto.md
+++ b/docs/core/manifesto.md
@@ -5,22 +5,15 @@ RTS turns AI execution into verifiable operational memory.
 RTS is execution-memory infrastructure for AI operators.
 
 It preserves reasoning continuity.
-
 It audits agent execution structure.
-
 It reconstructs operational provenance from public evidence.
 All claims remain traceable to public execution evidence.
 
-RTS (Real Time Trust System) is an execution-memory infrastructure
-designed for long-running AI collaboration, GPT workflows,
-and research operations.
+RTS (Real Time Trust System) is an execution-memory infrastructure designed for long-running AI collaboration, GPT workflows, and research operations.
 
 Modern AI sessions restart. Reasoning fragments. Execution history disappears.
 
-
-
 RTS does not control agents. RTS observes execution.
-
 Execution history becomes infrastructure.
 
 **Core capabilities**
@@ -47,12 +40,10 @@ Reasoning fragments.
 Execution history disappears.
 
 RTS converts execution itself into verifiable operational memory.
-
 Execution history becomes infrastructure.
 
 RTS observes execution.  
 It never replaces human judgement.
-
 Human authority remains final.
 
 RTS is execution memory infrastructure for AI operators.
@@ -64,7 +55,6 @@ RTS is execution memory infrastructure for AI operators.
 RTS (Real Time Trust System) is an execution-memory operating framework designed to preserve reasoning continuity inside AI workflows.
 
 RTS is not an agent controller.
-
 RTS is an observability and reconstruction layer.
 
 Agent behavior may be chaotic.  
@@ -103,9 +93,7 @@ Nothing uploads without explicit GitHub push.
 CAPTURE → EVALUATE → DECIDE → EXECUTE → AUDIT → EVOLVE → RECORD → RESET
 
 Human authority remains final.
-
 RTS observes execution.
-
 It never replaces human judgement.
 
 ---
@@ -171,7 +159,6 @@ Operators lose:
 RTS preserves thinking.
 
 Execution becomes memory.
-
 Memory becomes identity.
 
 ---
@@ -199,7 +186,6 @@ RTS functions as a continuously auditable operational record.
 Real Time Trust System (RTS), Yamauchi N. (2026).
 
 Repository execution history serves as provenance evidence.
-
 RTS is released as a public operational research artifact.
 
 ---
@@ -213,15 +199,37 @@ Removal or falsification of:
 
 is considered repository integrity violation.
 
-Forks permitted.
+Forks are welcome.
+Commercial use is welcome.
+Joint development, sponsorship, and funding are welcome.
 
 Misrepresentation is not.
+Malicious use is not.
+Bad-faith deployment primarily intended to enable abuse is not.
+
+Independent development is not restricted merely because another project reaches a similar idea or architecture.
+
+---
+
+## **Open Development / Use Boundary**
+
+RTS is developed publicly and remains source-available.
+
+The project deliberately permits broad legitimate use while preserving three non-negotiable boundaries:
+
+1. do not knowingly falsify material RTS origin;
+2. do not use RTS with malicious intent to cause or materially facilitate harm;
+3. do not deploy or distribute RTS in bad faith primarily to enable such abuse.
+
+See `LICENSE`, `docs/legal/USE_POLICY.md`, and `docs/genesis/ORIGIN_LEDGER.md`.
+
+Because these use restrictions exceed OSI open-source criteria, RTS does not claim OSI-approved open-source status under the current license. The accurate public description is **source-available / open development**.
 
 ---
 
 ## **License**
 
-MIT License
+RTS Responsible Open Use License v1.0
 
 Copyright (c) 2026 Nobutaka Yamauchi
 
@@ -233,8 +241,9 @@ RTS exists to prevent loss of thinking.
 
 Ideas should survive execution.  
 History should survive iteration.
-
 Continuity creates trust.
+
+RTS is not intended to be locked away. Use it, improve it, integrate it, and build businesses around legitimate use if useful. Preserve material provenance and do not weaponize the project against others.
 
 ---
 
@@ -244,6 +253,9 @@ RTS evolved through live operational execution.
 
 ### **Operational evolution record**
 docs/genesis/GENESIS_TO_ZERO.md
+
+### **Public origin ledger**
+docs/genesis/ORIGIN_LEDGER.md
 
 ### **Agent execution structural audit**
 analysis/agent_index.md
@@ -260,20 +272,15 @@ Evidence is publicly reproducible through:
 - immutable snapshot hashes
 
 Execution history itself becomes audit material.
-
 Genesis reconstruction is evidence-derived.
-
 All claims are traceable to public execution evidence.
 
 No retrospective narrative rewriting was performed.
-
 Human operator judgement remains final.
-
 RTS observes execution.
 
 Execution became memory.  
 Memory became identity.
-
 History remains verifiable.
 
 END.

--- a/docs/genesis/ORIGIN_LEDGER.md
+++ b/docs/genesis/ORIGIN_LEDGER.md
@@ -1,0 +1,47 @@
+# RTS Public Origin Ledger
+
+This ledger exists to make RTS chronology easy to verify without relying on retrospective claims.
+
+## Rule
+
+For major RTS concepts, record the earliest repository evidence that can be publicly verified from GitHub commits or pull requests.
+
+The ledger is evidence-first:
+
+- GitHub history is the source of chronology;
+- entries should link to concrete commits or pull requests;
+- later summaries do not replace earlier evidence;
+- similarity alone is not evidence of copying;
+- independently developed similar ideas remain independent unless evidence shows otherwise.
+
+## Current verified milestones
+
+### Evidence-report and governed development line
+
+Public repository history before August 2026 records deterministic evidence packages, fail-closed validation, governance gates, privacy hardening, public-candidate discovery, execution authorization, and product-readiness work.
+
+### Deployment Identity / runtime debugging evidence pipeline
+
+PR #299, opened 2026-08-07, records the invariant:
+
+> Deployment Identity MUST be established before runtime implementation classification.
+
+It also records the pipeline:
+
+Observation → Deployment Identity Probe → Runtime Debug Gate → Runtime Evidence Correlation → Runtime Code Mapping Gate → Root Cause Claim Gate → Deployment Re-Identity → Retest / Regression Gate.
+
+### Flight Recorder / Repair Patch / post-2026-07-26 FREEZER intake
+
+PR #300, opened 2026-08-09, publicly records candidates including:
+
+- RTS Flight Recorder;
+- Repair Patch Generation Mechanism;
+- Deployment Identity Layer;
+- Governed Web Intake / Acquisition Layer;
+- Limit Over / Quarantine / Safe Release Policy.
+
+## Maintenance
+
+When a major concept is adopted, add its earliest verifiable public evidence here. Prefer exact PR/commit links and dates over narrative claims.
+
+This ledger documents chronology and provenance. It does not claim that similar later work by another party was copied from RTS unless separate evidence establishes that fact.

--- a/docs/legal/USE_POLICY.md
+++ b/docs/legal/USE_POLICY.md
@@ -1,0 +1,49 @@
+# RTS Attribution and Acceptable Use Policy v1
+
+RTS is intended to be developed in the open and used broadly.
+
+## Welcomed use
+
+RTS welcomes:
+
+- personal use;
+- research and education;
+- modification and forks;
+- integrations;
+- commercial products and services;
+- collaborative development;
+- sponsorship and funding.
+
+## Non-negotiable boundaries
+
+RTS does not permit:
+
+1. **Origin falsification** — knowingly presenting RTS-derived work as wholly independent where RTS code, documentation, architecture, or substantial project material was used as a basis.
+2. **Malicious use** — use intended to cause harm or materially assist unlawful access, fraud, malware, harassment, stalking, coercion, deliberate privacy invasion, credential theft, destructive interference, or comparable abuse.
+3. **Bad-faith deployment** — knowingly adapting or distributing RTS primarily to enable the harmful conduct above.
+
+Independent development is not restricted merely because another project reaches a similar idea or architecture.
+
+## Commercial use
+
+Commercial use is welcome when the license and attribution requirements are followed.
+
+You may sell software, hosting, support, integration, consulting, modified versions, and other offerings based on RTS. You may not erase material RTS provenance and then knowingly market an RTS-derived system as entirely independently invented.
+
+## Collaboration
+
+Joint development is strongly welcomed. Funding and sponsorship are also welcomed. These do not transfer authorship of pre-existing RTS history unless explicitly agreed in writing.
+
+## Public provenance
+
+GitHub commit and pull-request history is the primary public chronology for RTS development. Where feasible, major concepts should be linked to their earliest public repository evidence in `docs/genesis/ORIGIN_LEDGER.md`.
+
+## Enforcement posture
+
+RTS is deliberately permissive about legitimate use and deliberately strict about provenance falsification and malicious use.
+
+Nothing in this policy is intended as a threat or a promise of any particular enforcement method. Available legal, platform, contractual, or technical remedies may be used where appropriate.
+
+## License relationship
+
+The controlling grant is the repository `LICENSE`. This document explains project intent and should be read consistently with that license.

--- a/index.html
+++ b/index.html
@@ -4,153 +4,21 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <title>RTS — Execution Logging Protocol</title>
-
   <style>
-    body{
-      margin:0;
-      font-family:-apple-system,system-ui,"SF Pro Text";
-      background:linear-gradient(180deg,#bfe9ff,#e8f6ff);
-      color:#0b1220;
-    }
-    .wrap{max-width:860px;margin:auto;padding:18px;}
-    .card{
-      background:#fff;border-radius:22px;padding:20px;
-      box-shadow:0 14px 44px rgba(2,10,26,.18);
-      margin-bottom:18px;overflow:hidden;position:relative;
-    }
-    h1{font-size:clamp(30px,8vw,46px);line-height:1.05;margin:8px 0 10px;}
-    h2{margin-top:26px;margin-bottom:10px;font-size:22px;}
-    p{color:#4b5563;line-height:1.65;margin:10px 0;}
-    ul{padding-left:18px;line-height:1.7;margin:0;}
-    ol{padding-left:20px;line-height:1.7;margin:0;}
-    .box{
-      background:#fff;border-radius:18px;padding:18px;margin-top:12px;
-      box-shadow:0 10px 28px rgba(2,10,26,.12);
-      overflow:hidden;position:relative;
-    }
-    .pill{
-      display:inline-block;background:#eef3f7;padding:8px 12px;
-      border-radius:14px;margin:6px 6px 0 0;
-      font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;
-    }
-    .btnrow{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
-    .btn{
-      display:inline-block;text-decoration:none;
-      background:#0b1220;color:#fff;
-      padding:10px 14px;border-radius:12px;
-      font-size:14px;font-weight:600;
-    }
-    .btn.ghost{
-      background:#fff;color:#0b1220;border:1px solid rgba(11,18,32,.18);
-    }
-    .footer{
-      text-align:center;font-size:12px;color:#6b7280;margin-top:20px;
-    }
-    .footer a{color:#1f3a8a;text-decoration:none}
-    .footer a:hover{text-decoration:underline}
+    body{margin:0;font-family:-apple-system,system-ui,"SF Pro Text";background:linear-gradient(180deg,#bfe9ff,#e8f6ff);color:#0b1220;}
+    .wrap{max-width:860px;margin:auto;padding:18px}.card,.box{background:#fff;border-radius:22px;padding:20px;box-shadow:0 14px 44px rgba(2,10,26,.18);margin-bottom:18px}.box{border-radius:18px;box-shadow:0 10px 28px rgba(2,10,26,.12)}
+    h1{font-size:clamp(30px,8vw,46px);line-height:1.05;margin:8px 0 10px}h2{margin-top:26px;margin-bottom:10px;font-size:22px}p{color:#4b5563;line-height:1.65;margin:10px 0}ul,ol{padding-left:20px;line-height:1.7}.pill{display:inline-block;background:#eef3f7;padding:8px 12px;border-radius:14px;margin:6px 6px 0 0;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px}.btnrow{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}.btn{display:inline-block;text-decoration:none;background:#0b1220;color:#fff;padding:10px 14px;border-radius:12px;font-size:14px;font-weight:600}.btn.ghost{background:#fff;color:#0b1220;border:1px solid rgba(11,18,32,.18)}.footer{text-align:center;font-size:12px;color:#6b7280;margin-top:20px}.footer a{color:#1f3a8a;text-decoration:none}
   </style>
 </head>
-
-<body>
-  <div class="wrap">
-
-    <div class="card">
-      <h1>RTS</h1>
-      <p><b>Execution Logging Protocol for AI-Assisted Work</b></p>
-      <p>RTS is a structured execution provenance protocol. It preserves decision context in AI-accelerated environments.</p>
-
-      <div class="btnrow">
-        <a class="btn" href="/RTS/services/">Services</a>
-        <a class="btn ghost" href="/RTS/docs/rulebook/">Rulebook</a>
-        <a class="btn ghost" href="/RTS/legal/">Legal</a>
-      </div>
-    </div>
-
-    <h2>What RTS Preserves</h2>
-    <div class="box">
-      <ul>
-        <li>Decision intent</li>
-        <li>Active assumptions</li>
-        <li>Environmental constraints</li>
-        <li>Rejected alternatives</li>
-        <li>Outcome evaluation</li>
-      </ul>
-    </div>
-
-    <h2>Why It Exists</h2>
-    <div class="box">
-      <p>AI increases execution speed.</p>
-      <p>It does not preserve reasoning.</p>
-      <p><b>RTS restores traceability.</b></p>
-    </div>
-
-    <h2>What RTS Is Not</h2>
-    <div class="box">
-      <ul>
-        <li>Not memory embedding</li>
-        <li>Not vector retrieval</li>
-        <li>Not workflow automation</li>
-        <li>Not monitoring software</li>
-      </ul>
-    </div>
-
-    <h2>Protocol Structure</h2>
-    <div class="box">
-      <p>Each block records:</p>
-      <div>
-        <span class="pill">Context</span>
-        <span class="pill">Decision</span>
-        <span class="pill">Constraint</span>
-        <span class="pill">Assumption</span>
-        <span class="pill">Action</span>
-        <span class="pill">Outcome</span>
-      </div>
-    </div>
-
-    <h2>Operational Properties</h2>
-    <div class="box">
-      <ul>
-        <li>Tool-agnostic</li>
-        <li>GitHub-native</li>
-        <li>Local-first</li>
-        <li>No telemetry</li>
-        <li>Open protocol</li>
-      </ul>
-    </div>
-
-    <h2>Governance</h2>
-    <div class="box">
-      <p>RTS is open and public (MIT License).</p>
-      <p>Professional services applying RTS are independent from the core protocol.</p>
-    </div>
-
-    <h2>Quick Start</h2>
-    <div class="box">
-      <ol>
-        <li>Create a block.</li>
-        <li>Log decisions.</li>
-        <li>Commit.</li>
-      </ol>
-    </div>
-
-    <h2>Closing</h2>
-    <div class="box">
-      <p><b>Execution without provenance creates structural fragility.</b></p>
-      <p>RTS introduces continuity.</p>
-    </div>
-
-    <div class="footer">
-      <div style="margin-bottom:10px;">
-        <a href="/RTS/services/">Services</a> |
-        <a href="/RTS/artifacts/breakpoint/">Breakpoint</a> |
-        <a href="/RTS/docs/rulebook/">Rulebook</a> |
-        <a href="/RTS/legal/tokusho/">Tokusho</a> |
-        <a href="/RTS/legal/privacy/">Privacy</a> |
-        <a href="/RTS/legal/terms/">Terms</a>
-      </div>
-      Created by Nobutaka Yamauchi ● MIT License
-    </div>
-
-  </div>
-</body>
-</html>
+<body><div class="wrap">
+  <div class="card"><h1>RTS</h1><p><b>Execution Logging Protocol for AI-Assisted Work</b></p><p>RTS is a structured execution provenance protocol. It preserves decision context in AI-accelerated environments.</p><div class="btnrow"><a class="btn" href="/RTS/services/">Services</a><a class="btn ghost" href="/RTS/docs/rulebook/">Rulebook</a><a class="btn ghost" href="/RTS/legal/">Legal</a></div></div>
+  <h2>What RTS Preserves</h2><div class="box"><ul><li>Decision intent</li><li>Active assumptions</li><li>Environmental constraints</li><li>Rejected alternatives</li><li>Outcome evaluation</li></ul></div>
+  <h2>Why It Exists</h2><div class="box"><p>AI increases execution speed.</p><p>It does not preserve reasoning.</p><p><b>RTS restores traceability.</b></p></div>
+  <h2>What RTS Is Not</h2><div class="box"><ul><li>Not memory embedding</li><li>Not vector retrieval</li><li>Not workflow automation</li><li>Not monitoring software</li></ul></div>
+  <h2>Protocol Structure</h2><div class="box"><p>Each block records:</p><div><span class="pill">Context</span><span class="pill">Decision</span><span class="pill">Constraint</span><span class="pill">Assumption</span><span class="pill">Action</span><span class="pill">Outcome</span></div></div>
+  <h2>Operational Properties</h2><div class="box"><ul><li>Tool-agnostic</li><li>GitHub-native</li><li>Local-first</li><li>No telemetry</li><li>Open development</li><li>Public provenance</li></ul></div>
+  <h2>Governance and Use</h2><div class="box"><p>RTS is publicly developed and source-available under the RTS Responsible Open Use License v1.0.</p><p>Commercial use, forks, integrations, joint development, sponsorship, and funding are welcome.</p><p><b>Do not falsify RTS origin. Do not use RTS maliciously. Do not deploy it in bad faith to materially enable abuse.</b></p><p>Independent development is not restricted merely because another project reaches similar ideas.</p><p>See the repository LICENSE, Attribution / Acceptable Use Policy, and Public Origin Ledger for details.</p></div>
+  <h2>Quick Start</h2><div class="box"><ol><li>Create a block.</li><li>Log decisions.</li><li>Commit.</li></ol></div>
+  <h2>Closing</h2><div class="box"><p><b>Execution without provenance creates structural fragility.</b></p><p>RTS introduces continuity.</p></div>
+  <div class="footer"><div style="margin-bottom:10px;"><a href="/RTS/services/">Services</a> | <a href="/RTS/docs/rulebook/">Rulebook</a> | <a href="/RTS/legal/">Legal</a></div>Created by Nobutaka Yamauchi ● RTS Responsible Open Use License v1.0</div>
+</div></body></html>

--- a/legal/index.html
+++ b/legal/index.html
@@ -1,70 +1,10 @@
 <!doctype html>
 <html lang="ja">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>RTS Legal</title>
-
-  <style>
-    body{
-      margin:0;
-      font-family:-apple-system,system-ui,"SF Pro Text";
-      background:linear-gradient(180deg,#f6f7ff,#ffffff);
-      color:#0b1220;
-    }
-    .wrap{max-width:860px;margin:auto;padding:18px;}
-    .card{
-      background:#fff;border-radius:22px;padding:20px;
-      box-shadow:0 14px 44px rgba(2,10,26,.12);
-      margin-bottom:18px;
-    }
-    h1{font-size:28px;margin:0 0 8px;}
-    p{color:#4b5563;line-height:1.7;margin:10px 0;}
-    ul{padding-left:18px;line-height:1.9;margin:0;}
-    a{color:#1f3a8a;text-decoration:none}
-    a:hover{text-decoration:underline}
-    .muted{color:#6b7280;font-size:13px;line-height:1.6;}
-    .footer{text-align:center;font-size:12px;color:#6b7280;margin-top:20px;}
-  </style>
-</head>
-
-<body>
-  <div class="wrap">
-
-    <div class="card">
-      <div class="muted">RTS / Legal</div>
-      <h1>法的情報・ポリシー</h1>
-      <p>
-        このページでは、RTSサービスおよび本Webサイトに関連する法的情報とポリシー情報を提供します。
-        RTSはオープンな実行ログ記録プロトコルであり、プロトコルに基づいて独立した専門サービスが提供される場合があります。
-      </p>
-
-      <h2 style="font-size:18px;margin:18px 0 10px;">運営者</h2>
-      <p class="muted">
-        Operator: Nobutaka Yamauchi<br>
-        Trade name: risingson
-      </p>
-
-      <h2 style="font-size:18px;margin:18px 0 10px;">ページ一覧</h2>
-      <ul>
-        <li><a href="/RTS/legal/tokusho/">特定商取引法に基づく表記（Tokusho）</a></li>
-        <li><a href="/RTS/legal/privacy/">プライバシーポリシー（Privacy Policy）</a></li>
-        <li><a href="/RTS/legal/terms/">利用規約（Terms）</a></li>
-      </ul>
-
-      <h2 style="font-size:18px;margin:18px 0 10px;">ナビゲーション</h2>
-      <ul>
-        <li><a href="/RTS/">ホーム</a></li>
-        <li><a href="/RTS/services/">サービス</a></li>
-        <li><a href="/RTS/artifacts/breakpoint/">ブレイクポイント</a></li>
-        <li><a href="/RTS/docs/rulebook/">ルールブック</a></li>
-      </ul>
-    </div>
-
-    <div class="footer">
-      Created by Nobutaka Yamauchi ● MIT License
-    </div>
-
-  </div>
-</body>
-</html>
+<head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>RTS Legal</title>
+<style>body{margin:0;font-family:-apple-system,system-ui,"SF Pro Text";background:linear-gradient(180deg,#f6f7ff,#ffffff);color:#0b1220}.wrap{max-width:860px;margin:auto;padding:18px}.card{background:#fff;border-radius:22px;padding:20px;box-shadow:0 14px 44px rgba(2,10,26,.12);margin-bottom:18px}h1{font-size:28px;margin:0 0 8px}p{color:#4b5563;line-height:1.7;margin:10px 0}ul{padding-left:18px;line-height:1.9;margin:0}a{color:#1f3a8a;text-decoration:none}.muted{color:#6b7280;font-size:13px;line-height:1.6}.footer{text-align:center;font-size:12px;color:#6b7280;margin-top:20px}</style></head>
+<body><div class="wrap"><div class="card"><div class="muted">RTS / Legal</div><h1>法的情報・ポリシー</h1><p>RTSは公開開発・source-availableのプロジェクトです。商用利用、改変、共同開発、統合、資金提供を歓迎します。一方で、出自の意図的な偽装、悪意ある利用、悪用を主目的とする展開は許可されません。</p>
+<h2 style="font-size:18px;margin:18px 0 10px;">RTS公開利用条件</h2><ul><li><a href="https://github.com/nobutakayamauchi/RTS/blob/main/LICENSE">LICENSE</a></li><li><a href="https://github.com/nobutakayamauchi/RTS/blob/main/docs/legal/USE_POLICY.md">Attribution / Acceptable Use Policy</a></li><li><a href="https://github.com/nobutakayamauchi/RTS/blob/main/docs/genesis/ORIGIN_LEDGER.md">Public Origin Ledger</a></li></ul>
+<p class="muted">現行ライセンスには利用制限があるため、OSI-approved open sourceとは表示せず、source-available / open developmentとして扱います。</p>
+<h2 style="font-size:18px;margin:18px 0 10px;">運営者</h2><p class="muted">Operator: Nobutaka Yamauchi<br>Trade name: risingson</p>
+<h2 style="font-size:18px;margin:18px 0 10px;">ページ一覧</h2><ul><li><a href="/RTS/legal/tokusho/">特定商取引法に基づく表記</a></li><li><a href="/RTS/legal/privacy/">プライバシーポリシー</a></li><li><a href="/RTS/legal/terms/">利用規約</a></li></ul>
+<h2 style="font-size:18px;margin:18px 0 10px;">ナビゲーション</h2><ul><li><a href="/RTS/">ホーム</a></li><li><a href="/RTS/services/">サービス</a></li><li><a href="/RTS/docs/rulebook/">ルールブック</a></li></ul></div><div class="footer">Created by Nobutaka Yamauchi ● RTS Responsible Open Use License v1.0</div></div></body></html>


### PR DESCRIPTION
## Purpose

Establish one public GitHub baseline for RTS licensing, provenance, commercial-use permission, collaboration posture, and prohibited malicious use.

## Policy

RTS welcomes legitimate use, including:

- personal use and research;
- modification and forks;
- integrations;
- commercial products and services;
- joint development;
- sponsorship and funding.

Three boundaries are non-negotiable:

1. do not knowingly falsify material RTS origin;
2. do not use RTS with malicious intent to cause or materially facilitate harm;
3. do not deploy or distribute RTS in bad faith primarily to enable such abuse.

Independent development is explicitly not restricted merely because another project reaches similar ideas.

## Changes

- add `LICENSE` with RTS Responsible Open Use License v1.0;
- add `docs/legal/USE_POLICY.md`;
- add `docs/genesis/ORIGIN_LEDGER.md` as a public chronology index;
- replace legacy MIT references in README, CONTRIBUTING, manifesto, and public legal/site surfaces;
- add the malicious-use boundary to SECURITY.md;
- state explicitly that the current use-restricted license is source-available/open-development and is not represented as OSI-approved open source.

## Prior-version boundary

The new license applies from the commit that first adds `LICENSE` onward. It does not claim to retroactively revoke rights already granted under earlier terms.

## Validation

Branch comparison against `main` at `5fa2eb55e1a044444557185d9c8cada187599d94`:

- 9 commits ahead;
- 0 behind;
- 9 changed files;
- policy, origin, contribution, security, README, manifesto, and public-site surfaces aligned.

## Important legal note

This is a project-authored license/policy baseline, not a claim of OSI approval or legal counsel review. A later professional legal review may refine wording without erasing this public chronology.