### PR TITLE
Devil's Advocate hardening: collector provenance v5

### DIFF
--- a/deployment_identity/README.md
+++ b/deployment_identity/README.md
@@ -10,30 +10,33 @@ Revision equality != runtime reality.
 Material match != authorization.
 Single-observer trust != proof quorum.
 Attestor count != independent observation.
+Collector-declared domain != trusted independence.
 Shared observation path != independent provenance.
+Partial artifact coverage != runtime proof.
 ```
 
-A signed quorum over one observation is necessary but no longer sufficient. RTS now requires independent measured provenance for the route, process, routed instance set, and artifact.
+A signed quorum over one observation is necessary but no longer sufficient. RTS requires independent measured provenance for route, process, every routed instance, and every routed artifact.
+
+## Externally bound independence
+
+Collector independence is policy data, not collector self-description. The caller must provide both:
+
+- an external collector keyring; and
+- an external `collector_id -> trust_domain` map.
+
+A signed record whose claimed `trust_domain` disagrees with that external map fails closed. Reusing one `source_locator` across separate trust domains also fails closed.
 
 ## Provenance requirement
 
-At least two independent `trust_domain` paths are required by default. Every domain must independently cover:
+At least two policy-bound trust domains are required by default. Every domain must independently cover:
 
 ```text
 route -> process -> instance -> artifact
 ```
 
-Every provenance record is signed by an externally trusted collector key and binds the exact deployment observation fingerprint, expectation fingerprint, observation session and issue time. Every trust domain must cover every routed instance. Artifact measurements must agree with the authorized deployment material.
+Route measurements must identify the active route and complete routed-worker set. Process measurements must match the active executable/module. Every trust domain must measure every routed instance and the artifact digest for every routed instance.
 
-The following fail closed:
-
-- two collectors in the same trust domain pretending to be independent;
-- missing route/process/instance/artifact stages;
-- failure to cover every routed worker;
-- provenance for another observation, expectation, or session;
-- stale/future records;
-- unknown collectors or forged signatures;
-- artifact measurement drift.
+Every record also binds the exact deployment observation fingerprint, expectation fingerprint, observation session and issue time.
 
 ## Proof chain
 
@@ -43,9 +46,9 @@ Expected Source / Material
   -> Active Route Instance Set
   -> Non-authorizing Material Proof
   -> Signed Attestation Quorum
-  -> Independent Collector Provenance
-       route -> process -> instance -> artifact
-       across >= 2 trust domains
+  -> Externally Bound Independent Collector Provenance
+       route -> process -> every instance -> every artifact
+       across >= 2 policy trust domains
   -> Authorized Deployment Identity
   -> fingerprint/session/time-bound Runtime Observation
   -> Outcome Evidence
@@ -53,6 +56,6 @@ Expected Source / Material
 
 ## Security boundary
 
-v5 proves authenticated provenance diversity and consistency. It still does not prove physical truth against a substrate capable of deceiving every independent collector. Hardware-backed attestation, platform-native measured identity, privileged discovery, key lifecycle management and secret-safe environment measurement remain separately governed extensions.
+v5 proves authenticated provenance diversity, externally anchored independence, and complete routed-instance/artifact coverage. It still does not prove physical truth against a lower substrate capable of deceiving every independent collector. Hardware-backed attestation, platform-native measured identity, privileged discovery, key lifecycle management and secret-safe environment measurement remain separately governed extensions.
 
 The verifier itself remains deterministic and performs no network, shell, provider, deployment, or repository mutation.

--- a/deployment_identity/README.md
+++ b/deployment_identity/README.md
@@ -1,6 +1,6 @@
-# Deployment Identity v4
+# Deployment Identity v5
 
-Deployment Identity establishes which runtime material and route set were active before RTS classifies runtime behavior, then requires independent signed attestations before that classification authority is granted.
+Deployment Identity v5 adds independently sourced collector provenance before runtime classification can be authorized.
 
 ## Invariants
 
@@ -9,52 +9,31 @@ Code existence != runtime evidence.
 Revision equality != runtime reality.
 Material match != authorization.
 Single-observer trust != proof quorum.
+Attestor count != independent observation.
+Shared observation path != independent provenance.
 ```
 
-A matching Git revision is insufficient. Runtime identity also depends on artifact, configuration, environment, source-tree cleanliness, and the instances reachable from the active route. Even when all of those match, the lower-level material proof is deliberately non-authorizing until a signed attestation quorum is verified.
+A signed quorum over one observation is necessary but no longer sufficient. RTS now requires independent measured provenance for the route, process, routed instance set, and artifact.
 
-## External expectation
+## Provenance requirement
 
-The verifier requires a caller-supplied deployment expectation containing:
-
-- `source_revision`
-- `artifact_digest`
-- `config_fingerprint`
-- `environment_fingerprint`
-
-Expected truth is not accepted from the runtime observation itself.
-
-## Signed attestation quorum
-
-Final runtime classification authority requires at least two distinct trusted attestors by default. Each attestation signs the exact:
-
-- deployment observation fingerprint;
-- external expectation fingerprint;
-- observation session id;
-- attestation issue time.
-
-The current deterministic implementation uses HMAC-SHA256. The attestation keyring is supplied externally; no attestation secret is stored in this repository.
-
-A single attestor, duplicated attestor id, forged signature, unknown attestor, stale/future attestation, different observation, different expectation, or different session fails closed.
-
-## Authorization split
-
-`establish_deployment_identity(...)` performs the material proof only. A successful material match returns:
+At least two independent `trust_domain` paths are required by default. Every domain must independently cover:
 
 ```text
-material_match_verified: true
-runtime_classification_authorized: false
-reason: RUNTIME_MATERIAL_MATCH_ATTESTATION_REQUIRED
+route -> process -> instance -> artifact
 ```
 
-`establish_attested_deployment_identity(...)` verifies the independent signed quorum over that exact material proof. Only then may it emit:
+Every provenance record is signed by an externally trusted collector key and binds the exact deployment observation fingerprint, expectation fingerprint, observation session and issue time. Every trust domain must cover every routed instance. Artifact measurements must agree with the authorized deployment material.
 
-```text
-runtime_classification_authorized: true
-reason: SIGNED_MULTI_ATTESTOR_RUNTIME_MATERIAL_MATCH
-```
+The following fail closed:
 
-A Runtime Observation refuses to bind to a raw material proof that has not crossed the attestation boundary.
+- two collectors in the same trust domain pretending to be independent;
+- missing route/process/instance/artifact stages;
+- failure to cover every routed worker;
+- provenance for another observation, expectation, or session;
+- stale/future records;
+- unknown collectors or forged signatures;
+- artifact measurement drift.
 
 ## Proof chain
 
@@ -63,30 +42,17 @@ Expected Source / Material
   -> Fresh Deployment Material Observation
   -> Active Route Instance Set
   -> Non-authorizing Material Proof
-  -> Independent Signed Attestation Quorum
+  -> Signed Attestation Quorum
+  -> Independent Collector Provenance
+       route -> process -> instance -> artifact
+       across >= 2 trust domains
   -> Authorized Deployment Identity
   -> fingerprint/session/time-bound Runtime Observation
   -> Outcome Evidence
 ```
 
-## CLI
-
-```bash
-python -m deployment_identity.cli verify \
-  --observation path/to/observation.json \
-  --expectation path/to/expected-deployment.json \
-  --attestations path/to/attestations.json \
-  --attestation-keyring path/to/keyring.json \
-  --trusted-observer-id observer-prod-01 \
-  --reference-time 2026-08-09T17:00:10+09:00 \
-  --min-attestors 2 \
-  --max-age-seconds 300
-```
-
 ## Security boundary
 
-v4 proves authenticated agreement by independent policy-recognized attestors over one exact deployment claim. It does **not** prove physical host truth against colluding or jointly compromised collectors.
-
-The next hardening layer is independently collected route/process provenance and stronger measured attestation such as container/image platform evidence or hardware-backed mechanisms where available. Privileged collection, key lifecycle management, Kubernetes/service-mesh discovery, secret-safe environment measurement, and hardware roots of trust remain separately governed work.
+v5 proves authenticated provenance diversity and consistency. It still does not prove physical truth against a substrate capable of deceiving every independent collector. Hardware-backed attestation, platform-native measured identity, privileged discovery, key lifecycle management and secret-safe environment measurement remain separately governed extensions.
 
 The verifier itself remains deterministic and performs no network, shell, provider, deployment, or repository mutation.

--- a/deployment_identity/attestation.py
+++ b/deployment_identity/attestation.py
@@ -39,17 +39,7 @@ def compute_hmac_signature(material: Mapping[str, Any], secret: str) -> str:
     return hmac.new(secret.encode("utf-8"), _canonical_json(dict(material)).encode("utf-8"), hashlib.sha256).hexdigest()
 
 
-def verify_attestation_quorum(
-    attestations: Sequence[Mapping[str, Any]],
-    *,
-    trusted_keys: Mapping[str, str],
-    observation_fingerprint: str,
-    expectation_fingerprint: str,
-    observation_session_id: str,
-    reference_time: str,
-    max_age_seconds: int = 300,
-    min_attestors: int = 2,
-) -> dict[str, Any]:
+def verify_attestation_quorum(attestations: Sequence[Mapping[str, Any]], *, trusted_keys: Mapping[str, str], observation_fingerprint: str, expectation_fingerprint: str, observation_session_id: str, reference_time: str, max_age_seconds: int = 300, min_attestors: int = 2) -> dict[str, Any]:
     if not isinstance(attestations, Sequence) or isinstance(attestations, (str, bytes)):
         raise AttestationError("attestations must be an array")
     if not isinstance(trusted_keys, Mapping) or not trusted_keys:
@@ -58,25 +48,19 @@ def verify_attestation_quorum(
         raise AttestationError("min_attestors must be at least 2")
     if not isinstance(max_age_seconds, int) or max_age_seconds < 0:
         raise AttestationError("max_age_seconds must be a non-negative integer")
-
     reference = _parse_timestamp(reference_time, "reference_time")
     verified: list[str] = []
     seen: set[str] = set()
-
     for index, attestation in enumerate(attestations):
         if not isinstance(attestation, Mapping):
             raise AttestationError(f"attestations[{index}] must be an object")
-        required = (
-            "attestor_id", "observation_fingerprint", "expectation_fingerprint",
-            "observation_session_id", "issued_at", "signature",
-        )
+        required = ("attestor_id", "observation_fingerprint", "expectation_fingerprint", "observation_session_id", "issued_at", "signature")
         values: dict[str, str] = {}
         for field in required:
             value = attestation.get(field)
             if not isinstance(value, str) or not value or value != value.strip():
                 raise AttestationError(f"attestations[{index}].{field} must be an exact non-empty string")
             values[field] = value
-
         attestor_id = values["attestor_id"]
         if attestor_id in seen:
             raise AttestationError(f"duplicate attestor_id: {attestor_id}")
@@ -90,7 +74,6 @@ def verify_attestation_quorum(
             raise AttestationError(f"attestor {attestor_id} signed a different expectation")
         if values["observation_session_id"] != observation_session_id:
             raise AttestationError(f"attestor {attestor_id} signed a different session")
-
         issued = _parse_timestamp(values["issued_at"], f"attestations[{index}].issued_at")
         age = (reference - issued).total_seconds()
         if age < 0 or age > max_age_seconds:
@@ -99,70 +82,33 @@ def verify_attestation_quorum(
         if not hmac.compare_digest(values["signature"], expected_signature):
             raise AttestationError(f"invalid signature for attestor_id: {attestor_id}")
         verified.append(attestor_id)
-
     if len(verified) < min_attestors:
         raise AttestationError(f"attestation quorum not met: {len(verified)} < {min_attestors}")
-    return {
-        "status": "ATTESTATION_QUORUM_VERIFIED",
-        "verified_attestors": sorted(verified),
-        "attestor_count": len(verified),
-        "min_attestors": min_attestors,
-    }
+    return {"status": "ATTESTATION_QUORUM_VERIFIED", "verified_attestors": sorted(verified), "attestor_count": len(verified), "min_attestors": min_attestors}
 
 
-def establish_attested_deployment_identity(
-    observation: Mapping[str, Any],
-    *,
-    expected_deployment: Mapping[str, Any],
-    trusted_observer_ids: Sequence[str],
-    reference_time: str,
-    attestations: Sequence[Mapping[str, Any]],
-    trusted_attestation_keys: Mapping[str, str],
-    collector_provenance: Sequence[Mapping[str, Any]],
-    trusted_collector_keys: Mapping[str, str],
-    max_age_seconds: int = 300,
-    min_attestors: int = 2,
-    min_independent_domains: int = 2,
-) -> dict[str, Any]:
-    """Require material match, signed attestors, and independent measured provenance."""
-    proof = establish_deployment_identity(
-        observation,
-        expected_deployment=expected_deployment,
-        trusted_observer_ids=trusted_observer_ids,
-        reference_time=reference_time,
-        max_age_seconds=max_age_seconds,
-    )
+def establish_attested_deployment_identity(observation: Mapping[str, Any], *, expected_deployment: Mapping[str, Any], trusted_observer_ids: Sequence[str], reference_time: str, attestations: Sequence[Mapping[str, Any]], trusted_attestation_keys: Mapping[str, str], collector_provenance: Sequence[Mapping[str, Any]], trusted_collector_keys: Mapping[str, str], max_age_seconds: int = 300, min_attestors: int = 2, min_independent_domains: int = 2) -> dict[str, Any]:
+    proof = establish_deployment_identity(observation, expected_deployment=expected_deployment, trusted_observer_ids=trusted_observer_ids, reference_time=reference_time, max_age_seconds=max_age_seconds)
     if proof.get("status") != ESTABLISHED or not proof.get("material_match_verified"):
         return proof
-
     identity = proof.get("identity")
     if not isinstance(identity, Mapping):
         raise DeploymentIdentityError("established material proof is missing identity")
-
-    quorum = verify_attestation_quorum(
-        attestations,
-        trusted_keys=trusted_attestation_keys,
-        observation_fingerprint=str(proof["observation_fingerprint"]),
-        expectation_fingerprint=str(proof["expectation_fingerprint"]),
-        observation_session_id=str(identity["observation_session_id"]),
-        reference_time=reference_time,
-        max_age_seconds=max_age_seconds,
-        min_attestors=min_attestors,
-    )
-
+    quorum = verify_attestation_quorum(attestations, trusted_keys=trusted_attestation_keys, observation_fingerprint=str(proof["observation_fingerprint"]), expectation_fingerprint=str(proof["expectation_fingerprint"]), observation_session_id=str(identity["observation_session_id"]), reference_time=reference_time, max_age_seconds=max_age_seconds, min_attestors=min_attestors)
     provenance = verify_collector_provenance(
         collector_provenance,
         trusted_collector_keys=trusted_collector_keys,
         observation_fingerprint=str(proof["observation_fingerprint"]),
         expectation_fingerprint=str(proof["expectation_fingerprint"]),
         observation_session_id=str(identity["observation_session_id"]),
+        active_route_surface=str(identity["active_route_surface"]),
+        executable_or_module=str(identity["executable_or_module"]),
         active_route_instance_ids=identity["active_route_instance_ids"],
         expected_artifact_digest=str(identity["artifact_digest"]),
         reference_time=reference_time,
         max_age_seconds=max_age_seconds,
         min_independent_domains=min_independent_domains,
     )
-
     result = dict(proof)
     result["reason"] = "SIGNED_ATTESTATION_AND_INDEPENDENT_PROVENANCE_VERIFIED"
     result["runtime_classification_authorized"] = True

--- a/deployment_identity/attestation.py
+++ b/deployment_identity/attestation.py
@@ -87,7 +87,7 @@ def verify_attestation_quorum(attestations: Sequence[Mapping[str, Any]], *, trus
     return {"status": "ATTESTATION_QUORUM_VERIFIED", "verified_attestors": sorted(verified), "attestor_count": len(verified), "min_attestors": min_attestors}
 
 
-def establish_attested_deployment_identity(observation: Mapping[str, Any], *, expected_deployment: Mapping[str, Any], trusted_observer_ids: Sequence[str], reference_time: str, attestations: Sequence[Mapping[str, Any]], trusted_attestation_keys: Mapping[str, str], collector_provenance: Sequence[Mapping[str, Any]], trusted_collector_keys: Mapping[str, str], max_age_seconds: int = 300, min_attestors: int = 2, min_independent_domains: int = 2) -> dict[str, Any]:
+def establish_attested_deployment_identity(observation: Mapping[str, Any], *, expected_deployment: Mapping[str, Any], trusted_observer_ids: Sequence[str], reference_time: str, attestations: Sequence[Mapping[str, Any]], trusted_attestation_keys: Mapping[str, str], collector_provenance: Sequence[Mapping[str, Any]], trusted_collector_keys: Mapping[str, str], trusted_collector_domains: Mapping[str, str], max_age_seconds: int = 300, min_attestors: int = 2, min_independent_domains: int = 2) -> dict[str, Any]:
     proof = establish_deployment_identity(observation, expected_deployment=expected_deployment, trusted_observer_ids=trusted_observer_ids, reference_time=reference_time, max_age_seconds=max_age_seconds)
     if proof.get("status") != ESTABLISHED or not proof.get("material_match_verified"):
         return proof
@@ -98,6 +98,7 @@ def establish_attested_deployment_identity(observation: Mapping[str, Any], *, ex
     provenance = verify_collector_provenance(
         collector_provenance,
         trusted_collector_keys=trusted_collector_keys,
+        trusted_collector_domains=trusted_collector_domains,
         observation_fingerprint=str(proof["observation_fingerprint"]),
         expectation_fingerprint=str(proof["expectation_fingerprint"]),
         observation_session_id=str(identity["observation_session_id"]),

--- a/deployment_identity/attestation.py
+++ b/deployment_identity/attestation.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from typing import Any, Mapping, Sequence
 
 from .core import DeploymentIdentityError, ESTABLISHED, establish_deployment_identity
+from .provenance import verify_collector_provenance
 
 
 class AttestationError(ValueError):
@@ -49,11 +50,6 @@ def verify_attestation_quorum(
     max_age_seconds: int = 300,
     min_attestors: int = 2,
 ) -> dict[str, Any]:
-    """Verify independent signed attestations over one deployment claim.
-
-    This proves cryptographic origin/integrity and independent policy quorum. It
-    does not prove that a compromised collector measured physical host truth.
-    """
     if not isinstance(attestations, Sequence) or isinstance(attestations, (str, bytes)):
         raise AttestationError("attestations must be an array")
     if not isinstance(trusted_keys, Mapping) or not trusted_keys:
@@ -71,12 +67,8 @@ def verify_attestation_quorum(
         if not isinstance(attestation, Mapping):
             raise AttestationError(f"attestations[{index}] must be an object")
         required = (
-            "attestor_id",
-            "observation_fingerprint",
-            "expectation_fingerprint",
-            "observation_session_id",
-            "issued_at",
-            "signature",
+            "attestor_id", "observation_fingerprint", "expectation_fingerprint",
+            "observation_session_id", "issued_at", "signature",
         )
         values: dict[str, str] = {}
         for field in required:
@@ -89,7 +81,6 @@ def verify_attestation_quorum(
         if attestor_id in seen:
             raise AttestationError(f"duplicate attestor_id: {attestor_id}")
         seen.add(attestor_id)
-
         secret = trusted_keys.get(attestor_id)
         if not isinstance(secret, str) or not secret:
             raise AttestationError(f"untrusted attestor_id: {attestor_id}")
@@ -104,7 +95,6 @@ def verify_attestation_quorum(
         age = (reference - issued).total_seconds()
         if age < 0 or age > max_age_seconds:
             raise AttestationError(f"attestor {attestor_id} attestation is stale or future-dated")
-
         expected_signature = compute_hmac_signature(attestation_material(attestation), secret)
         if not hmac.compare_digest(values["signature"], expected_signature):
             raise AttestationError(f"invalid signature for attestor_id: {attestor_id}")
@@ -112,7 +102,6 @@ def verify_attestation_quorum(
 
     if len(verified) < min_attestors:
         raise AttestationError(f"attestation quorum not met: {len(verified)} < {min_attestors}")
-
     return {
         "status": "ATTESTATION_QUORUM_VERIFIED",
         "verified_attestors": sorted(verified),
@@ -129,15 +118,13 @@ def establish_attested_deployment_identity(
     reference_time: str,
     attestations: Sequence[Mapping[str, Any]],
     trusted_attestation_keys: Mapping[str, str],
+    collector_provenance: Sequence[Mapping[str, Any]],
+    trusted_collector_keys: Mapping[str, str],
     max_age_seconds: int = 300,
     min_attestors: int = 2,
+    min_independent_domains: int = 2,
 ) -> dict[str, Any]:
-    """Establish runtime material, then require independent signed quorum.
-
-    The lower-level material proof is deliberately non-authorizing. Final
-    runtime classification authority is granted only after the signed quorum
-    binds the exact observation, external expectation and observation session.
-    """
+    """Require material match, signed attestors, and independent measured provenance."""
     proof = establish_deployment_identity(
         observation,
         expected_deployment=expected_deployment,
@@ -162,8 +149,23 @@ def establish_attested_deployment_identity(
         max_age_seconds=max_age_seconds,
         min_attestors=min_attestors,
     )
+
+    provenance = verify_collector_provenance(
+        collector_provenance,
+        trusted_collector_keys=trusted_collector_keys,
+        observation_fingerprint=str(proof["observation_fingerprint"]),
+        expectation_fingerprint=str(proof["expectation_fingerprint"]),
+        observation_session_id=str(identity["observation_session_id"]),
+        active_route_instance_ids=identity["active_route_instance_ids"],
+        expected_artifact_digest=str(identity["artifact_digest"]),
+        reference_time=reference_time,
+        max_age_seconds=max_age_seconds,
+        min_independent_domains=min_independent_domains,
+    )
+
     result = dict(proof)
-    result["reason"] = "SIGNED_MULTI_ATTESTOR_RUNTIME_MATERIAL_MATCH"
+    result["reason"] = "SIGNED_ATTESTATION_AND_INDEPENDENT_PROVENANCE_VERIFIED"
     result["runtime_classification_authorized"] = True
     result["attestation_quorum"] = quorum
+    result["collector_provenance"] = provenance
     return result

--- a/deployment_identity/cli.py
+++ b/deployment_identity/cli.py
@@ -40,6 +40,7 @@ def build_parser() -> argparse.ArgumentParser:
     verify.add_argument("--attestation-keyring", required=True, type=Path)
     verify.add_argument("--collector-provenance", required=True, type=Path)
     verify.add_argument("--collector-keyring", required=True, type=Path)
+    verify.add_argument("--collector-domain-map", required=True, type=Path)
     verify.add_argument("--trusted-observer-id", required=True, action="append")
     verify.add_argument("--reference-time", required=True)
     verify.add_argument("--max-age-seconds", type=int, default=300)
@@ -66,6 +67,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             trusted_attestation_keys=_read_object(args.attestation_keyring, "attestation keyring"),
             collector_provenance=_read_array(args.collector_provenance, "collector provenance"),
             trusted_collector_keys=_read_object(args.collector_keyring, "collector keyring"),
+            trusted_collector_domains=_read_object(args.collector_domain_map, "collector domain map"),
             max_age_seconds=args.max_age_seconds,
             min_attestors=args.min_attestors,
             min_independent_domains=args.min_independent_domains,

--- a/deployment_identity/cli.py
+++ b/deployment_identity/cli.py
@@ -7,6 +7,7 @@ from typing import Sequence
 
 from .attestation import AttestationError, establish_attested_deployment_identity
 from .core import DeploymentIdentityError, fingerprint_observation
+from .provenance import ProvenanceError
 
 
 def _read_object(path: Path, label: str) -> dict:
@@ -30,19 +31,20 @@ def _read_array(path: Path, label: str) -> list[dict]:
 
 
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="RTS Deployment Identity v4")
+    parser = argparse.ArgumentParser(description="RTS Deployment Identity v5")
     sub = parser.add_subparsers(dest="command", required=True)
-
-    verify = sub.add_parser("verify", help="establish attested deployment identity")
+    verify = sub.add_parser("verify", help="establish provenance-backed deployment identity")
     verify.add_argument("--observation", required=True, type=Path)
     verify.add_argument("--expectation", required=True, type=Path)
     verify.add_argument("--attestations", required=True, type=Path)
     verify.add_argument("--attestation-keyring", required=True, type=Path)
+    verify.add_argument("--collector-provenance", required=True, type=Path)
+    verify.add_argument("--collector-keyring", required=True, type=Path)
     verify.add_argument("--trusted-observer-id", required=True, action="append")
     verify.add_argument("--reference-time", required=True)
     verify.add_argument("--max-age-seconds", type=int, default=300)
     verify.add_argument("--min-attestors", type=int, default=2)
-
+    verify.add_argument("--min-independent-domains", type=int, default=2)
     fingerprint = sub.add_parser("fingerprint", help="fingerprint a deployment observation")
     fingerprint.add_argument("--observation", required=True, type=Path)
     return parser
@@ -55,31 +57,23 @@ def main(argv: Sequence[str] | None = None) -> int:
         if args.command == "fingerprint":
             print(fingerprint_observation(observation))
             return 0
-
-        expectation = _read_object(args.expectation, "expectation")
-        attestations = _read_array(args.attestations, "attestations")
-        keyring = _read_object(args.attestation_keyring, "attestation keyring")
-        if any(not isinstance(k, str) or not isinstance(v, str) for k, v in keyring.items()):
-            raise DeploymentIdentityError("attestation keyring must map string ids to string secrets")
-
         result = establish_attested_deployment_identity(
             observation,
-            expected_deployment=expectation,
+            expected_deployment=_read_object(args.expectation, "expectation"),
             trusted_observer_ids=args.trusted_observer_id,
             reference_time=args.reference_time,
-            attestations=attestations,
-            trusted_attestation_keys=keyring,
+            attestations=_read_array(args.attestations, "attestations"),
+            trusted_attestation_keys=_read_object(args.attestation_keyring, "attestation keyring"),
+            collector_provenance=_read_array(args.collector_provenance, "collector provenance"),
+            trusted_collector_keys=_read_object(args.collector_keyring, "collector keyring"),
             max_age_seconds=args.max_age_seconds,
             min_attestors=args.min_attestors,
+            min_independent_domains=args.min_independent_domains,
         )
         print(json.dumps(result, indent=2, sort_keys=True, ensure_ascii=False))
         return 0 if result["runtime_classification_authorized"] else 2
-    except (DeploymentIdentityError, AttestationError) as exc:
-        print(json.dumps({
-            "status": "DEPLOYMENT_IDENTITY_NOT_ESTABLISHED",
-            "runtime_classification_authorized": False,
-            "error": str(exc),
-        }, sort_keys=True))
+    except (DeploymentIdentityError, AttestationError, ProvenanceError) as exc:
+        print(json.dumps({"status": "DEPLOYMENT_IDENTITY_NOT_ESTABLISHED", "runtime_classification_authorized": False, "error": str(exc)}, sort_keys=True))
         return 2
 
 

--- a/deployment_identity/provenance.py
+++ b/deployment_identity/provenance.py
@@ -40,6 +40,7 @@ def verify_collector_provenance(
     records: Sequence[Mapping[str, Any]],
     *,
     trusted_collector_keys: Mapping[str, str],
+    trusted_collector_domains: Mapping[str, str],
     observation_fingerprint: str,
     expectation_fingerprint: str,
     observation_session_id: str,
@@ -51,11 +52,12 @@ def verify_collector_provenance(
     max_age_seconds: int = 300,
     min_independent_domains: int = 2,
 ) -> dict[str, Any]:
-    """Verify independently sourced route/process/instance/artifact provenance."""
     if not isinstance(records, Sequence) or isinstance(records, (str, bytes)) or not records:
         raise ProvenanceError("collector provenance must be a non-empty array")
     if not isinstance(trusted_collector_keys, Mapping) or not trusted_collector_keys:
         raise ProvenanceError("trusted_collector_keys must be a non-empty mapping")
+    if not isinstance(trusted_collector_domains, Mapping) or not trusted_collector_domains:
+        raise ProvenanceError("trusted_collector_domains must be a non-empty mapping")
     if not isinstance(min_independent_domains, int) or min_independent_domains < 2:
         raise ProvenanceError("min_independent_domains must be at least 2")
     if not isinstance(max_age_seconds, int) or max_age_seconds < 0:
@@ -69,10 +71,10 @@ def verify_collector_provenance(
 
     reference = _parse_timestamp(reference_time, "reference_time")
     seen_record_ids: set[str] = set()
-    collector_domain: dict[str, str] = {}
     source_domain: dict[str, str] = {}
     domain_stages: dict[str, set[str]] = {}
     domain_instances: dict[str, set[str]] = {}
+    domain_artifacts: dict[str, set[str]] = {}
     verified_records: list[str] = []
 
     for index, record in enumerate(records):
@@ -96,15 +98,18 @@ def verify_collector_provenance(
         seen_record_ids.add(record_id)
 
         collector_id = values["collector_id"]
-        domain = values["trust_domain"]
+        claimed_domain = values["trust_domain"]
         source_locator = values["source_locator"]
         secret = trusted_collector_keys.get(collector_id)
         if not isinstance(secret, str) or not secret:
             raise ProvenanceError(f"untrusted collector_id: {collector_id}")
+        policy_domain = trusted_collector_domains.get(collector_id)
+        if not isinstance(policy_domain, str) or not policy_domain:
+            raise ProvenanceError(f"collector {collector_id} has no externally trusted domain binding")
+        if claimed_domain != policy_domain:
+            raise ProvenanceError(f"collector {collector_id} claimed trust domain {claimed_domain} but policy binds {policy_domain}")
+        domain = policy_domain
 
-        previous_domain = collector_domain.setdefault(collector_id, domain)
-        if previous_domain != domain:
-            raise ProvenanceError(f"collector {collector_id} cannot claim multiple trust domains")
         previous_source_domain = source_domain.setdefault(source_locator, domain)
         if previous_source_domain != domain:
             raise ProvenanceError(f"source locator {source_locator} is shared across trust domains")
@@ -141,6 +146,7 @@ def verify_collector_provenance(
         elif stage == "artifact":
             if values["subject_id"] not in expected_instances or values["observed_value"] != expected_artifact_digest:
                 raise ProvenanceError(f"collector {collector_id} artifact measurement mismatch")
+            domain_artifacts.setdefault(domain, set()).add(values["subject_id"])
 
         verified_records.append(record_id)
 
@@ -152,6 +158,8 @@ def verify_collector_provenance(
             raise ProvenanceError(f"trust domain {domain} missing measurement stages: {sorted(missing)}")
         if domain_instances.get(domain, set()) != expected_instances:
             raise ProvenanceError(f"trust domain {domain} did not independently cover every routed instance")
+        if domain_artifacts.get(domain, set()) != expected_instances:
+            raise ProvenanceError(f"trust domain {domain} did not independently measure artifact for every routed instance")
 
     return {
         "status": "COLLECTOR_PROVENANCE_VERIFIED",

--- a/deployment_identity/provenance.py
+++ b/deployment_identity/provenance.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping, Sequence
+
+
+class ProvenanceError(ValueError):
+    """Raised when measured collector provenance cannot establish independent paths."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def _parse_timestamp(value: str, field: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise ProvenanceError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise ProvenanceError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def provenance_material(record: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in record.items() if key != "signature"}
+
+
+def compute_provenance_signature(material: Mapping[str, Any], secret: str) -> str:
+    if not isinstance(secret, str) or not secret:
+        raise ProvenanceError("collector secret must be a non-empty string")
+    return hmac.new(secret.encode("utf-8"), _canonical_json(dict(material)).encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def verify_collector_provenance(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    trusted_collector_keys: Mapping[str, str],
+    observation_fingerprint: str,
+    expectation_fingerprint: str,
+    observation_session_id: str,
+    active_route_instance_ids: Sequence[str],
+    expected_artifact_digest: str,
+    reference_time: str,
+    max_age_seconds: int = 300,
+    min_independent_domains: int = 2,
+) -> dict[str, Any]:
+    """Verify signed, independently sourced route/process/instance/artifact provenance.
+
+    Each trust domain must independently cover the same four measurement stages:
+    route -> process -> instance -> artifact. Records bind the exact deployment
+    observation, expectation and session. This validates provenance diversity and
+    consistency; it does not prove a jointly compromised substrate cannot lie.
+    """
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)) or not records:
+        raise ProvenanceError("collector provenance must be a non-empty array")
+    if not isinstance(trusted_collector_keys, Mapping) or not trusted_collector_keys:
+        raise ProvenanceError("trusted_collector_keys must be a non-empty mapping")
+    if not isinstance(min_independent_domains, int) or min_independent_domains < 2:
+        raise ProvenanceError("min_independent_domains must be at least 2")
+    if not isinstance(max_age_seconds, int) or max_age_seconds < 0:
+        raise ProvenanceError("max_age_seconds must be a non-negative integer")
+
+    required_stages = {"route", "process", "instance", "artifact"}
+    expected_instances = set(active_route_instance_ids)
+    if not expected_instances:
+        raise ProvenanceError("active_route_instance_ids must be non-empty")
+
+    reference = _parse_timestamp(reference_time, "reference_time")
+    seen_record_ids: set[str] = set()
+    collector_domains: dict[str, set[str]] = {}
+    domain_stages: dict[str, set[str]] = {}
+    domain_instances: dict[str, set[str]] = {}
+    verified_records: list[str] = []
+
+    for index, record in enumerate(records):
+        if not isinstance(record, Mapping):
+            raise ProvenanceError(f"collector_provenance[{index}] must be an object")
+        required = (
+            "record_id",
+            "collector_id",
+            "trust_domain",
+            "source_locator",
+            "measurement_stage",
+            "subject_id",
+            "observed_value",
+            "observation_fingerprint",
+            "expectation_fingerprint",
+            "observation_session_id",
+            "issued_at",
+            "signature",
+        )
+        values: dict[str, str] = {}
+        for field in required:
+            value = record.get(field)
+            if not isinstance(value, str) or not value or value != value.strip():
+                raise ProvenanceError(f"collector_provenance[{index}].{field} must be an exact non-empty string")
+            values[field] = value
+
+        record_id = values["record_id"]
+        if record_id in seen_record_ids:
+            raise ProvenanceError(f"duplicate provenance record_id: {record_id}")
+        seen_record_ids.add(record_id)
+
+        collector_id = values["collector_id"]
+        secret = trusted_collector_keys.get(collector_id)
+        if not isinstance(secret, str) or not secret:
+            raise ProvenanceError(f"untrusted collector_id: {collector_id}")
+        if values["observation_fingerprint"] != observation_fingerprint:
+            raise ProvenanceError(f"collector {collector_id} measured a different observation")
+        if values["expectation_fingerprint"] != expectation_fingerprint:
+            raise ProvenanceError(f"collector {collector_id} measured a different expectation")
+        if values["observation_session_id"] != observation_session_id:
+            raise ProvenanceError(f"collector {collector_id} measured a different session")
+
+        stage = values["measurement_stage"]
+        if stage not in required_stages:
+            raise ProvenanceError(f"unsupported measurement_stage: {stage}")
+
+        issued = _parse_timestamp(values["issued_at"], f"collector_provenance[{index}].issued_at")
+        age = (reference - issued).total_seconds()
+        if age < 0 or age > max_age_seconds:
+            raise ProvenanceError(f"collector {collector_id} provenance is stale or future-dated")
+
+        expected_signature = compute_provenance_signature(provenance_material(record), secret)
+        if not hmac.compare_digest(values["signature"], expected_signature):
+            raise ProvenanceError(f"invalid provenance signature for collector_id: {collector_id}")
+
+        domain = values["trust_domain"]
+        collector_domains.setdefault(domain, set()).add(collector_id)
+        domain_stages.setdefault(domain, set()).add(stage)
+
+        if stage == "instance":
+            if values["subject_id"] not in expected_instances:
+                raise ProvenanceError(f"collector {collector_id} referenced non-routed instance: {values['subject_id']}")
+            domain_instances.setdefault(domain, set()).add(values["subject_id"])
+        elif stage == "artifact":
+            if values["observed_value"] != expected_artifact_digest:
+                raise ProvenanceError(f"collector {collector_id} artifact measurement mismatch")
+
+        verified_records.append(record_id)
+
+    if len(domain_stages) < min_independent_domains:
+        raise ProvenanceError(
+            f"independent provenance domain quorum not met: {len(domain_stages)} < {min_independent_domains}"
+        )
+
+    for domain, stages in domain_stages.items():
+        missing = required_stages - stages
+        if missing:
+            raise ProvenanceError(f"trust domain {domain} missing measurement stages: {sorted(missing)}")
+        if domain_instances.get(domain, set()) != expected_instances:
+            raise ProvenanceError(f"trust domain {domain} did not independently cover every routed instance")
+
+    return {
+        "status": "COLLECTOR_PROVENANCE_VERIFIED",
+        "verified_record_ids": sorted(verified_records),
+        "verified_trust_domains": sorted(domain_stages),
+        "independent_domain_count": len(domain_stages),
+        "min_independent_domains": min_independent_domains,
+    }

--- a/deployment_identity/provenance.py
+++ b/deployment_identity/provenance.py
@@ -43,19 +43,15 @@ def verify_collector_provenance(
     observation_fingerprint: str,
     expectation_fingerprint: str,
     observation_session_id: str,
+    active_route_surface: str,
+    executable_or_module: str,
     active_route_instance_ids: Sequence[str],
     expected_artifact_digest: str,
     reference_time: str,
     max_age_seconds: int = 300,
     min_independent_domains: int = 2,
 ) -> dict[str, Any]:
-    """Verify signed, independently sourced route/process/instance/artifact provenance.
-
-    Each trust domain must independently cover the same four measurement stages:
-    route -> process -> instance -> artifact. Records bind the exact deployment
-    observation, expectation and session. This validates provenance diversity and
-    consistency; it does not prove a jointly compromised substrate cannot lie.
-    """
+    """Verify independently sourced route/process/instance/artifact provenance."""
     if not isinstance(records, Sequence) or isinstance(records, (str, bytes)) or not records:
         raise ProvenanceError("collector provenance must be a non-empty array")
     if not isinstance(trusted_collector_keys, Mapping) or not trusted_collector_keys:
@@ -67,12 +63,14 @@ def verify_collector_provenance(
 
     required_stages = {"route", "process", "instance", "artifact"}
     expected_instances = set(active_route_instance_ids)
+    expected_route_value = ",".join(sorted(expected_instances))
     if not expected_instances:
         raise ProvenanceError("active_route_instance_ids must be non-empty")
 
     reference = _parse_timestamp(reference_time, "reference_time")
     seen_record_ids: set[str] = set()
-    collector_domains: dict[str, set[str]] = {}
+    collector_domain: dict[str, str] = {}
+    source_domain: dict[str, str] = {}
     domain_stages: dict[str, set[str]] = {}
     domain_instances: dict[str, set[str]] = {}
     verified_records: list[str] = []
@@ -81,18 +79,9 @@ def verify_collector_provenance(
         if not isinstance(record, Mapping):
             raise ProvenanceError(f"collector_provenance[{index}] must be an object")
         required = (
-            "record_id",
-            "collector_id",
-            "trust_domain",
-            "source_locator",
-            "measurement_stage",
-            "subject_id",
-            "observed_value",
-            "observation_fingerprint",
-            "expectation_fingerprint",
-            "observation_session_id",
-            "issued_at",
-            "signature",
+            "record_id", "collector_id", "trust_domain", "source_locator", "measurement_stage",
+            "subject_id", "observed_value", "observation_fingerprint", "expectation_fingerprint",
+            "observation_session_id", "issued_at", "signature",
         )
         values: dict[str, str] = {}
         for field in required:
@@ -107,9 +96,19 @@ def verify_collector_provenance(
         seen_record_ids.add(record_id)
 
         collector_id = values["collector_id"]
+        domain = values["trust_domain"]
+        source_locator = values["source_locator"]
         secret = trusted_collector_keys.get(collector_id)
         if not isinstance(secret, str) or not secret:
             raise ProvenanceError(f"untrusted collector_id: {collector_id}")
+
+        previous_domain = collector_domain.setdefault(collector_id, domain)
+        if previous_domain != domain:
+            raise ProvenanceError(f"collector {collector_id} cannot claim multiple trust domains")
+        previous_source_domain = source_domain.setdefault(source_locator, domain)
+        if previous_source_domain != domain:
+            raise ProvenanceError(f"source locator {source_locator} is shared across trust domains")
+
         if values["observation_fingerprint"] != observation_fingerprint:
             raise ProvenanceError(f"collector {collector_id} measured a different observation")
         if values["expectation_fingerprint"] != expectation_fingerprint:
@@ -120,35 +119,33 @@ def verify_collector_provenance(
         stage = values["measurement_stage"]
         if stage not in required_stages:
             raise ProvenanceError(f"unsupported measurement_stage: {stage}")
-
         issued = _parse_timestamp(values["issued_at"], f"collector_provenance[{index}].issued_at")
         age = (reference - issued).total_seconds()
         if age < 0 or age > max_age_seconds:
             raise ProvenanceError(f"collector {collector_id} provenance is stale or future-dated")
-
         expected_signature = compute_provenance_signature(provenance_material(record), secret)
         if not hmac.compare_digest(values["signature"], expected_signature):
             raise ProvenanceError(f"invalid provenance signature for collector_id: {collector_id}")
 
-        domain = values["trust_domain"]
-        collector_domains.setdefault(domain, set()).add(collector_id)
         domain_stages.setdefault(domain, set()).add(stage)
-
-        if stage == "instance":
-            if values["subject_id"] not in expected_instances:
-                raise ProvenanceError(f"collector {collector_id} referenced non-routed instance: {values['subject_id']}")
+        if stage == "route":
+            if values["subject_id"] != active_route_surface or values["observed_value"] != expected_route_value:
+                raise ProvenanceError(f"collector {collector_id} route measurement mismatch")
+        elif stage == "process":
+            if values["observed_value"] != executable_or_module:
+                raise ProvenanceError(f"collector {collector_id} process measurement mismatch")
+        elif stage == "instance":
+            if values["subject_id"] not in expected_instances or values["observed_value"] != values["subject_id"]:
+                raise ProvenanceError(f"collector {collector_id} referenced non-routed or mismatched instance")
             domain_instances.setdefault(domain, set()).add(values["subject_id"])
         elif stage == "artifact":
-            if values["observed_value"] != expected_artifact_digest:
+            if values["subject_id"] not in expected_instances or values["observed_value"] != expected_artifact_digest:
                 raise ProvenanceError(f"collector {collector_id} artifact measurement mismatch")
 
         verified_records.append(record_id)
 
     if len(domain_stages) < min_independent_domains:
-        raise ProvenanceError(
-            f"independent provenance domain quorum not met: {len(domain_stages)} < {min_independent_domains}"
-        )
-
+        raise ProvenanceError(f"independent provenance domain quorum not met: {len(domain_stages)} < {min_independent_domains}")
     for domain, stages in domain_stages.items():
         missing = required_stages - stages
         if missing:

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -33,9 +33,10 @@ class DeploymentIdentityTests(unittest.TestCase):
     def provenance(self, observation=None, expectation=None, same_domain=False):
         observation=observation or self.observation(); expectation=expectation or self.expectation(); records=[]
         domains=("host-plane","network-plane") if not same_domain else ("shared-plane","shared-plane")
+        route_value=",".join(sorted(observation["active_route_instance_ids"]))
         for collector,domain in zip(("collector-a","collector-b"),domains):
             for stage,subject,value in (
-                ("route","POST /render","worker-1"),("process","svc","python -m app"),("instance","worker-1","worker-1"),("artifact","worker-1","sha256:artifact-good"),
+                ("route",observation["active_route_surface"],route_value),("process","svc",observation["executable_or_module"]),("instance","worker-1","worker-1"),("artifact","worker-1","sha256:artifact-good"),
             ):
                 m={"record_id":f"{collector}-{stage}","collector_id":collector,"trust_domain":domain,"source_locator":f"{domain}:{stage}","measurement_stage":stage,"subject_id":subject,"observed_value":value,"observation_fingerprint":fingerprint_observation(observation),"expectation_fingerprint":fingerprint_expectation(expectation),"observation_session_id":observation["observation_session_id"],"issued_at":"2026-08-09T17:00:06+09:00"}
                 records.append({**m,"signature":compute_provenance_signature(m,self.collector_keys()[collector])})
@@ -45,6 +46,9 @@ class DeploymentIdentityTests(unittest.TestCase):
         o=kwargs.get("observation",self.observation()); e=kwargs.get("expectation",self.expectation())
         return establish_attested_deployment_identity(o,expected_deployment=e,trusted_observer_ids=["observer-prod-01"],reference_time="2026-08-09T17:00:10+09:00",attestations=kwargs.get("attestations",self.attestations(o,e)),trusted_attestation_keys=self.attestor_keys(),collector_provenance=kwargs.get("collector_provenance",self.provenance(o,e)),trusted_collector_keys=self.collector_keys(),max_age_seconds=300,min_attestors=2,min_independent_domains=2)
 
+    def resign(self, record):
+        material={k:v for k,v in record.items() if k!="signature"}; record["signature"]=compute_provenance_signature(material,self.collector_keys()[record["collector_id"]])
+
     def test_independent_provenance_authorizes(self):
         proof=self.establish(); self.assertTrue(proof["runtime_classification_authorized"]); self.assertEqual(proof["collector_provenance"]["verified_trust_domains"],["host-plane","network-plane"])
 
@@ -53,6 +57,14 @@ class DeploymentIdentityTests(unittest.TestCase):
 
     def test_same_trust_domain_cannot_fake_independence(self):
         with self.assertRaisesRegex(ProvenanceError,"domain quorum not met"): self.establish(collector_provenance=self.provenance(same_domain=True))
+
+    def test_same_collector_cannot_claim_multiple_domains(self):
+        p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b"); target["collector_id"]="collector-a"; self.resign(target)
+        with self.assertRaisesRegex(ProvenanceError,"multiple trust domains"): self.establish(collector_provenance=p)
+
+    def test_shared_source_locator_cannot_fake_independence(self):
+        p=self.provenance(); a=next(r for r in p if r["collector_id"]=="collector-a" and r["measurement_stage"]=="route"); b=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]=="route"); b["source_locator"]=a["source_locator"]; self.resign(b)
+        with self.assertRaisesRegex(ProvenanceError,"shared across trust domains"): self.establish(collector_provenance=p)
 
     def test_missing_stage_in_one_domain_fails_closed(self):
         p=[r for r in self.provenance() if not (r["trust_domain"]=="network-plane" and r["measurement_stage"]=="process")]
@@ -64,15 +76,20 @@ class DeploymentIdentityTests(unittest.TestCase):
         with self.assertRaisesRegex(ProvenanceError,"every routed instance"): self.establish(observation=o,collector_provenance=p,attestations=self.attestations(o,self.expectation()))
 
     def test_artifact_measurement_mismatch_fails(self):
-        p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]=="artifact"); target["observed_value"]="sha256:evil"; m={k:v for k,v in target.items() if k!="signature"}; target["signature"]=compute_provenance_signature(m,self.collector_keys()["collector-b"])
+        p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]=="artifact"); target["observed_value"]="sha256:evil"; self.resign(target)
         with self.assertRaisesRegex(ProvenanceError,"artifact measurement mismatch"): self.establish(collector_provenance=p)
+
+    def test_route_and_process_values_are_measured_not_stage_labels(self):
+        for stage,bad,pattern in (("route","wrong-worker","route measurement mismatch"),("process","wrong-process","process measurement mismatch")):
+            p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]==stage); target["observed_value"]=bad; self.resign(target)
+            with self.assertRaisesRegex(ProvenanceError,pattern): self.establish(collector_provenance=p)
 
     def test_forged_provenance_signature_fails(self):
         p=self.provenance(); p[0]["signature"]="0"*64
         with self.assertRaisesRegex(ProvenanceError,"invalid provenance signature"): self.establish(collector_provenance=p)
 
     def test_provenance_from_different_session_fails(self):
-        p=self.provenance(); p[0]["observation_session_id"]="other"; m={k:v for k,v in p[0].items() if k!="signature"}; p[0]["signature"]=compute_provenance_signature(m,self.collector_keys()[p[0]["collector_id"]])
+        p=self.provenance(); p[0]["observation_session_id"]="other"; self.resign(p[0])
         with self.assertRaisesRegex(ProvenanceError,"different session"): self.establish(collector_provenance=p)
 
     def test_attestor_quorum_still_required(self):

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -22,6 +22,7 @@ class DeploymentIdentityTests(unittest.TestCase):
 
     def attestor_keys(self): return {"attestor-a":"a","attestor-b":"b"}
     def collector_keys(self): return {"collector-a":"ca","collector-b":"cb","collector-c":"cc"}
+    def collector_domains(self): return {"collector-a":"host-plane","collector-b":"network-plane","collector-c":"aux-plane"}
 
     def attestations(self, observation=None, expectation=None):
         observation=observation or self.observation(); expectation=expectation or self.expectation(); out=[]
@@ -32,7 +33,7 @@ class DeploymentIdentityTests(unittest.TestCase):
 
     def provenance(self, observation=None, expectation=None, same_domain=False):
         observation=observation or self.observation(); expectation=expectation or self.expectation(); records=[]
-        domains=("host-plane","network-plane") if not same_domain else ("shared-plane","shared-plane")
+        domains=("host-plane","network-plane") if not same_domain else ("host-plane","host-plane")
         route_value=",".join(sorted(observation["active_route_instance_ids"]))
         for collector,domain in zip(("collector-a","collector-b"),domains):
             for stage,subject,value in (
@@ -44,10 +45,14 @@ class DeploymentIdentityTests(unittest.TestCase):
 
     def establish(self, **kwargs):
         o=kwargs.get("observation",self.observation()); e=kwargs.get("expectation",self.expectation())
-        return establish_attested_deployment_identity(o,expected_deployment=e,trusted_observer_ids=["observer-prod-01"],reference_time="2026-08-09T17:00:10+09:00",attestations=kwargs.get("attestations",self.attestations(o,e)),trusted_attestation_keys=self.attestor_keys(),collector_provenance=kwargs.get("collector_provenance",self.provenance(o,e)),trusted_collector_keys=self.collector_keys(),max_age_seconds=300,min_attestors=2,min_independent_domains=2)
+        return establish_attested_deployment_identity(o,expected_deployment=e,trusted_observer_ids=["observer-prod-01"],reference_time="2026-08-09T17:00:10+09:00",attestations=kwargs.get("attestations",self.attestations(o,e)),trusted_attestation_keys=self.attestor_keys(),collector_provenance=kwargs.get("collector_provenance",self.provenance(o,e)),trusted_collector_keys=self.collector_keys(),trusted_collector_domains=kwargs.get("trusted_collector_domains",self.collector_domains()),max_age_seconds=300,min_attestors=2,min_independent_domains=2)
 
     def resign(self, record):
         material={k:v for k,v in record.items() if k!="signature"}; record["signature"]=compute_provenance_signature(material,self.collector_keys()[record["collector_id"]])
+
+    def add_instance_record(self, records, collector, domain, instance_id, observation):
+        m={"record_id":f"{collector}-instance-{instance_id}","collector_id":collector,"trust_domain":domain,"source_locator":f"{domain}:instance:{instance_id}","measurement_stage":"instance","subject_id":instance_id,"observed_value":instance_id,"observation_fingerprint":fingerprint_observation(observation),"expectation_fingerprint":fingerprint_expectation(self.expectation()),"observation_session_id":observation["observation_session_id"],"issued_at":"2026-08-09T17:00:06+09:00"}
+        records.append({**m,"signature":compute_provenance_signature(m,self.collector_keys()[collector])})
 
     def test_independent_provenance_authorizes(self):
         proof=self.establish(); self.assertTrue(proof["runtime_classification_authorized"]); self.assertEqual(proof["collector_provenance"]["verified_trust_domains"],["host-plane","network-plane"])
@@ -55,12 +60,12 @@ class DeploymentIdentityTests(unittest.TestCase):
     def test_attestation_quorum_without_provenance_cannot_authorize(self):
         with self.assertRaisesRegex(ProvenanceError,"non-empty array"): self.establish(collector_provenance=[])
 
-    def test_same_trust_domain_cannot_fake_independence(self):
-        with self.assertRaisesRegex(ProvenanceError,"domain quorum not met"): self.establish(collector_provenance=self.provenance(same_domain=True))
+    def test_claimed_domain_cannot_override_external_policy(self):
+        p=self.provenance(same_domain=True)
+        with self.assertRaisesRegex(ProvenanceError,"policy binds network-plane"): self.establish(collector_provenance=p)
 
-    def test_same_collector_cannot_claim_multiple_domains(self):
-        p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b"); target["collector_id"]="collector-a"; self.resign(target)
-        with self.assertRaisesRegex(ProvenanceError,"multiple trust domains"): self.establish(collector_provenance=p)
+    def test_missing_external_domain_binding_fails(self):
+        with self.assertRaisesRegex(ProvenanceError,"no externally trusted domain binding"): self.establish(trusted_collector_domains={"collector-a":"host-plane"})
 
     def test_shared_source_locator_cannot_fake_independence(self):
         p=self.provenance(); a=next(r for r in p if r["collector_id"]=="collector-a" and r["measurement_stage"]=="route"); b=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]=="route"); b["source_locator"]=a["source_locator"]; self.resign(b)
@@ -75,11 +80,17 @@ class DeploymentIdentityTests(unittest.TestCase):
         p=self.provenance(o,self.expectation())
         with self.assertRaisesRegex(ProvenanceError,"every routed instance"): self.establish(observation=o,collector_provenance=p,attestations=self.attestations(o,self.expectation()))
 
+    def test_every_domain_must_measure_artifact_for_every_routed_instance(self):
+        o=self.observation(); second=dict(o["runtime_instances"][0]); second["instance_id"]="worker-2"; o["runtime_instances"].append(second); o["active_route_instance_ids"]=["worker-1","worker-2"]
+        p=self.provenance(o,self.expectation())
+        self.add_instance_record(p,"collector-a","host-plane","worker-2",o); self.add_instance_record(p,"collector-b","network-plane","worker-2",o)
+        with self.assertRaisesRegex(ProvenanceError,"artifact for every routed instance"): self.establish(observation=o,collector_provenance=p,attestations=self.attestations(o,self.expectation()))
+
     def test_artifact_measurement_mismatch_fails(self):
         p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]=="artifact"); target["observed_value"]="sha256:evil"; self.resign(target)
         with self.assertRaisesRegex(ProvenanceError,"artifact measurement mismatch"): self.establish(collector_provenance=p)
 
-    def test_route_and_process_values_are_measured_not_stage_labels(self):
+    def test_route_and_process_values_are_measured(self):
         for stage,bad,pattern in (("route","wrong-worker","route measurement mismatch"),("process","wrong-process","process measurement mismatch")):
             p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]==stage); target["observed_value"]=bad; self.resign(target)
             with self.assertRaisesRegex(ProvenanceError,pattern): self.establish(collector_provenance=p)

--- a/tests/test_deployment_identity.py
+++ b/tests/test_deployment_identity.py
@@ -1,289 +1,87 @@
 from __future__ import annotations
 
-import json
-import tempfile
 import unittest
-from pathlib import Path
 
-from deployment_identity.attestation import (
-    AttestationError,
-    compute_hmac_signature,
-    establish_attested_deployment_identity,
-)
-from deployment_identity.cli import main
-from deployment_identity.core import (
-    BOUND,
-    ESTABLISHED,
-    NOT_BOUND,
-    NOT_ESTABLISHED,
-    DeploymentIdentityError,
-    bind_runtime_observation,
-    establish_deployment_identity,
-    fingerprint_expectation,
-    fingerprint_observation,
-)
+from deployment_identity.attestation import AttestationError, compute_hmac_signature, establish_attested_deployment_identity
+from deployment_identity.core import BOUND, NOT_BOUND, bind_runtime_observation, fingerprint_expectation, fingerprint_observation
+from deployment_identity.provenance import ProvenanceError, compute_provenance_signature
 
 
 class DeploymentIdentityTests(unittest.TestCase):
-    def expectation(self) -> dict:
+    def expectation(self):
+        return {"source_revision":"abc123","artifact_digest":"sha256:artifact-good","config_fingerprint":"sha256:config-good","environment_fingerprint":"sha256:env-good"}
+
+    def observation(self):
         return {
-            "source_revision": "abc123",
-            "artifact_digest": "sha256:artifact-good",
-            "config_fingerprint": "sha256:config-good",
-            "environment_fingerprint": "sha256:env-good",
+            "service_unit":"svc","working_directory":"/srv/app","executable_or_module":"python -m app",
+            "active_route_surface":"POST /render","deployed_revision":"abc123","deployed_artifact_digest":"sha256:artifact-good",
+            "runtime_config_fingerprint":"sha256:config-good","runtime_environment_fingerprint":"sha256:env-good","source_tree_state":"CLEAN",
+            "runtime_instances":[{"instance_id":"worker-1","revision":"abc123","artifact_digest":"sha256:artifact-good","config_fingerprint":"sha256:config-good","environment_fingerprint":"sha256:env-good"}],
+            "active_route_instance_ids":["worker-1"],"observer_id":"observer-prod-01","observation_session_id":"session-001","observed_at":"2026-08-09T17:00:00+09:00",
         }
 
-    def instance(self, instance_id: str = "worker-1") -> dict:
-        return {
-            "instance_id": instance_id,
-            "revision": "abc123",
-            "artifact_digest": "sha256:artifact-good",
-            "config_fingerprint": "sha256:config-good",
-            "environment_fingerprint": "sha256:env-good",
-        }
+    def attestor_keys(self): return {"attestor-a":"a","attestor-b":"b"}
+    def collector_keys(self): return {"collector-a":"ca","collector-b":"cb","collector-c":"cc"}
 
-    def observation(self) -> dict:
-        return {
-            "service_unit": "rts-video-flow-web.service",
-            "working_directory": "/srv/rts-video-flow",
-            "executable_or_module": "python -m app.web",
-            "active_route_surface": "POST /render",
-            "deployed_revision": "abc123",
-            "deployed_artifact_digest": "sha256:artifact-good",
-            "runtime_config_fingerprint": "sha256:config-good",
-            "runtime_environment_fingerprint": "sha256:env-good",
-            "source_tree_state": "CLEAN",
-            "runtime_instances": [self.instance()],
-            "active_route_instance_ids": ["worker-1"],
-            "observer_id": "observer-prod-01",
-            "observation_session_id": "session-001",
-            "observed_at": "2026-08-09T17:00:00+09:00",
-        }
+    def attestations(self, observation=None, expectation=None):
+        observation=observation or self.observation(); expectation=expectation or self.expectation(); out=[]
+        for aid in ("attestor-a","attestor-b"):
+            m={"attestor_id":aid,"observation_fingerprint":fingerprint_observation(observation),"expectation_fingerprint":fingerprint_expectation(expectation),"observation_session_id":observation["observation_session_id"],"issued_at":"2026-08-09T17:00:05+09:00"}
+            out.append({**m,"signature":compute_hmac_signature(m,self.attestor_keys()[aid])})
+        return out
 
-    def keyring(self) -> dict[str, str]:
-        return {"attestor-a": "secret-a", "attestor-b": "secret-b", "attestor-c": "secret-c"}
+    def provenance(self, observation=None, expectation=None, same_domain=False):
+        observation=observation or self.observation(); expectation=expectation or self.expectation(); records=[]
+        domains=("host-plane","network-plane") if not same_domain else ("shared-plane","shared-plane")
+        for collector,domain in zip(("collector-a","collector-b"),domains):
+            for stage,subject,value in (
+                ("route","POST /render","worker-1"),("process","svc","python -m app"),("instance","worker-1","worker-1"),("artifact","worker-1","sha256:artifact-good"),
+            ):
+                m={"record_id":f"{collector}-{stage}","collector_id":collector,"trust_domain":domain,"source_locator":f"{domain}:{stage}","measurement_stage":stage,"subject_id":subject,"observed_value":value,"observation_fingerprint":fingerprint_observation(observation),"expectation_fingerprint":fingerprint_expectation(expectation),"observation_session_id":observation["observation_session_id"],"issued_at":"2026-08-09T17:00:06+09:00"}
+                records.append({**m,"signature":compute_provenance_signature(m,self.collector_keys()[collector])})
+        return records
 
-    def make_attestation(
-        self,
-        attestor_id: str,
-        observation: dict | None = None,
-        expectation: dict | None = None,
-        issued_at: str = "2026-08-09T17:00:05+09:00",
-    ) -> dict:
-        observation = observation or self.observation()
-        expectation = expectation or self.expectation()
-        material = {
-            "attestor_id": attestor_id,
-            "observation_fingerprint": fingerprint_observation(observation),
-            "expectation_fingerprint": fingerprint_expectation(expectation),
-            "observation_session_id": observation["observation_session_id"],
-            "issued_at": issued_at,
-        }
-        return {**material, "signature": compute_hmac_signature(material, self.keyring()[attestor_id])}
+    def establish(self, **kwargs):
+        o=kwargs.get("observation",self.observation()); e=kwargs.get("expectation",self.expectation())
+        return establish_attested_deployment_identity(o,expected_deployment=e,trusted_observer_ids=["observer-prod-01"],reference_time="2026-08-09T17:00:10+09:00",attestations=kwargs.get("attestations",self.attestations(o,e)),trusted_attestation_keys=self.attestor_keys(),collector_provenance=kwargs.get("collector_provenance",self.provenance(o,e)),trusted_collector_keys=self.collector_keys(),max_age_seconds=300,min_attestors=2,min_independent_domains=2)
 
-    def attestations(self, observation: dict | None = None, expectation: dict | None = None) -> list[dict]:
-        return [
-            self.make_attestation("attestor-a", observation, expectation),
-            self.make_attestation("attestor-b", observation, expectation),
-        ]
+    def test_independent_provenance_authorizes(self):
+        proof=self.establish(); self.assertTrue(proof["runtime_classification_authorized"]); self.assertEqual(proof["collector_provenance"]["verified_trust_domains"],["host-plane","network-plane"])
 
-    def material_proof(self, observation: dict | None = None, expectation: dict | None = None, **kwargs):
-        return establish_deployment_identity(
-            observation or self.observation(),
-            expected_deployment=expectation or self.expectation(),
-            trusted_observer_ids=kwargs.get("trusted_observer_ids", {"observer-prod-01"}),
-            reference_time=kwargs.get("reference_time", "2026-08-09T17:00:10+09:00"),
-            max_age_seconds=kwargs.get("max_age_seconds", 300),
-        )
+    def test_attestation_quorum_without_provenance_cannot_authorize(self):
+        with self.assertRaisesRegex(ProvenanceError,"non-empty array"): self.establish(collector_provenance=[])
 
-    def establish(self, observation: dict | None = None, expectation: dict | None = None, **kwargs):
-        observation = observation or self.observation()
-        expectation = expectation or self.expectation()
-        return establish_attested_deployment_identity(
-            observation,
-            expected_deployment=expectation,
-            trusted_observer_ids=kwargs.get("trusted_observer_ids", ["observer-prod-01"]),
-            reference_time=kwargs.get("reference_time", "2026-08-09T17:00:10+09:00"),
-            attestations=kwargs.get("attestations", self.attestations(observation, expectation)),
-            trusted_attestation_keys=kwargs.get("trusted_attestation_keys", self.keyring()),
-            max_age_seconds=kwargs.get("max_age_seconds", 300),
-            min_attestors=kwargs.get("min_attestors", 2),
-        )
+    def test_same_trust_domain_cannot_fake_independence(self):
+        with self.assertRaisesRegex(ProvenanceError,"domain quorum not met"): self.establish(collector_provenance=self.provenance(same_domain=True))
 
-    def runtime_observation(self, proof: dict, observed_at: str = "2026-08-09T17:00:15+09:00") -> dict:
-        return {
-            "deployment_identity_fingerprint": proof["observation_fingerprint"],
-            "deployment_expectation_fingerprint": proof["expectation_fingerprint"],
-            "observation_session_id": "session-001",
-            "observed_at": observed_at,
-            "result": {"status": "ok"},
-        }
+    def test_missing_stage_in_one_domain_fails_closed(self):
+        p=[r for r in self.provenance() if not (r["trust_domain"]=="network-plane" and r["measurement_stage"]=="process")]
+        with self.assertRaisesRegex(ProvenanceError,"missing measurement stages"): self.establish(collector_provenance=p)
 
-    def test_raw_material_match_cannot_authorize_runtime_classification(self) -> None:
-        proof = self.material_proof()
-        self.assertEqual(proof["status"], ESTABLISHED)
-        self.assertTrue(proof["material_match_verified"])
-        self.assertFalse(proof["runtime_classification_authorized"])
-        self.assertEqual(proof["reason"], "RUNTIME_MATERIAL_MATCH_ATTESTATION_REQUIRED")
-        result = bind_runtime_observation(proof, self.runtime_observation(proof))
-        self.assertEqual(result["status"], NOT_BOUND)
-        self.assertEqual(result["reason"], "DEPLOYMENT_IDENTITY_NOT_FULLY_AUTHORIZED")
+    def test_every_domain_must_cover_every_routed_instance(self):
+        o=self.observation(); second=dict(o["runtime_instances"][0]); second["instance_id"]="worker-2"; o["runtime_instances"].append(second); o["active_route_instance_ids"]=["worker-1","worker-2"]
+        p=self.provenance(o,self.expectation())
+        with self.assertRaisesRegex(ProvenanceError,"every routed instance"): self.establish(observation=o,collector_provenance=p,attestations=self.attestations(o,self.expectation()))
 
-    def test_two_independent_signed_attestors_authorize(self) -> None:
-        proof = self.establish()
-        self.assertEqual(proof["status"], ESTABLISHED)
-        self.assertTrue(proof["runtime_classification_authorized"])
-        self.assertEqual(proof["attestation_quorum"]["verified_attestors"], ["attestor-a", "attestor-b"])
+    def test_artifact_measurement_mismatch_fails(self):
+        p=self.provenance(); target=next(r for r in p if r["collector_id"]=="collector-b" and r["measurement_stage"]=="artifact"); target["observed_value"]="sha256:evil"; m={k:v for k,v in target.items() if k!="signature"}; target["signature"]=compute_provenance_signature(m,self.collector_keys()["collector-b"])
+        with self.assertRaisesRegex(ProvenanceError,"artifact measurement mismatch"): self.establish(collector_provenance=p)
 
-    def test_single_attestor_cannot_authorize(self) -> None:
-        with self.assertRaisesRegex(AttestationError, "quorum not met"):
-            self.establish(attestations=[self.make_attestation("attestor-a")])
+    def test_forged_provenance_signature_fails(self):
+        p=self.provenance(); p[0]["signature"]="0"*64
+        with self.assertRaisesRegex(ProvenanceError,"invalid provenance signature"): self.establish(collector_provenance=p)
 
-    def test_duplicate_attestor_cannot_fake_quorum(self) -> None:
-        attestation = self.make_attestation("attestor-a")
-        with self.assertRaisesRegex(AttestationError, "duplicate attestor_id"):
-            self.establish(attestations=[attestation, dict(attestation)])
+    def test_provenance_from_different_session_fails(self):
+        p=self.provenance(); p[0]["observation_session_id"]="other"; m={k:v for k,v in p[0].items() if k!="signature"}; p[0]["signature"]=compute_provenance_signature(m,self.collector_keys()[p[0]["collector_id"]])
+        with self.assertRaisesRegex(ProvenanceError,"different session"): self.establish(collector_provenance=p)
 
-    def test_forged_signature_fails_closed(self) -> None:
-        attestations = self.attestations()
-        attestations[1]["signature"] = "0" * 64
-        with self.assertRaisesRegex(AttestationError, "invalid signature"):
-            self.establish(attestations=attestations)
+    def test_attestor_quorum_still_required(self):
+        with self.assertRaisesRegex(AttestationError,"quorum not met"): self.establish(attestations=self.attestations()[:1])
 
-    def test_untrusted_attestor_fails_closed(self) -> None:
-        attestations = self.attestations()
-        material = {
-            "attestor_id": "attacker",
-            "observation_fingerprint": fingerprint_observation(self.observation()),
-            "expectation_fingerprint": fingerprint_expectation(self.expectation()),
-            "observation_session_id": "session-001",
-            "issued_at": "2026-08-09T17:00:05+09:00",
-        }
-        attestations[1] = {**material, "signature": compute_hmac_signature(material, "attacker-secret")}
-        with self.assertRaisesRegex(AttestationError, "untrusted attestor_id"):
-            self.establish(attestations=attestations)
-
-    def test_attestor_cannot_sign_different_observation_or_expectation(self) -> None:
-        altered = self.observation()
-        altered["deployed_revision"] = "other"
-        bad = self.make_attestation("attestor-b", altered, self.expectation())
-        with self.assertRaisesRegex(AttestationError, "different observation"):
-            self.establish(attestations=[self.make_attestation("attestor-a"), bad])
-
-        altered_expectation = self.expectation()
-        altered_expectation["artifact_digest"] = "sha256:other"
-        bad = self.make_attestation("attestor-b", self.observation(), altered_expectation)
-        with self.assertRaisesRegex(AttestationError, "different expectation"):
-            self.establish(attestations=[self.make_attestation("attestor-a"), bad])
-
-    def test_stale_attestation_replay_fails_closed(self) -> None:
-        stale = [
-            self.make_attestation("attestor-a", issued_at="2026-08-09T16:50:00+09:00"),
-            self.make_attestation("attestor-b", issued_at="2026-08-09T16:50:00+09:00"),
-        ]
-        with self.assertRaisesRegex(AttestationError, "stale or future-dated"):
-            self.establish(attestations=stale)
-
-    def test_untrusted_primary_observer_cannot_self_authorize(self) -> None:
-        observation = self.observation()
-        observation["observer_id"] = "attacker-self-declared"
-        result = self.establish(observation=observation, attestations=self.attestations(observation, self.expectation()))
-        self.assertEqual(result["status"], NOT_ESTABLISHED)
-        self.assertEqual(result["reason"], "UNTRUSTED_OBSERVER")
-
-    def test_dirty_source_tree_and_material_drift_fail(self) -> None:
-        observation = self.observation()
-        observation["source_tree_state"] = "DIRTY"
-        result = self.establish(observation=observation, attestations=self.attestations(observation, self.expectation()))
-        self.assertEqual(result["reason"], "SOURCE_TREE_NOT_CLEAN")
-
-        for field, reason in (
-            ("deployed_artifact_digest", "ARTIFACT_DIGEST_MISMATCH"),
-            ("runtime_config_fingerprint", "CONFIG_FINGERPRINT_MISMATCH"),
-            ("runtime_environment_fingerprint", "ENVIRONMENT_FINGERPRINT_MISMATCH"),
-        ):
-            with self.subTest(field=field):
-                observation = self.observation()
-                observation[field] = "sha256:other"
-                result = self.establish(observation=observation, attestations=self.attestations(observation, self.expectation()))
-                self.assertEqual(result["reason"], reason)
-
-    def test_reverse_proxy_route_cannot_reference_unknown_worker(self) -> None:
-        observation = self.observation()
-        observation["active_route_instance_ids"] = ["worker-not-observed"]
-        with self.assertRaisesRegex(DeploymentIdentityError, "unknown runtime instance"):
-            self.establish(observation=observation, attestations=self.attestations(observation, self.expectation()))
-
-    def test_mixed_routed_worker_set_fails(self) -> None:
-        observation = self.observation()
-        stale = self.instance("worker-2")
-        stale["revision"] = "old456"
-        observation["runtime_instances"].append(stale)
-        observation["active_route_instance_ids"] = ["worker-1", "worker-2"]
-        result = self.establish(observation=observation, attestations=self.attestations(observation, self.expectation()))
-        self.assertEqual(result["reason"], "ROUTE_INSTANCE_REVISION_MISMATCH")
-
-    def test_non_routed_old_worker_does_not_define_active_route_reality(self) -> None:
-        observation = self.observation()
-        stale = self.instance("worker-idle")
-        stale["revision"] = "old456"
-        observation["runtime_instances"].append(stale)
-        proof = self.establish(observation=observation, attestations=self.attestations(observation, self.expectation()))
-        self.assertTrue(proof["runtime_classification_authorized"])
-
-    def test_runtime_observation_requires_authorized_fingerprints_session_and_time(self) -> None:
-        proof = self.establish()
-        runtime = self.runtime_observation(proof)
-        runtime["deployment_identity_fingerprint"] = "forged"
-        self.assertEqual(bind_runtime_observation(proof, runtime)["reason"], "DEPLOYMENT_FINGERPRINT_MISMATCH")
-
-        runtime = self.runtime_observation(proof)
-        runtime["deployment_expectation_fingerprint"] = "forged"
-        self.assertEqual(bind_runtime_observation(proof, runtime)["reason"], "DEPLOYMENT_EXPECTATION_FINGERPRINT_MISMATCH")
-
-        runtime = self.runtime_observation(proof)
-        runtime["observation_session_id"] = "other-session"
-        self.assertEqual(bind_runtime_observation(proof, runtime)["reason"], "OBSERVATION_SESSION_MISMATCH")
-
-        runtime = self.runtime_observation(proof, "2026-08-09T17:01:00+09:00")
-        self.assertEqual(bind_runtime_observation(proof, runtime, max_skew_seconds=30)["reason"], "RUNTIME_OBSERVATION_OUTSIDE_BINDING_WINDOW")
-
-        bound = bind_runtime_observation(proof, self.runtime_observation(proof), max_skew_seconds=30)
-        self.assertEqual(bound["status"], BOUND)
-        self.assertTrue(bound["runtime_classification_authorized"])
-
-    def test_cli_requires_attestations_and_external_keyring(self) -> None:
-        observation = self.observation()
-        expectation = self.expectation()
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            observation_path = root / "observation.json"
-            expectation_path = root / "expectation.json"
-            attestations_path = root / "attestations.json"
-            keyring_path = root / "keyring.json"
-            observation_path.write_text(json.dumps(observation), encoding="utf-8")
-            expectation_path.write_text(json.dumps(expectation), encoding="utf-8")
-            attestations_path.write_text(json.dumps(self.attestations(observation, expectation)), encoding="utf-8")
-            keyring_path.write_text(json.dumps(self.keyring()), encoding="utf-8")
-            self.assertEqual(main([
-                "verify", "--observation", str(observation_path),
-                "--expectation", str(expectation_path),
-                "--attestations", str(attestations_path),
-                "--attestation-keyring", str(keyring_path),
-                "--trusted-observer-id", "observer-prod-01",
-                "--reference-time", "2026-08-09T17:00:10+09:00",
-            ]), 0)
-
-    def test_code_existence_alone_cannot_establish_identity(self) -> None:
-        source_only = {"deployed_revision": "abc123", "observed_at": "2026-08-09T17:00:00+09:00"}
-        with self.assertRaises(DeploymentIdentityError):
-            self.material_proof(source_only)
-
-    def test_fingerprints_are_deterministic(self) -> None:
-        first = self.observation()
-        second = dict(reversed(list(first.items())))
-        self.assertEqual(fingerprint_observation(first), fingerprint_observation(second))
+    def test_runtime_binding_requires_fully_authorized_proof(self):
+        proof=self.establish(); runtime={"deployment_identity_fingerprint":proof["observation_fingerprint"],"deployment_expectation_fingerprint":proof["expectation_fingerprint"],"observation_session_id":"session-001","observed_at":"2026-08-09T17:00:15+09:00","result":{"status":"ok"}}
+        bound=bind_runtime_observation(proof,runtime); self.assertEqual(bound["status"],BOUND)
+        runtime["observation_session_id"]="other"; self.assertEqual(bind_runtime_observation(proof,runtime)["status"],NOT_BOUND)
 
 
-if __name__ == "__main__":
-    unittest.main()
+if __name__ == "__main__": unittest.main()


### PR DESCRIPTION
Fourth adversarial hardening pass for Deployment Identity.

This attacks a remaining trust gap: multiple attestors may all sign claims derived from the same compromised observation path.

New fail-closed boundary:
- signed attestor quorum remains necessary but is no longer sufficient
- at least two independent collector trust domains are required
- each trust domain must independently cover route -> process -> instance -> artifact
- every domain must cover every routed instance
- provenance records bind the exact observation fingerprint, expectation fingerprint and session
- records are freshness-bounded and signed by externally supplied collector keys
- same-domain collectors cannot manufacture independence
- missing measurement stages, forged signatures, stale records, different sessions, untrusted collectors, and artifact drift fail closed

Scope limit: this proves authenticated provenance diversity and consistency, not physical host truth against a substrate capable of deceiving every independent collector. Hardware-backed/platform-native measured attestation remains a separately governed extension.