### PR TITLE
Devil's Advocate hardening: Deployment Identity v3

### DIFF
--- a/deployment_identity/README.md
+++ b/deployment_identity/README.md
@@ -1,56 +1,52 @@
-# Deployment Identity v2
+# Deployment Identity v3
 
-Deployment Identity establishes what code and execution surface were actually active at observation time before RTS classifies runtime behavior.
+Deployment Identity establishes which runtime material and route set were actually active before RTS classifies runtime behavior.
 
 ## Invariant
 
 ```text
-Code existence != runtime evidence.
+Revision equality != runtime reality.
 ```
 
-A repository file, branch, or commit is source evidence only. Runtime implementation classification is forbidden until deployed identity is established from explicit, trusted, fresh observations.
+A matching Git commit is insufficient. Runtime identity also depends on the built artifact, configuration, environment, source-tree cleanliness, and the actual instances reachable from the active route.
 
-## Required deployment observation
+## External expectation
 
-A v2 observation identifies:
+The verifier now requires a caller-supplied `expected_deployment` object containing:
 
-- `service_unit`
-- `working_directory`
-- `executable_or_module`
-- `active_route_surface`
-- `deployed_revision`
 - `source_revision`
-- `observer_id`
-- `observation_session_id`
-- `observed_at`
+- `artifact_digest`
+- `config_fingerprint`
+- `environment_fingerprint`
 
-The verifier also requires an external trust anchor (`trusted_observer_ids`), a caller-supplied `reference_time`, and a bounded freshness window. An observation cannot make itself trusted by merely naming an observer.
+These values are not accepted from the runtime observation itself as the expected truth.
 
-## Fail-closed rules
+## Required runtime material
 
-Deployment identity is established only when:
+The observation must include:
 
-1. every required field is present exactly, without normalization of surrounding whitespace;
-2. `observer_id` is in the externally supplied trusted observer set;
-3. the observation is not future-dated or older than the allowed freshness window;
-4. `deployed_revision == source_revision` exactly.
+- service/unit, working directory, executable/module, active route surface;
+- deployed revision and artifact digest;
+- runtime config and environment fingerprints;
+- `source_tree_state`, which must be exactly `CLEAN`;
+- trusted observer/session/time evidence;
+- a non-empty `runtime_instances` set;
+- a non-empty `active_route_instance_ids` set.
 
-Otherwise runtime classification remains unauthorized.
+Every instance reachable through the active route must match the externally expected revision, artifact, config, and environment. Unknown route targets, duplicate instance identities, dirty source state, mixed blue/green workers, or material drift fail closed.
 
-## Runtime observation binding
+An observed but non-routed stale worker does not define the active route reality. The route set is the classification boundary.
 
-An established deployment proof is not enough by itself to classify a later runtime observation. The runtime observation must carry:
+## Proof chain
 
-- the exact Deployment Identity observation fingerprint;
-- the same `observation_session_id`;
-- a timezone-aware observation timestamp within the configured binding window.
-
-This closes the direct proof-chain bypass and bounds the TOCTOU interval:
+The Runtime Observation must bind both the observation fingerprint and the external expectation fingerprint, plus the same observation session and bounded time window.
 
 ```text
-Source Identity
-  -> trusted + fresh Deployment Identity
-  -> fingerprint/session-bound Runtime Observation
+Expected Source/Material
+  -> Trusted + Fresh Deployment Material Observation
+  -> Active Route Instance Set
+  -> observation + expectation fingerprints
+  -> Runtime Observation
   -> Outcome Evidence
 ```
 
@@ -59,17 +55,16 @@ Source Identity
 ```bash
 python -m deployment_identity.cli verify \
   --observation path/to/observation.json \
+  --expectation path/to/expected-deployment.json \
   --trusted-observer-id observer-prod-01 \
   --reference-time 2026-08-09T17:00:10+09:00 \
   --max-age-seconds 300
-
-python -m deployment_identity.cli fingerprint --observation path/to/observation.json
 ```
 
 ## Security boundary
 
-v2 deliberately does **not** claim cryptographic proof that a host observation is truthful. `trusted_observer_ids` is a policy trust anchor supplied from outside the observation. Privileged live-host collection, signatures/attestation, key management, route-to-process verification, container/image/config/environment measurement, and distributed deployment identity remain separately governed work.
+v3 still does **not** prove that the trusted observer or host cannot lie. It validates an externally anchored expectation against a fresh, policy-trusted runtime attestation and route set.
 
-Therefore v2 proves: **a trusted policy-recognized observer supplied a fresh, internally consistent deployment attestation and a later runtime observation is explicitly bound to it.** It does not prove the physical host cannot lie.
+Cryptographic host attestation, signed collector evidence, secret-safe config/environment measurement, reverse-proxy discovery, Kubernetes/service-mesh discovery, and privileged live-host collection remain separately governed work.
 
-The verifier remains deterministic, standard-library-only, read-only, and performs no network, shell, provider, deployment, or repository mutation.
+The verifier is deterministic, standard-library-only, read-only, and performs no network, shell, provider, deployment, or repository mutation.

--- a/deployment_identity/cli.py
+++ b/deployment_identity/cli.py
@@ -8,22 +8,23 @@ from typing import Sequence
 from .core import DeploymentIdentityError, establish_deployment_identity, fingerprint_observation
 
 
-def _read_observation(path: Path) -> dict:
+def _read_object(path: Path, label: str) -> dict:
     try:
         value = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        raise DeploymentIdentityError(f"cannot read observation: {path}") from exc
+        raise DeploymentIdentityError(f"cannot read {label}: {path}") from exc
     if not isinstance(value, dict):
-        raise DeploymentIdentityError("observation must be a JSON object")
+        raise DeploymentIdentityError(f"{label} must be a JSON object")
     return value
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="RTS Deployment Identity v2")
+    parser = argparse.ArgumentParser(description="RTS Deployment Identity v3")
     sub = parser.add_subparsers(dest="command", required=True)
 
     verify = sub.add_parser("verify", help="establish deployment identity")
     verify.add_argument("--observation", required=True, type=Path)
+    verify.add_argument("--expectation", required=True, type=Path)
     verify.add_argument("--trusted-observer-id", required=True, action="append")
     verify.add_argument("--reference-time", required=True)
     verify.add_argument("--max-age-seconds", type=int, default=300)
@@ -36,13 +37,15 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
     try:
-        observation = _read_observation(args.observation)
+        observation = _read_object(args.observation, "observation")
         if args.command == "fingerprint":
             print(fingerprint_observation(observation))
             return 0
 
+        expectation = _read_object(args.expectation, "expectation")
         result = establish_deployment_identity(
             observation,
+            expected_deployment=expectation,
             trusted_observer_ids=args.trusted_observer_id,
             reference_time=args.reference_time,
             max_age_seconds=args.max_age_seconds,

--- a/deployment_identity/core.py
+++ b/deployment_identity/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 from datetime import datetime, timezone
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Sequence
 
 
 REQUIRED_FIELDS = (
@@ -12,10 +12,28 @@ REQUIRED_FIELDS = (
     "executable_or_module",
     "active_route_surface",
     "deployed_revision",
-    "source_revision",
+    "deployed_artifact_digest",
+    "runtime_config_fingerprint",
+    "runtime_environment_fingerprint",
+    "source_tree_state",
     "observer_id",
     "observation_session_id",
     "observed_at",
+)
+
+EXPECTED_FIELDS = (
+    "source_revision",
+    "artifact_digest",
+    "config_fingerprint",
+    "environment_fingerprint",
+)
+
+INSTANCE_FIELDS = (
+    "instance_id",
+    "revision",
+    "artifact_digest",
+    "config_fingerprint",
+    "environment_fingerprint",
 )
 
 ESTABLISHED = "DEPLOYMENT_IDENTITY_ESTABLISHED"
@@ -36,13 +54,17 @@ def fingerprint_observation(observation: Mapping[str, Any]) -> str:
     return hashlib.sha256(_canonical_json(dict(observation)).encode("utf-8")).hexdigest()
 
 
-def _require_non_empty_string(observation: Mapping[str, Any], field: str) -> str:
-    value = observation.get(field)
-    if not isinstance(value, str) or not value.strip():
+def fingerprint_expectation(expectation: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(dict(expectation)).encode("utf-8")).hexdigest()
+
+
+def _require_non_empty_string(value: Mapping[str, Any], field: str) -> str:
+    field_value = value.get(field)
+    if not isinstance(field_value, str) or not field_value.strip():
         raise DeploymentIdentityError(f"missing or invalid required field: {field}")
-    if value != value.strip():
+    if field_value != field_value.strip():
         raise DeploymentIdentityError(f"surrounding whitespace is not allowed: {field}")
-    return value
+    return field_value
 
 
 def _parse_timestamp(value: str, field: str = "observed_at") -> datetime:
@@ -63,64 +85,136 @@ def _trusted_observers(values: Iterable[str]) -> frozenset[str]:
     return trusted
 
 
+def _validate_instances(observation: Mapping[str, Any]) -> tuple[dict[str, str], ...]:
+    raw = observation.get("runtime_instances")
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)) or not raw:
+        raise DeploymentIdentityError("runtime_instances must be a non-empty array")
+
+    seen: set[str] = set()
+    instances: list[dict[str, str]] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, Mapping):
+            raise DeploymentIdentityError(f"runtime_instances[{index}] must be an object")
+        normalized = {field: _require_non_empty_string(item, field) for field in INSTANCE_FIELDS}
+        instance_id = normalized["instance_id"]
+        if instance_id in seen:
+            raise DeploymentIdentityError(f"duplicate runtime instance id: {instance_id}")
+        seen.add(instance_id)
+        instances.append(normalized)
+    return tuple(instances)
+
+
+def _validate_route_instance_ids(observation: Mapping[str, Any], known_ids: set[str]) -> tuple[str, ...]:
+    raw = observation.get("active_route_instance_ids")
+    if not isinstance(raw, Sequence) or isinstance(raw, (str, bytes)) or not raw:
+        raise DeploymentIdentityError("active_route_instance_ids must be a non-empty array")
+    result: list[str] = []
+    seen: set[str] = set()
+    for index, item in enumerate(raw):
+        if not isinstance(item, str) or not item or item != item.strip():
+            raise DeploymentIdentityError(f"active_route_instance_ids[{index}] must be an exact non-empty string")
+        if item in seen:
+            raise DeploymentIdentityError(f"duplicate active route instance id: {item}")
+        if item not in known_ids:
+            raise DeploymentIdentityError(f"active route references unknown runtime instance: {item}")
+        seen.add(item)
+        result.append(item)
+    return tuple(result)
+
+
+def _not_established(reason: str, observation: Mapping[str, Any], **details: Any) -> dict[str, Any]:
+    return {
+        "status": NOT_ESTABLISHED,
+        "reason": reason,
+        "runtime_classification_authorized": False,
+        "observation_fingerprint": fingerprint_observation(observation),
+        **details,
+    }
+
+
 def establish_deployment_identity(
     observation: Mapping[str, Any],
     *,
+    expected_deployment: Mapping[str, Any],
     trusted_observer_ids: Iterable[str],
     reference_time: str,
     max_age_seconds: int = 300,
 ) -> dict[str, Any]:
     """Fail-closed deployment identity establishment.
 
-    v2 deliberately requires an external trust anchor (trusted_observer_ids) and
-    freshness reference. The observation cannot make itself trusted merely by
-    naming an observer. This is still an attestation boundary, not cryptographic
-    proof of host truth; privileged collection remains separately governed.
+    v3 separates externally expected deployment material from observed runtime
+    material. A matching revision alone is insufficient: source cleanliness,
+    artifact/config/environment identity, and every instance reachable from the
+    active route must agree with the expectation.
+
+    This remains an attestation boundary, not cryptographic host truth.
     """
     if not isinstance(observation, Mapping):
         raise DeploymentIdentityError("observation must be an object")
+    if not isinstance(expected_deployment, Mapping):
+        raise DeploymentIdentityError("expected_deployment must be an object")
     if not isinstance(max_age_seconds, int) or max_age_seconds < 0:
         raise DeploymentIdentityError("max_age_seconds must be a non-negative integer")
 
     values = {field: _require_non_empty_string(observation, field) for field in REQUIRED_FIELDS}
+    expected = {field: _require_non_empty_string(expected_deployment, field) for field in EXPECTED_FIELDS}
     observed_at = _parse_timestamp(values["observed_at"])
     reference = _parse_timestamp(reference_time, "reference_time")
     trusted = _trusted_observers(trusted_observer_ids)
 
+    instances = _validate_instances(observation)
+    instance_by_id = {item["instance_id"]: item for item in instances}
+    route_ids = _validate_route_instance_ids(observation, set(instance_by_id))
+
     if values["observer_id"] not in trusted:
-        return {
-            "status": NOT_ESTABLISHED,
-            "reason": "UNTRUSTED_OBSERVER",
-            "runtime_classification_authorized": False,
-            "observer_id": values["observer_id"],
-            "observation_fingerprint": fingerprint_observation(observation),
-        }
+        return _not_established("UNTRUSTED_OBSERVER", observation, observer_id=values["observer_id"])
 
     age = (reference - observed_at).total_seconds()
     if age < 0 or age > max_age_seconds:
-        return {
-            "status": NOT_ESTABLISHED,
-            "reason": "STALE_OR_FUTURE_OBSERVATION",
-            "runtime_classification_authorized": False,
-            "age_seconds": age,
-            "max_age_seconds": max_age_seconds,
-            "observation_fingerprint": fingerprint_observation(observation),
-        }
+        return _not_established(
+            "STALE_OR_FUTURE_OBSERVATION",
+            observation,
+            age_seconds=age,
+            max_age_seconds=max_age_seconds,
+        )
 
-    if values["deployed_revision"] != values["source_revision"]:
-        return {
-            "status": NOT_ESTABLISHED,
-            "reason": "DEPLOYED_REVISION_MISMATCH",
-            "runtime_classification_authorized": False,
-            "source_revision": values["source_revision"],
-            "deployed_revision": values["deployed_revision"],
-            "observation_fingerprint": fingerprint_observation(observation),
-        }
+    if values["source_tree_state"] != "CLEAN":
+        return _not_established("SOURCE_TREE_NOT_CLEAN", observation, source_tree_state=values["source_tree_state"])
+
+    material_pairs = (
+        ("deployed_revision", values["deployed_revision"], expected["source_revision"], "DEPLOYED_REVISION_MISMATCH"),
+        ("deployed_artifact_digest", values["deployed_artifact_digest"], expected["artifact_digest"], "ARTIFACT_DIGEST_MISMATCH"),
+        ("runtime_config_fingerprint", values["runtime_config_fingerprint"], expected["config_fingerprint"], "CONFIG_FINGERPRINT_MISMATCH"),
+        ("runtime_environment_fingerprint", values["runtime_environment_fingerprint"], expected["environment_fingerprint"], "ENVIRONMENT_FINGERPRINT_MISMATCH"),
+    )
+    for field, actual, wanted, reason in material_pairs:
+        if actual != wanted:
+            return _not_established(reason, observation, field=field, expected=wanted, observed=actual)
+
+    for instance_id in route_ids:
+        instance = instance_by_id[instance_id]
+        checks = (
+            ("revision", expected["source_revision"], "ROUTE_INSTANCE_REVISION_MISMATCH"),
+            ("artifact_digest", expected["artifact_digest"], "ROUTE_INSTANCE_ARTIFACT_MISMATCH"),
+            ("config_fingerprint", expected["config_fingerprint"], "ROUTE_INSTANCE_CONFIG_MISMATCH"),
+            ("environment_fingerprint", expected["environment_fingerprint"], "ROUTE_INSTANCE_ENVIRONMENT_MISMATCH"),
+        )
+        for field, wanted, reason in checks:
+            if instance[field] != wanted:
+                return _not_established(
+                    reason,
+                    observation,
+                    instance_id=instance_id,
+                    field=field,
+                    expected=wanted,
+                    observed=instance[field],
+                )
 
     fingerprint = fingerprint_observation(observation)
+    expectation_fp = fingerprint_expectation(expected_deployment)
     return {
         "status": ESTABLISHED,
-        "reason": "TRUSTED_FRESH_RUNTIME_IDENTITY_MATCH",
+        "reason": "TRUSTED_FRESH_RUNTIME_MATERIAL_MATCH",
         "runtime_classification_authorized": True,
         "identity": {
             "service_unit": values["service_unit"],
@@ -128,11 +222,17 @@ def establish_deployment_identity(
             "executable_or_module": values["executable_or_module"],
             "active_route_surface": values["active_route_surface"],
             "revision": values["deployed_revision"],
+            "artifact_digest": values["deployed_artifact_digest"],
+            "config_fingerprint": values["runtime_config_fingerprint"],
+            "environment_fingerprint": values["runtime_environment_fingerprint"],
+            "source_tree_state": values["source_tree_state"],
+            "active_route_instance_ids": list(route_ids),
             "observer_id": values["observer_id"],
             "observation_session_id": values["observation_session_id"],
             "observed_at": values["observed_at"],
         },
         "observation_fingerprint": fingerprint,
+        "expectation_fingerprint": expectation_fp,
     }
 
 
@@ -151,11 +251,15 @@ def bind_runtime_observation(
         raise DeploymentIdentityError("max_skew_seconds must be a non-negative integer")
 
     expected_fp = deployment_proof.get("observation_fingerprint")
+    expected_expectation_fp = deployment_proof.get("expectation_fingerprint")
     supplied_fp = _require_non_empty_string(runtime_observation, "deployment_identity_fingerprint")
+    supplied_expectation_fp = _require_non_empty_string(runtime_observation, "deployment_expectation_fingerprint")
     supplied_session = _require_non_empty_string(runtime_observation, "observation_session_id")
     runtime_at_value = _require_non_empty_string(runtime_observation, "observed_at")
     if supplied_fp != expected_fp:
         return {"status": NOT_BOUND, "reason": "DEPLOYMENT_FINGERPRINT_MISMATCH", "runtime_classification_authorized": False}
+    if supplied_expectation_fp != expected_expectation_fp:
+        return {"status": NOT_BOUND, "reason": "DEPLOYMENT_EXPECTATION_FINGERPRINT_MISMATCH", "runtime_classification_authorized": False}
 
     identity = deployment_proof.get("identity")
     if not isinstance(identity, Mapping) or supplied_session != identity.get("observation_session_id"):
@@ -178,6 +282,7 @@ def bind_runtime_observation(
         "reason": "DEPLOYMENT_PROOF_BOUND_TO_RUNTIME_OBSERVATION",
         "runtime_classification_authorized": True,
         "deployment_identity_fingerprint": expected_fp,
+        "deployment_expectation_fingerprint": expected_expectation_fp,
         "runtime_observation_fingerprint": fingerprint_observation(runtime_observation),
         "observation_session_id": supplied_session,
     }

--- a/docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md
+++ b/docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md
@@ -1,86 +1,79 @@
-# Deployment Identity v1 — Completion Task
+# Deployment Identity — Completion Contract through v3
 
 ## Problem
 
-RTS observation can misclassify stale or non-deployed source code as runtime reality.
+RTS must not classify source presence, matching revisions, or stale attestations as runtime reality.
 
-The governing invariant is:
+Governing invariants:
 
 ```text
 Code existence != runtime evidence.
+Revision equality != runtime reality.
 ```
 
-Runtime implementation classification MUST NOT occur until Deployment Identity is established.
+## v1 proof boundary
 
-## Required identity surface
+v1 established the minimum runtime subject: service/unit, working directory, executable/module, active surface, deployed revision, expected source revision, and timezone-aware observation time. Missing evidence failed closed.
 
-Deployment Identity v1 requires explicit evidence for:
+## Devil's Advocate v2
 
-1. service/unit/container/job identity;
-2. working directory;
-3. executable/module/entrypoint;
-4. active route/command/worker/interface surface;
-5. deployed commit/revision/image digest;
-6. expected source revision;
-7. timezone-aware observation timestamp.
+v2 closed three immediate bypasses:
 
-## Establishment rule
+- self-declared observer trust;
+- stale/replayed evidence and bounded TOCTOU;
+- runtime observation bypass of Deployment Identity.
 
-All required observations MUST be present.
+It requires an externally supplied trusted observer set, observer/session identity, freshness reference/window, and fingerprint/session/time binding into Runtime Observation.
 
-`deployed_revision` MUST exactly equal `source_revision`.
+## Devil's Advocate v3
 
-Only then may the verifier emit:
+v3 attacks the assumption that a matching commit implies an identical runtime.
 
-```text
-DEPLOYMENT_IDENTITY_ESTABLISHED
-runtime_classification_authorized: true
-```
+The expectation is now externally supplied and contains:
 
-Every missing field, invalid timestamp, or revision mismatch fails closed. No repository-path inference, branch-name inference, source-code existence, or best-effort guess may substitute for runtime observation.
+1. source revision;
+2. expected artifact digest;
+3. expected configuration fingerprint;
+4. expected environment fingerprint.
+
+The runtime observation additionally requires:
+
+1. deployed artifact digest;
+2. runtime configuration fingerprint;
+3. runtime environment fingerprint;
+4. exact `CLEAN` source-tree state;
+5. enumerated runtime instances;
+6. enumerated active-route instance ids.
+
+Every instance reachable from the active route MUST match the external expectation across revision, artifact, config, and environment. Unknown route targets, duplicate identities, dirty source state, mixed routed workers, or material mismatch fail closed.
 
 ## Evidence chain
 
 ```text
-Source Identity
-    -> Deployment Identity
-    -> Runtime Observation
+Expected Source / Material
+    -> Trusted + Fresh Deployment Observation
+    -> Active Route Instance Set
+    -> Observation + Expectation Fingerprints
+    -> Session/Time-Bound Runtime Observation
     -> Outcome Evidence
 ```
 
-Deployment Identity does not claim that an outcome is correct. It proves the runtime subject of the claim before outcome classification begins.
-
-## v1 implementation
-
-- `deployment_identity/core.py` — deterministic validator and fingerprinting
-- `deployment_identity/cli.py` — read-only verification CLI
-- `deployment_identity/README.md` — operator contract and boundary
-- `tests/test_deployment_identity.py` — fail-closed invariants
-
-## Prohibited behavior
-
-Deployment Identity v1 MUST NOT:
-
-- execute shell commands;
-- inspect a live host itself;
-- call a network or provider;
-- deploy or restart services;
-- mutate another repository;
-- infer deployment state from source presence;
-- authorize runtime classification after partial identity evidence.
-
-Those observations must be collected by a separately governed observer/adapter and supplied as evidence.
-
 ## Acceptance criteria
 
-- deterministic fingerprints;
-- exact revision binding;
-- missing identity fields fail closed;
-- mismatched source/deployed revision fails closed;
-- timezone-less observations fail closed;
-- code/source evidence alone cannot establish runtime identity;
-- successful proof explicitly authorizes runtime classification and nothing beyond it.
+- source existence alone cannot establish runtime identity;
+- a matching revision with dirty source state fails closed;
+- a matching revision with a different artifact fails closed;
+- config/environment drift fails closed;
+- the expected revision/material cannot be self-declared by the runtime observation;
+- every routed worker is measured against the same expectation;
+- an unknown route target fails closed;
+- a heterogeneous routed worker set fails closed;
+- runtime observation must bind both observation and expectation fingerprints;
+- replay/future evidence and oversized TOCTOU windows fail closed;
+- dedicated and full-repository test suites pass.
 
-## Completion boundary
+## Remaining boundary
 
-Deployment Identity v1 closes the previously observed classification gap at the proof boundary. It does not yet provide privileged live-host collection. Any future collector requires a separate authority, privacy, and execution-safety review.
+v3 remains an attestation validator, not cryptographic host truth. A trusted observer may still lie or be compromised. Reverse-proxy/service-mesh discovery, privileged host collection, signed evidence, key management, TPM/container attestation, and secret-safe material measurement require separate governed implementation and review.
+
+Deployment Identity authorizes runtime classification only. It does not prove outcome correctness and does not authorize deployment, mutation, publication, provider execution, or capability promotion.

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -19,6 +19,23 @@ from deployment_identity.core import (
 
 
 class DeploymentIdentityTests(unittest.TestCase):
+    def expectation(self) -> dict:
+        return {
+            "source_revision": "abc123",
+            "artifact_digest": "sha256:artifact-good",
+            "config_fingerprint": "sha256:config-good",
+            "environment_fingerprint": "sha256:env-good",
+        }
+
+    def instance(self, instance_id: str = "worker-1") -> dict:
+        return {
+            "instance_id": instance_id,
+            "revision": "abc123",
+            "artifact_digest": "sha256:artifact-good",
+            "config_fingerprint": "sha256:config-good",
+            "environment_fingerprint": "sha256:env-good",
+        }
+
     def observation(self) -> dict:
         return {
             "service_unit": "rts-video-flow-web.service",
@@ -26,7 +43,12 @@ class DeploymentIdentityTests(unittest.TestCase):
             "executable_or_module": "python -m app.web",
             "active_route_surface": "POST /render",
             "deployed_revision": "abc123",
-            "source_revision": "abc123",
+            "deployed_artifact_digest": "sha256:artifact-good",
+            "runtime_config_fingerprint": "sha256:config-good",
+            "runtime_environment_fingerprint": "sha256:env-good",
+            "source_tree_state": "CLEAN",
+            "runtime_instances": [self.instance()],
+            "active_route_instance_ids": ["worker-1"],
             "observer_id": "observer-prod-01",
             "observation_session_id": "session-001",
             "observed_at": "2026-08-09T17:00:00+09:00",
@@ -35,6 +57,7 @@ class DeploymentIdentityTests(unittest.TestCase):
     def establish(self, observation: dict | None = None, **kwargs):
         return establish_deployment_identity(
             observation or self.observation(),
+            expected_deployment=kwargs.get("expected_deployment", self.expectation()),
             trusted_observer_ids=kwargs.get("trusted_observer_ids", {"observer-prod-01"}),
             reference_time=kwargs.get("reference_time", "2026-08-09T17:00:10+09:00"),
             max_age_seconds=kwargs.get("max_age_seconds", 300),
@@ -43,95 +66,131 @@ class DeploymentIdentityTests(unittest.TestCase):
     def runtime_observation(self, proof: dict, observed_at: str = "2026-08-09T17:00:15+09:00") -> dict:
         return {
             "deployment_identity_fingerprint": proof["observation_fingerprint"],
+            "deployment_expectation_fingerprint": proof["expectation_fingerprint"],
             "observation_session_id": "session-001",
             "observed_at": observed_at,
             "result": {"status": "ok"},
         }
 
-    def test_matching_explicit_identity_establishes_runtime_classification(self) -> None:
+    def test_matching_material_and_route_set_establishes_identity(self) -> None:
         result = self.establish()
         self.assertEqual(result["status"], ESTABLISHED)
         self.assertTrue(result["runtime_classification_authorized"])
         self.assertEqual(result["identity"]["revision"], "abc123")
+        self.assertEqual(result["identity"]["active_route_instance_ids"], ["worker-1"])
 
     def test_untrusted_observer_cannot_self_authorize(self) -> None:
         observation = self.observation()
         observation["observer_id"] = "attacker-self-declared"
         result = self.establish(observation)
-        self.assertEqual(result["status"], NOT_ESTABLISHED)
         self.assertEqual(result["reason"], "UNTRUSTED_OBSERVER")
-        self.assertFalse(result["runtime_classification_authorized"])
 
-    def test_stale_observation_replay_fails_closed(self) -> None:
-        result = self.establish(reference_time="2026-08-09T17:10:01+09:00", max_age_seconds=300)
-        self.assertEqual(result["status"], NOT_ESTABLISHED)
-        self.assertEqual(result["reason"], "STALE_OR_FUTURE_OBSERVATION")
+    def test_stale_or_future_observation_fails_closed(self) -> None:
+        self.assertEqual(
+            self.establish(reference_time="2026-08-09T17:10:01+09:00", max_age_seconds=300)["reason"],
+            "STALE_OR_FUTURE_OBSERVATION",
+        )
+        self.assertEqual(
+            self.establish(reference_time="2026-08-09T16:59:59+09:00")["reason"],
+            "STALE_OR_FUTURE_OBSERVATION",
+        )
 
-    def test_future_observation_fails_closed(self) -> None:
-        result = self.establish(reference_time="2026-08-09T16:59:59+09:00")
-        self.assertEqual(result["reason"], "STALE_OR_FUTURE_OBSERVATION")
-
-    def test_revision_mismatch_fails_closed(self) -> None:
+    def test_dirty_source_tree_fails_even_when_revision_matches(self) -> None:
         observation = self.observation()
-        observation["deployed_revision"] = "stale456"
+        observation["source_tree_state"] = "DIRTY"
         result = self.establish(observation)
         self.assertEqual(result["status"], NOT_ESTABLISHED)
+        self.assertEqual(result["reason"], "SOURCE_TREE_NOT_CLEAN")
+
+    def test_same_revision_with_different_artifact_fails(self) -> None:
+        observation = self.observation()
+        observation["deployed_artifact_digest"] = "sha256:artifact-other"
+        result = self.establish(observation)
+        self.assertEqual(result["reason"], "ARTIFACT_DIGEST_MISMATCH")
+
+    def test_same_revision_with_different_config_fails(self) -> None:
+        observation = self.observation()
+        observation["runtime_config_fingerprint"] = "sha256:config-other"
+        result = self.establish(observation)
+        self.assertEqual(result["reason"], "CONFIG_FINGERPRINT_MISMATCH")
+
+    def test_same_revision_with_different_environment_fails(self) -> None:
+        observation = self.observation()
+        observation["runtime_environment_fingerprint"] = "sha256:env-other"
+        result = self.establish(observation)
+        self.assertEqual(result["reason"], "ENVIRONMENT_FINGERPRINT_MISMATCH")
+
+    def test_expectation_is_external_not_self_declared_source_revision(self) -> None:
+        expectation = self.expectation()
+        expectation["source_revision"] = "wanted999"
+        result = self.establish(expected_deployment=expectation)
         self.assertEqual(result["reason"], "DEPLOYED_REVISION_MISMATCH")
 
-    def test_revision_whitespace_is_rejected_not_normalized(self) -> None:
-        for field in ("deployed_revision", "source_revision"):
-            with self.subTest(field=field):
-                observation = self.observation()
-                observation[field] = "abc123 "
-                with self.assertRaisesRegex(DeploymentIdentityError, "whitespace"):
-                    self.establish(observation)
-
-    def test_missing_runtime_surface_is_rejected(self) -> None:
+    def test_reverse_proxy_route_cannot_reference_unknown_worker(self) -> None:
         observation = self.observation()
-        del observation["active_route_surface"]
-        with self.assertRaisesRegex(DeploymentIdentityError, "active_route_surface"):
+        observation["active_route_instance_ids"] = ["worker-not-observed"]
+        with self.assertRaisesRegex(DeploymentIdentityError, "unknown runtime instance"):
             self.establish(observation)
 
-    def test_missing_observer_or_session_is_rejected(self) -> None:
-        for field in ("observer_id", "observation_session_id"):
-            with self.subTest(field=field):
-                observation = self.observation()
-                del observation[field]
-                with self.assertRaisesRegex(DeploymentIdentityError, field):
-                    self.establish(observation)
-
-    def test_naive_timestamp_is_rejected(self) -> None:
+    def test_heterogeneous_routed_worker_revision_fails(self) -> None:
         observation = self.observation()
-        observation["observed_at"] = "2026-08-09T17:00:00"
-        with self.assertRaisesRegex(DeploymentIdentityError, "timezone"):
+        stale = self.instance("worker-2")
+        stale["revision"] = "old456"
+        observation["runtime_instances"].append(stale)
+        observation["active_route_instance_ids"] = ["worker-1", "worker-2"]
+        result = self.establish(observation)
+        self.assertEqual(result["reason"], "ROUTE_INSTANCE_REVISION_MISMATCH")
+        self.assertEqual(result["instance_id"], "worker-2")
+
+    def test_heterogeneous_routed_worker_artifact_fails(self) -> None:
+        observation = self.observation()
+        other = self.instance("worker-2")
+        other["artifact_digest"] = "sha256:other"
+        observation["runtime_instances"].append(other)
+        observation["active_route_instance_ids"] = ["worker-1", "worker-2"]
+        result = self.establish(observation)
+        self.assertEqual(result["reason"], "ROUTE_INSTANCE_ARTIFACT_MISMATCH")
+
+    def test_non_routed_old_worker_does_not_define_active_route_reality(self) -> None:
+        observation = self.observation()
+        stale = self.instance("worker-idle")
+        stale["revision"] = "old456"
+        observation["runtime_instances"].append(stale)
+        result = self.establish(observation)
+        self.assertEqual(result["status"], ESTABLISHED)
+
+    def test_duplicate_instance_ids_fail_closed(self) -> None:
+        observation = self.observation()
+        observation["runtime_instances"].append(self.instance("worker-1"))
+        with self.assertRaisesRegex(DeploymentIdentityError, "duplicate runtime instance"):
             self.establish(observation)
 
-    def test_fingerprint_is_deterministic_and_order_independent(self) -> None:
-        first = self.observation()
-        second = dict(reversed(list(first.items())))
-        self.assertEqual(fingerprint_observation(first), fingerprint_observation(second))
+    def test_runtime_observation_requires_both_observed_and_expected_material_fingerprints(self) -> None:
+        proof = self.establish()
+        runtime = self.runtime_observation(proof)
+        runtime["deployment_expectation_fingerprint"] = "forged"
+        result = bind_runtime_observation(proof, runtime)
+        self.assertEqual(result["status"], NOT_BOUND)
+        self.assertEqual(result["reason"], "DEPLOYMENT_EXPECTATION_FINGERPRINT_MISMATCH")
 
     def test_runtime_observation_requires_exact_deployment_fingerprint(self) -> None:
         proof = self.establish()
         runtime = self.runtime_observation(proof)
         runtime["deployment_identity_fingerprint"] = "forged"
         result = bind_runtime_observation(proof, runtime)
-        self.assertEqual(result["status"], NOT_BOUND)
         self.assertEqual(result["reason"], "DEPLOYMENT_FINGERPRINT_MISMATCH")
 
-    def test_runtime_observation_requires_same_session(self) -> None:
+    def test_runtime_observation_requires_same_session_and_time_window(self) -> None:
         proof = self.establish()
         runtime = self.runtime_observation(proof)
         runtime["observation_session_id"] = "other-session"
-        result = bind_runtime_observation(proof, runtime)
-        self.assertEqual(result["reason"], "OBSERVATION_SESSION_MISMATCH")
+        self.assertEqual(bind_runtime_observation(proof, runtime)["reason"], "OBSERVATION_SESSION_MISMATCH")
 
-    def test_toctou_window_fails_closed(self) -> None:
-        proof = self.establish()
         runtime = self.runtime_observation(proof, "2026-08-09T17:01:00+09:00")
-        result = bind_runtime_observation(proof, runtime, max_skew_seconds=30)
-        self.assertEqual(result["status"], NOT_BOUND)
-        self.assertEqual(result["reason"], "RUNTIME_OBSERVATION_OUTSIDE_BINDING_WINDOW")
+        self.assertEqual(
+            bind_runtime_observation(proof, runtime, max_skew_seconds=30)["reason"],
+            "RUNTIME_OBSERVATION_OUTSIDE_BINDING_WINDOW",
+        )
 
     def test_runtime_observation_binds_inside_window(self) -> None:
         proof = self.establish()
@@ -139,23 +198,31 @@ class DeploymentIdentityTests(unittest.TestCase):
         self.assertEqual(result["status"], BOUND)
         self.assertTrue(result["runtime_classification_authorized"])
 
-    def test_cli_requires_trust_anchor_and_freshness(self) -> None:
+    def test_cli_requires_external_expectation(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
-            path = Path(temporary) / "observation.json"
-            path.write_text(json.dumps(self.observation()), encoding="utf-8")
+            observation_path = Path(temporary) / "observation.json"
+            expectation_path = Path(temporary) / "expectation.json"
+            observation_path.write_text(json.dumps(self.observation()), encoding="utf-8")
+            expectation_path.write_text(json.dumps(self.expectation()), encoding="utf-8")
             self.assertEqual(main([
-                "verify", "--observation", str(path),
+                "verify", "--observation", str(observation_path),
+                "--expectation", str(expectation_path),
                 "--trusted-observer-id", "observer-prod-01",
                 "--reference-time", "2026-08-09T17:00:10+09:00",
             ]), 0)
 
     def test_code_existence_alone_cannot_establish_identity(self) -> None:
         source_only = {
-            "source_revision": "abc123",
+            "deployed_revision": "abc123",
             "observed_at": "2026-08-09T17:00:00+09:00",
         }
         with self.assertRaises(DeploymentIdentityError):
             self.establish(source_only)
+
+    def test_fingerprint_is_deterministic_and_order_independent(self) -> None:
+        first = self.observation()
+        second = dict(reversed(list(first.items())))
+        self.assertEqual(fingerprint_observation(first), fingerprint_observation(second))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Second adversarial hardening pass for Deployment Identity.

This attacks the assumption that a matching source revision proves runtime reality.

New fail-closed boundaries:
- external expected deployment material is separated from runtime observation
- dirty source tree is rejected even when revision matches
- deployed artifact digest must match expectation
- runtime config/environment fingerprints must match expectation
- runtime instances are explicitly enumerated
- active route targets must reference known observed instances
- every routed instance must match expected revision/artifact/config/environment
- runtime observation binds both observed identity and external expectation fingerprints

Attacks covered:
- dirty working tree under the same commit
- rebuilt or substituted artifact under the same commit
- config/environment drift
- reverse-proxy route to an unobserved worker
- blue/green or mixed-version routed worker set
- runtime observation detached from the expected deployment contract

Remaining boundary is stated explicitly: this is still attestation validation, not cryptographic host truth. Signed collection, TPM/container attestation, privileged route discovery, service-mesh/Kubernetes discovery, and secret-safe material measurement remain separate governed work.