### PR TITLE
Add Deployment Identity v1 proof boundary

### DIFF
--- a/.github/workflows/deployment-identity-tests.yml
+++ b/.github/workflows/deployment-identity-tests.yml
@@ -1,0 +1,34 @@
+name: Deployment Identity Tests
+
+on:
+  pull_request:
+    paths:
+      - "deployment_identity/**"
+      - "tests/test_deployment_identity.py"
+      - "docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md"
+      - ".github/workflows/deployment-identity-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "deployment_identity/**"
+      - "tests/test_deployment_identity.py"
+      - "docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md"
+      - ".github/workflows/deployment-identity-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  deployment-identity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run Deployment Identity tests
+        run: python -B -m unittest discover -s tests -p 'test_deployment_identity.py' -v
+      - name: Run full repository tests
+        run: python -B -m unittest discover -s tests -v

--- a/deployment_identity/README.md
+++ b/deployment_identity/README.md
@@ -1,0 +1,48 @@
+# Deployment Identity v1
+
+Deployment Identity establishes what code and execution surface were actually active at observation time before RTS classifies runtime behavior.
+
+## Invariant
+
+```text
+Code existence != runtime evidence.
+```
+
+A repository file, branch, or commit is source evidence only. Runtime implementation classification is forbidden until the deployed identity is established from explicit observations.
+
+## Required observations
+
+A v1 deployment observation must identify all of:
+
+- `service_unit` — the running service, unit, container, job, or equivalent execution owner;
+- `working_directory` — the runtime working directory;
+- `executable_or_module` — the executable, module, image entrypoint, or equivalent;
+- `active_route_surface` — the active route, command, worker queue, interface, or other exercised surface;
+- `deployed_revision` — the exact deployed commit/revision/image digest;
+- `source_revision` — the exact source revision whose behavior is being classified;
+- `observed_at` — timezone-aware observation timestamp.
+
+## Fail-closed rule
+
+Deployment identity is established only when every required field is present and `deployed_revision == source_revision`.
+
+Otherwise the result is `DEPLOYMENT_IDENTITY_NOT_ESTABLISHED`, and runtime implementation classification remains unauthorized.
+
+## Commands
+
+```bash
+python -m deployment_identity.cli verify --observation path/to/observation.json
+python -m deployment_identity.cli fingerprint --observation path/to/observation.json
+```
+
+The verifier is deterministic, standard-library-only, read-only, and performs no network, shell, provider, deployment, or repository mutation.
+
+## Boundary
+
+Deployment Identity does not prove that an outcome is correct. It proves only that the runtime surface being discussed is bound to the expected source revision and required runtime identity observations.
+
+The intended evidence chain is:
+
+```text
+Source Identity -> Deployment Identity -> Runtime Observation -> Outcome Evidence
+```

--- a/deployment_identity/__init__.py
+++ b/deployment_identity/__init__.py
@@ -1,0 +1,9 @@
+"""Deployment identity proof boundary for RTS."""
+
+from .core import DeploymentIdentityError, establish_deployment_identity, fingerprint_observation
+
+__all__ = [
+    "DeploymentIdentityError",
+    "establish_deployment_identity",
+    "fingerprint_observation",
+]

--- a/deployment_identity/cli.py
+++ b/deployment_identity/cli.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from .core import DeploymentIdentityError, establish_deployment_identity, fingerprint_observation
+
+
+def _read_observation(path: Path) -> dict:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise DeploymentIdentityError(f"cannot read observation: {path}") from exc
+    if not isinstance(value, dict):
+        raise DeploymentIdentityError("observation must be a JSON object")
+    return value
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="RTS Deployment Identity v1")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    verify = sub.add_parser("verify", help="establish deployment identity")
+    verify.add_argument("--observation", required=True, type=Path)
+
+    fingerprint = sub.add_parser("fingerprint", help="fingerprint a deployment observation")
+    fingerprint.add_argument("--observation", required=True, type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        observation = _read_observation(args.observation)
+        if args.command == "fingerprint":
+            print(fingerprint_observation(observation))
+            return 0
+
+        result = establish_deployment_identity(observation)
+        print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False))
+        return 0 if result["runtime_classification_authorized"] else 2
+    except DeploymentIdentityError as exc:
+        print(json.dumps({
+            "status": "DEPLOYMENT_IDENTITY_NOT_ESTABLISHED",
+            "runtime_classification_authorized": False,
+            "error": str(exc),
+        }, sort_keys=True))
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deployment_identity/core.py
+++ b/deployment_identity/core.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime
+from typing import Any, Mapping
+
+
+REQUIRED_FIELDS = (
+    "service_unit",
+    "working_directory",
+    "executable_or_module",
+    "active_route_surface",
+    "deployed_revision",
+    "source_revision",
+    "observed_at",
+)
+
+ESTABLISHED = "DEPLOYMENT_IDENTITY_ESTABLISHED"
+NOT_ESTABLISHED = "DEPLOYMENT_IDENTITY_NOT_ESTABLISHED"
+
+
+class DeploymentIdentityError(ValueError):
+    """Raised when a deployment observation cannot establish runtime identity."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def fingerprint_observation(observation: Mapping[str, Any]) -> str:
+    """Return a deterministic SHA-256 fingerprint for an observation."""
+    return hashlib.sha256(_canonical_json(dict(observation)).encode("utf-8")).hexdigest()
+
+
+def _require_non_empty_string(observation: Mapping[str, Any], field: str) -> str:
+    value = observation.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise DeploymentIdentityError(f"missing or invalid required field: {field}")
+    return value.strip()
+
+
+def _validate_timestamp(value: str) -> None:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise DeploymentIdentityError("observed_at must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise DeploymentIdentityError("observed_at must include a timezone")
+
+
+def establish_deployment_identity(observation: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and bind runtime identity to the expected source revision.
+
+    This function is deliberately read-only and fail-closed. It never infers
+    deployment identity from repository contents. Runtime identity must be
+    explicitly observed.
+    """
+    if not isinstance(observation, Mapping):
+        raise DeploymentIdentityError("observation must be an object")
+
+    values = {field: _require_non_empty_string(observation, field) for field in REQUIRED_FIELDS}
+    _validate_timestamp(values["observed_at"])
+
+    if values["deployed_revision"] != values["source_revision"]:
+        return {
+            "status": NOT_ESTABLISHED,
+            "reason": "DEPLOYED_REVISION_MISMATCH",
+            "runtime_classification_authorized": False,
+            "source_revision": values["source_revision"],
+            "deployed_revision": values["deployed_revision"],
+            "observation_fingerprint": fingerprint_observation(observation),
+        }
+
+    return {
+        "status": ESTABLISHED,
+        "reason": "EXPLICIT_RUNTIME_IDENTITY_MATCH",
+        "runtime_classification_authorized": True,
+        "identity": {
+            "service_unit": values["service_unit"],
+            "working_directory": values["working_directory"],
+            "executable_or_module": values["executable_or_module"],
+            "active_route_surface": values["active_route_surface"],
+            "revision": values["deployed_revision"],
+            "observed_at": values["observed_at"],
+        },
+        "observation_fingerprint": fingerprint_observation(observation),
+    }

--- a/deployment_identity/core.py
+++ b/deployment_identity/core.py
@@ -37,7 +37,9 @@ def _require_non_empty_string(observation: Mapping[str, Any], field: str) -> str
     value = observation.get(field)
     if not isinstance(value, str) or not value.strip():
         raise DeploymentIdentityError(f"missing or invalid required field: {field}")
-    return value.strip()
+    if value != value.strip():
+        raise DeploymentIdentityError(f"surrounding whitespace is not allowed: {field}")
+    return value
 
 
 def _validate_timestamp(value: str) -> None:

--- a/docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md
+++ b/docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md
@@ -1,0 +1,86 @@
+# Deployment Identity v1 — Completion Task
+
+## Problem
+
+RTS observation can misclassify stale or non-deployed source code as runtime reality.
+
+The governing invariant is:
+
+```text
+Code existence != runtime evidence.
+```
+
+Runtime implementation classification MUST NOT occur until Deployment Identity is established.
+
+## Required identity surface
+
+Deployment Identity v1 requires explicit evidence for:
+
+1. service/unit/container/job identity;
+2. working directory;
+3. executable/module/entrypoint;
+4. active route/command/worker/interface surface;
+5. deployed commit/revision/image digest;
+6. expected source revision;
+7. timezone-aware observation timestamp.
+
+## Establishment rule
+
+All required observations MUST be present.
+
+`deployed_revision` MUST exactly equal `source_revision`.
+
+Only then may the verifier emit:
+
+```text
+DEPLOYMENT_IDENTITY_ESTABLISHED
+runtime_classification_authorized: true
+```
+
+Every missing field, invalid timestamp, or revision mismatch fails closed. No repository-path inference, branch-name inference, source-code existence, or best-effort guess may substitute for runtime observation.
+
+## Evidence chain
+
+```text
+Source Identity
+    -> Deployment Identity
+    -> Runtime Observation
+    -> Outcome Evidence
+```
+
+Deployment Identity does not claim that an outcome is correct. It proves the runtime subject of the claim before outcome classification begins.
+
+## v1 implementation
+
+- `deployment_identity/core.py` — deterministic validator and fingerprinting
+- `deployment_identity/cli.py` — read-only verification CLI
+- `deployment_identity/README.md` — operator contract and boundary
+- `tests/test_deployment_identity.py` — fail-closed invariants
+
+## Prohibited behavior
+
+Deployment Identity v1 MUST NOT:
+
+- execute shell commands;
+- inspect a live host itself;
+- call a network or provider;
+- deploy or restart services;
+- mutate another repository;
+- infer deployment state from source presence;
+- authorize runtime classification after partial identity evidence.
+
+Those observations must be collected by a separately governed observer/adapter and supplied as evidence.
+
+## Acceptance criteria
+
+- deterministic fingerprints;
+- exact revision binding;
+- missing identity fields fail closed;
+- mismatched source/deployed revision fails closed;
+- timezone-less observations fail closed;
+- code/source evidence alone cannot establish runtime identity;
+- successful proof explicitly authorizes runtime classification and nothing beyond it.
+
+## Completion boundary
+
+Deployment Identity v1 closes the previously observed classification gap at the proof boundary. It does not yet provide privileged live-host collection. Any future collector requires a separate authority, privacy, and execution-safety review.

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from deployment_identity.cli import main
+from deployment_identity.core import (
+    DeploymentIdentityError,
+    ESTABLISHED,
+    NOT_ESTABLISHED,
+    establish_deployment_identity,
+    fingerprint_observation,
+)
+
+
+class DeploymentIdentityTests(unittest.TestCase):
+    def observation(self) -> dict:
+        return {
+            "service_unit": "rts-video-flow-web.service",
+            "working_directory": "/srv/rts-video-flow",
+            "executable_or_module": "python -m app.web",
+            "active_route_surface": "POST /render",
+            "deployed_revision": "abc123",
+            "source_revision": "abc123",
+            "observed_at": "2026-08-09T17:00:00+09:00",
+        }
+
+    def test_matching_explicit_identity_establishes_runtime_classification(self) -> None:
+        result = establish_deployment_identity(self.observation())
+        self.assertEqual(result["status"], ESTABLISHED)
+        self.assertTrue(result["runtime_classification_authorized"])
+        self.assertEqual(result["identity"]["revision"], "abc123")
+
+    def test_revision_mismatch_fails_closed(self) -> None:
+        observation = self.observation()
+        observation["deployed_revision"] = "stale456"
+        result = establish_deployment_identity(observation)
+        self.assertEqual(result["status"], NOT_ESTABLISHED)
+        self.assertFalse(result["runtime_classification_authorized"])
+        self.assertEqual(result["reason"], "DEPLOYED_REVISION_MISMATCH")
+
+    def test_missing_runtime_surface_is_rejected(self) -> None:
+        observation = self.observation()
+        del observation["active_route_surface"]
+        with self.assertRaisesRegex(DeploymentIdentityError, "active_route_surface"):
+            establish_deployment_identity(observation)
+
+    def test_blank_runtime_fields_are_rejected(self) -> None:
+        for field in (
+            "service_unit",
+            "working_directory",
+            "executable_or_module",
+            "active_route_surface",
+            "deployed_revision",
+            "source_revision",
+            "observed_at",
+        ):
+            with self.subTest(field=field):
+                observation = self.observation()
+                observation[field] = "  "
+                with self.assertRaises(DeploymentIdentityError):
+                    establish_deployment_identity(observation)
+
+    def test_naive_timestamp_is_rejected(self) -> None:
+        observation = self.observation()
+        observation["observed_at"] = "2026-08-09T17:00:00"
+        with self.assertRaisesRegex(DeploymentIdentityError, "timezone"):
+            establish_deployment_identity(observation)
+
+    def test_fingerprint_is_deterministic_and_order_independent(self) -> None:
+        first = self.observation()
+        second = dict(reversed(list(first.items())))
+        self.assertEqual(fingerprint_observation(first), fingerprint_observation(second))
+
+    def test_cli_returns_nonzero_when_identity_is_not_established(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "observation.json"
+            observation = self.observation()
+            observation["deployed_revision"] = "wrong"
+            path.write_text(json.dumps(observation), encoding="utf-8")
+            self.assertEqual(main(["verify", "--observation", str(path)]), 2)
+
+    def test_code_existence_alone_cannot_establish_identity(self) -> None:
+        source_only = {
+            "source_revision": "abc123",
+            "observed_at": "2026-08-09T17:00:00+09:00",
+        }
+        with self.assertRaises(DeploymentIdentityError):
+            establish_deployment_identity(source_only)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -41,6 +41,14 @@ class DeploymentIdentityTests(unittest.TestCase):
         self.assertFalse(result["runtime_classification_authorized"])
         self.assertEqual(result["reason"], "DEPLOYED_REVISION_MISMATCH")
 
+    def test_revision_whitespace_is_rejected_not_normalized(self) -> None:
+        for field in ("deployed_revision", "source_revision"):
+            with self.subTest(field=field):
+                observation = self.observation()
+                observation[field] = "abc123 "
+                with self.assertRaisesRegex(DeploymentIdentityError, "whitespace"):
+                    establish_deployment_identity(observation)
+
     def test_missing_runtime_surface_is_rejected(self) -> None:
         observation = self.observation()
         del observation["active_route_surface"]


### PR DESCRIPTION
Closes the runtime-reality classification gap discovered during RTS dogfooding.

Invariant:

`Code existence != runtime evidence.`

This PR adds a deterministic, fail-closed Deployment Identity verifier that requires explicit service/unit, working directory, executable/module, active route surface, deployed revision, expected source revision, and timezone-aware observation time before runtime classification may proceed.

Key boundaries:
- no inference from repository contents
- exact deployed/source revision binding
- missing identity evidence fails closed
- source-code existence alone can never establish runtime identity
- verifier is read-only and standard-library-only
- establishment authorizes runtime classification only, not deployment, publication, execution, or outcome correctness

Evidence chain:

`Source Identity -> Deployment Identity -> Runtime Observation -> Outcome Evidence`

Tests cover revision mismatch, missing/blank fields, timestamps, deterministic fingerprints, CLI fail-closed behavior, and the source-only false-positive case.