### PR TITLE
Devil's Advocate hardening: Deployment Identity v2

### DIFF
--- a/deployment_identity/README.md
+++ b/deployment_identity/README.md
@@ -1,4 +1,4 @@
-# Deployment Identity v1
+# Deployment Identity v2
 
 Deployment Identity establishes what code and execution surface were actually active at observation time before RTS classifies runtime behavior.
 
@@ -8,41 +8,68 @@ Deployment Identity establishes what code and execution surface were actually ac
 Code existence != runtime evidence.
 ```
 
-A repository file, branch, or commit is source evidence only. Runtime implementation classification is forbidden until the deployed identity is established from explicit observations.
+A repository file, branch, or commit is source evidence only. Runtime implementation classification is forbidden until deployed identity is established from explicit, trusted, fresh observations.
 
-## Required observations
+## Required deployment observation
 
-A v1 deployment observation must identify all of:
+A v2 observation identifies:
 
-- `service_unit` — the running service, unit, container, job, or equivalent execution owner;
-- `working_directory` — the runtime working directory;
-- `executable_or_module` — the executable, module, image entrypoint, or equivalent;
-- `active_route_surface` — the active route, command, worker queue, interface, or other exercised surface;
-- `deployed_revision` — the exact deployed commit/revision/image digest;
-- `source_revision` — the exact source revision whose behavior is being classified;
-- `observed_at` — timezone-aware observation timestamp.
+- `service_unit`
+- `working_directory`
+- `executable_or_module`
+- `active_route_surface`
+- `deployed_revision`
+- `source_revision`
+- `observer_id`
+- `observation_session_id`
+- `observed_at`
 
-## Fail-closed rule
+The verifier also requires an external trust anchor (`trusted_observer_ids`), a caller-supplied `reference_time`, and a bounded freshness window. An observation cannot make itself trusted by merely naming an observer.
 
-Deployment identity is established only when every required field is present and `deployed_revision == source_revision`.
+## Fail-closed rules
 
-Otherwise the result is `DEPLOYMENT_IDENTITY_NOT_ESTABLISHED`, and runtime implementation classification remains unauthorized.
+Deployment identity is established only when:
+
+1. every required field is present exactly, without normalization of surrounding whitespace;
+2. `observer_id` is in the externally supplied trusted observer set;
+3. the observation is not future-dated or older than the allowed freshness window;
+4. `deployed_revision == source_revision` exactly.
+
+Otherwise runtime classification remains unauthorized.
+
+## Runtime observation binding
+
+An established deployment proof is not enough by itself to classify a later runtime observation. The runtime observation must carry:
+
+- the exact Deployment Identity observation fingerprint;
+- the same `observation_session_id`;
+- a timezone-aware observation timestamp within the configured binding window.
+
+This closes the direct proof-chain bypass and bounds the TOCTOU interval:
+
+```text
+Source Identity
+  -> trusted + fresh Deployment Identity
+  -> fingerprint/session-bound Runtime Observation
+  -> Outcome Evidence
+```
 
 ## Commands
 
 ```bash
-python -m deployment_identity.cli verify --observation path/to/observation.json
+python -m deployment_identity.cli verify \
+  --observation path/to/observation.json \
+  --trusted-observer-id observer-prod-01 \
+  --reference-time 2026-08-09T17:00:10+09:00 \
+  --max-age-seconds 300
+
 python -m deployment_identity.cli fingerprint --observation path/to/observation.json
 ```
 
-The verifier is deterministic, standard-library-only, read-only, and performs no network, shell, provider, deployment, or repository mutation.
+## Security boundary
 
-## Boundary
+v2 deliberately does **not** claim cryptographic proof that a host observation is truthful. `trusted_observer_ids` is a policy trust anchor supplied from outside the observation. Privileged live-host collection, signatures/attestation, key management, route-to-process verification, container/image/config/environment measurement, and distributed deployment identity remain separately governed work.
 
-Deployment Identity does not prove that an outcome is correct. It proves only that the runtime surface being discussed is bound to the expected source revision and required runtime identity observations.
+Therefore v2 proves: **a trusted policy-recognized observer supplied a fresh, internally consistent deployment attestation and a later runtime observation is explicitly bound to it.** It does not prove the physical host cannot lie.
 
-The intended evidence chain is:
-
-```text
-Source Identity -> Deployment Identity -> Runtime Observation -> Outcome Evidence
-```
+The verifier remains deterministic, standard-library-only, read-only, and performs no network, shell, provider, deployment, or repository mutation.

--- a/deployment_identity/__init__.py
+++ b/deployment_identity/__init__.py
@@ -1,9 +1,15 @@
 """Deployment identity proof boundary for RTS."""
 
-from .core import DeploymentIdentityError, establish_deployment_identity, fingerprint_observation
+from .core import (
+    DeploymentIdentityError,
+    bind_runtime_observation,
+    establish_deployment_identity,
+    fingerprint_observation,
+)
 
 __all__ = [
     "DeploymentIdentityError",
+    "bind_runtime_observation",
     "establish_deployment_identity",
     "fingerprint_observation",
 ]

--- a/deployment_identity/cli.py
+++ b/deployment_identity/cli.py
@@ -19,11 +19,14 @@ def _read_observation(path: Path) -> dict:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="RTS Deployment Identity v1")
+    parser = argparse.ArgumentParser(description="RTS Deployment Identity v2")
     sub = parser.add_subparsers(dest="command", required=True)
 
     verify = sub.add_parser("verify", help="establish deployment identity")
     verify.add_argument("--observation", required=True, type=Path)
+    verify.add_argument("--trusted-observer-id", required=True, action="append")
+    verify.add_argument("--reference-time", required=True)
+    verify.add_argument("--max-age-seconds", type=int, default=300)
 
     fingerprint = sub.add_parser("fingerprint", help="fingerprint a deployment observation")
     fingerprint.add_argument("--observation", required=True, type=Path)
@@ -38,7 +41,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(fingerprint_observation(observation))
             return 0
 
-        result = establish_deployment_identity(observation)
+        result = establish_deployment_identity(
+            observation,
+            trusted_observer_ids=args.trusted_observer_id,
+            reference_time=args.reference_time,
+            max_age_seconds=args.max_age_seconds,
+        )
         print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False))
         return 0 if result["runtime_classification_authorized"] else 2
     except DeploymentIdentityError as exc:

--- a/deployment_identity/core.py
+++ b/deployment_identity/core.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
-from datetime import datetime
-from typing import Any, Mapping
+from datetime import datetime, timezone
+from typing import Any, Iterable, Mapping
 
 
 REQUIRED_FIELDS = (
@@ -13,15 +13,19 @@ REQUIRED_FIELDS = (
     "active_route_surface",
     "deployed_revision",
     "source_revision",
+    "observer_id",
+    "observation_session_id",
     "observed_at",
 )
 
 ESTABLISHED = "DEPLOYMENT_IDENTITY_ESTABLISHED"
 NOT_ESTABLISHED = "DEPLOYMENT_IDENTITY_NOT_ESTABLISHED"
+BOUND = "RUNTIME_OBSERVATION_BOUND"
+NOT_BOUND = "RUNTIME_OBSERVATION_NOT_BOUND"
 
 
 class DeploymentIdentityError(ValueError):
-    """Raised when a deployment observation cannot establish runtime identity."""
+    """Raised when deployment evidence cannot establish runtime identity."""
 
 
 def _canonical_json(value: Any) -> str:
@@ -29,7 +33,6 @@ def _canonical_json(value: Any) -> str:
 
 
 def fingerprint_observation(observation: Mapping[str, Any]) -> str:
-    """Return a deterministic SHA-256 fingerprint for an observation."""
     return hashlib.sha256(_canonical_json(dict(observation)).encode("utf-8")).hexdigest()
 
 
@@ -42,28 +45,67 @@ def _require_non_empty_string(observation: Mapping[str, Any], field: str) -> str
     return value
 
 
-def _validate_timestamp(value: str) -> None:
+def _parse_timestamp(value: str, field: str = "observed_at") -> datetime:
     normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
     try:
         parsed = datetime.fromisoformat(normalized)
     except ValueError as exc:
-        raise DeploymentIdentityError("observed_at must be an ISO-8601 timestamp") from exc
+        raise DeploymentIdentityError(f"{field} must be an ISO-8601 timestamp") from exc
     if parsed.tzinfo is None:
-        raise DeploymentIdentityError("observed_at must include a timezone")
+        raise DeploymentIdentityError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
 
 
-def establish_deployment_identity(observation: Mapping[str, Any]) -> dict[str, Any]:
-    """Validate and bind runtime identity to the expected source revision.
+def _trusted_observers(values: Iterable[str]) -> frozenset[str]:
+    trusted = frozenset(values)
+    if not trusted or any(not isinstance(v, str) or not v or v != v.strip() for v in trusted):
+        raise DeploymentIdentityError("trusted_observer_ids must contain exact non-empty ids")
+    return trusted
 
-    This function is deliberately read-only and fail-closed. It never infers
-    deployment identity from repository contents. Runtime identity must be
-    explicitly observed.
+
+def establish_deployment_identity(
+    observation: Mapping[str, Any],
+    *,
+    trusted_observer_ids: Iterable[str],
+    reference_time: str,
+    max_age_seconds: int = 300,
+) -> dict[str, Any]:
+    """Fail-closed deployment identity establishment.
+
+    v2 deliberately requires an external trust anchor (trusted_observer_ids) and
+    freshness reference. The observation cannot make itself trusted merely by
+    naming an observer. This is still an attestation boundary, not cryptographic
+    proof of host truth; privileged collection remains separately governed.
     """
     if not isinstance(observation, Mapping):
         raise DeploymentIdentityError("observation must be an object")
+    if not isinstance(max_age_seconds, int) or max_age_seconds < 0:
+        raise DeploymentIdentityError("max_age_seconds must be a non-negative integer")
 
     values = {field: _require_non_empty_string(observation, field) for field in REQUIRED_FIELDS}
-    _validate_timestamp(values["observed_at"])
+    observed_at = _parse_timestamp(values["observed_at"])
+    reference = _parse_timestamp(reference_time, "reference_time")
+    trusted = _trusted_observers(trusted_observer_ids)
+
+    if values["observer_id"] not in trusted:
+        return {
+            "status": NOT_ESTABLISHED,
+            "reason": "UNTRUSTED_OBSERVER",
+            "runtime_classification_authorized": False,
+            "observer_id": values["observer_id"],
+            "observation_fingerprint": fingerprint_observation(observation),
+        }
+
+    age = (reference - observed_at).total_seconds()
+    if age < 0 or age > max_age_seconds:
+        return {
+            "status": NOT_ESTABLISHED,
+            "reason": "STALE_OR_FUTURE_OBSERVATION",
+            "runtime_classification_authorized": False,
+            "age_seconds": age,
+            "max_age_seconds": max_age_seconds,
+            "observation_fingerprint": fingerprint_observation(observation),
+        }
 
     if values["deployed_revision"] != values["source_revision"]:
         return {
@@ -75,9 +117,10 @@ def establish_deployment_identity(observation: Mapping[str, Any]) -> dict[str, A
             "observation_fingerprint": fingerprint_observation(observation),
         }
 
+    fingerprint = fingerprint_observation(observation)
     return {
         "status": ESTABLISHED,
-        "reason": "EXPLICIT_RUNTIME_IDENTITY_MATCH",
+        "reason": "TRUSTED_FRESH_RUNTIME_IDENTITY_MATCH",
         "runtime_classification_authorized": True,
         "identity": {
             "service_unit": values["service_unit"],
@@ -85,7 +128,56 @@ def establish_deployment_identity(observation: Mapping[str, Any]) -> dict[str, A
             "executable_or_module": values["executable_or_module"],
             "active_route_surface": values["active_route_surface"],
             "revision": values["deployed_revision"],
+            "observer_id": values["observer_id"],
+            "observation_session_id": values["observation_session_id"],
             "observed_at": values["observed_at"],
         },
-        "observation_fingerprint": fingerprint_observation(observation),
+        "observation_fingerprint": fingerprint,
+    }
+
+
+def bind_runtime_observation(
+    deployment_proof: Mapping[str, Any],
+    runtime_observation: Mapping[str, Any],
+    *,
+    max_skew_seconds: int = 30,
+) -> dict[str, Any]:
+    """Bind a runtime observation to an established Deployment Identity proof."""
+    if not isinstance(deployment_proof, Mapping) or not isinstance(runtime_observation, Mapping):
+        raise DeploymentIdentityError("deployment proof and runtime observation must be objects")
+    if deployment_proof.get("status") != ESTABLISHED or not deployment_proof.get("runtime_classification_authorized"):
+        return {"status": NOT_BOUND, "reason": "DEPLOYMENT_IDENTITY_NOT_ESTABLISHED", "runtime_classification_authorized": False}
+    if not isinstance(max_skew_seconds, int) or max_skew_seconds < 0:
+        raise DeploymentIdentityError("max_skew_seconds must be a non-negative integer")
+
+    expected_fp = deployment_proof.get("observation_fingerprint")
+    supplied_fp = _require_non_empty_string(runtime_observation, "deployment_identity_fingerprint")
+    supplied_session = _require_non_empty_string(runtime_observation, "observation_session_id")
+    runtime_at_value = _require_non_empty_string(runtime_observation, "observed_at")
+    if supplied_fp != expected_fp:
+        return {"status": NOT_BOUND, "reason": "DEPLOYMENT_FINGERPRINT_MISMATCH", "runtime_classification_authorized": False}
+
+    identity = deployment_proof.get("identity")
+    if not isinstance(identity, Mapping) or supplied_session != identity.get("observation_session_id"):
+        return {"status": NOT_BOUND, "reason": "OBSERVATION_SESSION_MISMATCH", "runtime_classification_authorized": False}
+
+    deployment_at = _parse_timestamp(str(identity.get("observed_at")), "deployment_observed_at")
+    runtime_at = _parse_timestamp(runtime_at_value, "runtime_observed_at")
+    skew = (runtime_at - deployment_at).total_seconds()
+    if skew < 0 or skew > max_skew_seconds:
+        return {
+            "status": NOT_BOUND,
+            "reason": "RUNTIME_OBSERVATION_OUTSIDE_BINDING_WINDOW",
+            "runtime_classification_authorized": False,
+            "skew_seconds": skew,
+            "max_skew_seconds": max_skew_seconds,
+        }
+
+    return {
+        "status": BOUND,
+        "reason": "DEPLOYMENT_PROOF_BOUND_TO_RUNTIME_OBSERVATION",
+        "runtime_classification_authorized": True,
+        "deployment_identity_fingerprint": expected_fp,
+        "runtime_observation_fingerprint": fingerprint_observation(runtime_observation),
+        "observation_session_id": supplied_session,
     }

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -7,9 +7,12 @@ from pathlib import Path
 
 from deployment_identity.cli import main
 from deployment_identity.core import (
+    BOUND,
     DeploymentIdentityError,
     ESTABLISHED,
+    NOT_BOUND,
     NOT_ESTABLISHED,
+    bind_runtime_observation,
     establish_deployment_identity,
     fingerprint_observation,
 )
@@ -24,21 +27,55 @@ class DeploymentIdentityTests(unittest.TestCase):
             "active_route_surface": "POST /render",
             "deployed_revision": "abc123",
             "source_revision": "abc123",
+            "observer_id": "observer-prod-01",
+            "observation_session_id": "session-001",
             "observed_at": "2026-08-09T17:00:00+09:00",
         }
 
+    def establish(self, observation: dict | None = None, **kwargs):
+        return establish_deployment_identity(
+            observation or self.observation(),
+            trusted_observer_ids=kwargs.get("trusted_observer_ids", {"observer-prod-01"}),
+            reference_time=kwargs.get("reference_time", "2026-08-09T17:00:10+09:00"),
+            max_age_seconds=kwargs.get("max_age_seconds", 300),
+        )
+
+    def runtime_observation(self, proof: dict, observed_at: str = "2026-08-09T17:00:15+09:00") -> dict:
+        return {
+            "deployment_identity_fingerprint": proof["observation_fingerprint"],
+            "observation_session_id": "session-001",
+            "observed_at": observed_at,
+            "result": {"status": "ok"},
+        }
+
     def test_matching_explicit_identity_establishes_runtime_classification(self) -> None:
-        result = establish_deployment_identity(self.observation())
+        result = self.establish()
         self.assertEqual(result["status"], ESTABLISHED)
         self.assertTrue(result["runtime_classification_authorized"])
         self.assertEqual(result["identity"]["revision"], "abc123")
 
+    def test_untrusted_observer_cannot_self_authorize(self) -> None:
+        observation = self.observation()
+        observation["observer_id"] = "attacker-self-declared"
+        result = self.establish(observation)
+        self.assertEqual(result["status"], NOT_ESTABLISHED)
+        self.assertEqual(result["reason"], "UNTRUSTED_OBSERVER")
+        self.assertFalse(result["runtime_classification_authorized"])
+
+    def test_stale_observation_replay_fails_closed(self) -> None:
+        result = self.establish(reference_time="2026-08-09T17:10:01+09:00", max_age_seconds=300)
+        self.assertEqual(result["status"], NOT_ESTABLISHED)
+        self.assertEqual(result["reason"], "STALE_OR_FUTURE_OBSERVATION")
+
+    def test_future_observation_fails_closed(self) -> None:
+        result = self.establish(reference_time="2026-08-09T16:59:59+09:00")
+        self.assertEqual(result["reason"], "STALE_OR_FUTURE_OBSERVATION")
+
     def test_revision_mismatch_fails_closed(self) -> None:
         observation = self.observation()
         observation["deployed_revision"] = "stale456"
-        result = establish_deployment_identity(observation)
+        result = self.establish(observation)
         self.assertEqual(result["status"], NOT_ESTABLISHED)
-        self.assertFalse(result["runtime_classification_authorized"])
         self.assertEqual(result["reason"], "DEPLOYED_REVISION_MISMATCH")
 
     def test_revision_whitespace_is_rejected_not_normalized(self) -> None:
@@ -47,48 +84,70 @@ class DeploymentIdentityTests(unittest.TestCase):
                 observation = self.observation()
                 observation[field] = "abc123 "
                 with self.assertRaisesRegex(DeploymentIdentityError, "whitespace"):
-                    establish_deployment_identity(observation)
+                    self.establish(observation)
 
     def test_missing_runtime_surface_is_rejected(self) -> None:
         observation = self.observation()
         del observation["active_route_surface"]
         with self.assertRaisesRegex(DeploymentIdentityError, "active_route_surface"):
-            establish_deployment_identity(observation)
+            self.establish(observation)
 
-    def test_blank_runtime_fields_are_rejected(self) -> None:
-        for field in (
-            "service_unit",
-            "working_directory",
-            "executable_or_module",
-            "active_route_surface",
-            "deployed_revision",
-            "source_revision",
-            "observed_at",
-        ):
+    def test_missing_observer_or_session_is_rejected(self) -> None:
+        for field in ("observer_id", "observation_session_id"):
             with self.subTest(field=field):
                 observation = self.observation()
-                observation[field] = "  "
-                with self.assertRaises(DeploymentIdentityError):
-                    establish_deployment_identity(observation)
+                del observation[field]
+                with self.assertRaisesRegex(DeploymentIdentityError, field):
+                    self.establish(observation)
 
     def test_naive_timestamp_is_rejected(self) -> None:
         observation = self.observation()
         observation["observed_at"] = "2026-08-09T17:00:00"
         with self.assertRaisesRegex(DeploymentIdentityError, "timezone"):
-            establish_deployment_identity(observation)
+            self.establish(observation)
 
     def test_fingerprint_is_deterministic_and_order_independent(self) -> None:
         first = self.observation()
         second = dict(reversed(list(first.items())))
         self.assertEqual(fingerprint_observation(first), fingerprint_observation(second))
 
-    def test_cli_returns_nonzero_when_identity_is_not_established(self) -> None:
+    def test_runtime_observation_requires_exact_deployment_fingerprint(self) -> None:
+        proof = self.establish()
+        runtime = self.runtime_observation(proof)
+        runtime["deployment_identity_fingerprint"] = "forged"
+        result = bind_runtime_observation(proof, runtime)
+        self.assertEqual(result["status"], NOT_BOUND)
+        self.assertEqual(result["reason"], "DEPLOYMENT_FINGERPRINT_MISMATCH")
+
+    def test_runtime_observation_requires_same_session(self) -> None:
+        proof = self.establish()
+        runtime = self.runtime_observation(proof)
+        runtime["observation_session_id"] = "other-session"
+        result = bind_runtime_observation(proof, runtime)
+        self.assertEqual(result["reason"], "OBSERVATION_SESSION_MISMATCH")
+
+    def test_toctou_window_fails_closed(self) -> None:
+        proof = self.establish()
+        runtime = self.runtime_observation(proof, "2026-08-09T17:01:00+09:00")
+        result = bind_runtime_observation(proof, runtime, max_skew_seconds=30)
+        self.assertEqual(result["status"], NOT_BOUND)
+        self.assertEqual(result["reason"], "RUNTIME_OBSERVATION_OUTSIDE_BINDING_WINDOW")
+
+    def test_runtime_observation_binds_inside_window(self) -> None:
+        proof = self.establish()
+        result = bind_runtime_observation(proof, self.runtime_observation(proof), max_skew_seconds=30)
+        self.assertEqual(result["status"], BOUND)
+        self.assertTrue(result["runtime_classification_authorized"])
+
+    def test_cli_requires_trust_anchor_and_freshness(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             path = Path(temporary) / "observation.json"
-            observation = self.observation()
-            observation["deployed_revision"] = "wrong"
-            path.write_text(json.dumps(observation), encoding="utf-8")
-            self.assertEqual(main(["verify", "--observation", str(path)]), 2)
+            path.write_text(json.dumps(self.observation()), encoding="utf-8")
+            self.assertEqual(main([
+                "verify", "--observation", str(path),
+                "--trusted-observer-id", "observer-prod-01",
+                "--reference-time", "2026-08-09T17:00:10+09:00",
+            ]), 0)
 
     def test_code_existence_alone_cannot_establish_identity(self) -> None:
         source_only = {
@@ -96,7 +155,7 @@ class DeploymentIdentityTests(unittest.TestCase):
             "observed_at": "2026-08-09T17:00:00+09:00",
         }
         with self.assertRaises(DeploymentIdentityError):
-            establish_deployment_identity(source_only)
+            self.establish(source_only)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Applies the first Devil's Advocate gate to Deployment Identity.

Attacks addressed:
- self-declared observer authenticity
- stale/replayed or future-dated observations
- TOCTOU between deployment identity and runtime observation
- proof-chain bypass between Deployment Identity and Runtime Observation

v2 requires an externally supplied trusted observer set, freshness reference/window, observer/session identity, and explicit fingerprint/session/time binding into runtime observations.

Important boundary: this does NOT claim cryptographic host truth. Privileged collection, signatures/attestation, route-to-process verification, image/config/environment measurement, and distributed deployments remain separately governed work.

The goal is fail-closed responsibility, not an inflated proof claim.