### PR TITLE
Devil's Advocate hardening: outcome closure v6

### DIFF
--- a/.github/workflows/deployment-identity-tests.yml
+++ b/.github/workflows/deployment-identity-tests.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     paths:
       - "deployment_identity/**"
-      - "tests/test_deployment_identity.py"
+      - "tests/test_deployment_identity*.py"
       - "docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md"
       - ".github/workflows/deployment-identity-tests.yml"
   push:
@@ -12,7 +12,7 @@ on:
       - main
     paths:
       - "deployment_identity/**"
-      - "tests/test_deployment_identity.py"
+      - "tests/test_deployment_identity*.py"
       - "docs/implementation/DEPLOYMENT_IDENTITY_V1_TASK.md"
       - ".github/workflows/deployment-identity-tests.yml"
 
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - name: Run Deployment Identity tests
-        run: python -B -m unittest discover -s tests -p 'test_deployment_identity.py' -v
+      - name: Run Deployment Identity and Outcome Closure tests
+        run: python -B -m unittest discover -s tests -p 'test_deployment_identity*.py' -v
       - name: Run full repository tests
         run: python -B -m unittest discover -s tests -v

--- a/deployment_identity/README.md
+++ b/deployment_identity/README.md
@@ -1,6 +1,6 @@
-# Deployment Identity v5
+# Deployment Identity v6
 
-Deployment Identity v5 adds independently sourced collector provenance before runtime classification can be authorized.
+Deployment Identity v6 closes the live proof chain from authorized deployment and runtime observation into signed outcome evidence.
 
 ## Invariants
 
@@ -13,30 +13,27 @@ Attestor count != independent observation.
 Collector-declared domain != trusted independence.
 Shared observation path != independent provenance.
 Partial artifact coverage != runtime proof.
+Runtime proof != outcome proof.
+Matching execution label != proof closure.
+Unsigned outcome != authorized evidence.
+Replayed outcome != new evidence.
 ```
 
-A signed quorum over one observation is necessary but no longer sufficient. RTS requires independent measured provenance for route, process, every routed instance, and every routed artifact.
+## Live Outcome Closure
 
-## Externally bound independence
+A runtime result becomes eligible as live Outcome Evidence only after the runtime observation has already been bound to an authorized Deployment Identity.
 
-Collector independence is policy data, not collector self-description. The caller must provide both:
+The Outcome Closure verifier then requires the exact same:
 
-- an external collector keyring; and
-- an external `collector_id -> trust_domain` map.
+- deployment observation fingerprint;
+- external expectation fingerprint;
+- observation session id;
+- runtime observation fingerprint; and
+- execution id.
 
-A signed record whose claimed `trust_domain` disagrees with that external map fails closed. Reusing one `source_locator` across separate trust domains also fails closed.
+The supplied runtime observation is hashed again and must match the fingerprint already preserved by the Runtime Binding result. This prevents an outcome from being attached to a runtime record that was changed after authorization.
 
-## Provenance requirement
-
-At least two policy-bound trust domains are required by default. Every domain must independently cover:
-
-```text
-route -> process -> instance -> artifact
-```
-
-Route measurements must identify the active route and complete routed-worker set. Process measurements must match the active executable/module. Every trust domain must measure every routed instance and the artifact digest for every routed instance.
-
-Every record also binds the exact deployment observation fingerprint, expectation fingerprint, observation session and issue time.
+Outcome Evidence also requires an externally trusted `outcome_source_id` signature, an unused `evidence_id` relative to the caller-supplied evidence ledger, and an outcome timestamp within the governed execution window. Different run/session/deployment/runtime fingerprints, forged or unknown sources, replayed evidence ids, and temporally impossible outcomes fail closed.
 
 ## Proof chain
 
@@ -51,11 +48,17 @@ Expected Source / Material
        across >= 2 policy trust domains
   -> Authorized Deployment Identity
   -> fingerprint/session/time-bound Runtime Observation
-  -> Outcome Evidence
+  -> execution-bound Runtime Observation fingerprint
+  -> signed, replay-checked Outcome Evidence
+  -> Proof-Closed Outcome
 ```
+
+## Existing Outcome Evidence Corpus boundary
+
+The existing `outcome_evidence/` package remains a `SIMULATED_ONLY` research corpus and remains permanently non-promoting. v6 does not reinterpret those fixtures as external or production success. The live Outcome Closure is a separate verification layer and does not weaken the corpus boundary.
 
 ## Security boundary
 
-v5 proves authenticated provenance diversity, externally anchored independence, and complete routed-instance/artifact coverage. It still does not prove physical truth against a lower substrate capable of deceiving every independent collector. Hardware-backed attestation, platform-native measured identity, privileged discovery, key lifecycle management and secret-safe environment measurement remain separately governed extensions.
+v6 proves cryptographic origin from a policy-trusted outcome source and deterministic binding to one already-authorized runtime execution. It does **not** prove physical truth if the trusted outcome source itself or a lower substrate is compromised. Hardware-backed/platform-native measurement and external real-world success verification remain separately governed concerns.
 
-The verifier itself remains deterministic and performs no network, shell, provider, deployment, or repository mutation.
+Replay rejection depends on the caller supplying the current accepted evidence-id ledger. The verifier is deterministic and read-only; it does not mutate that ledger itself.

--- a/deployment_identity/__init__.py
+++ b/deployment_identity/__init__.py
@@ -13,15 +13,29 @@ from .core import (
     fingerprint_expectation,
     fingerprint_observation,
 )
+from .outcome import (
+    OUTCOME_BOUND,
+    OUTCOME_NOT_BOUND,
+    OutcomeEvidenceError,
+    bind_outcome_evidence,
+    compute_outcome_signature,
+    fingerprint_outcome,
+)
 
 __all__ = [
     "AttestationError",
     "DeploymentIdentityError",
+    "OUTCOME_BOUND",
+    "OUTCOME_NOT_BOUND",
+    "OutcomeEvidenceError",
+    "bind_outcome_evidence",
     "bind_runtime_observation",
     "compute_hmac_signature",
+    "compute_outcome_signature",
     "establish_attested_deployment_identity",
     "establish_deployment_identity",
     "fingerprint_expectation",
     "fingerprint_observation",
+    "fingerprint_outcome",
     "verify_attestation_quorum",
 ]

--- a/deployment_identity/outcome.py
+++ b/deployment_identity/outcome.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import hashlib
+import hmac
 import json
 from datetime import datetime, timezone
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
-from .core import BOUND, DeploymentIdentityError, fingerprint_observation
+from .core import BOUND, fingerprint_observation
 
 
 OUTCOME_BOUND = "OUTCOME_EVIDENCE_BOUND"
@@ -18,6 +19,16 @@ class OutcomeEvidenceError(ValueError):
 
 def _canonical_json(value: Any) -> str:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def outcome_material(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {key: item for key, item in value.items() if key != "signature"}
+
+
+def compute_outcome_signature(material: Mapping[str, Any], secret: str) -> str:
+    if not isinstance(secret, str) or not secret:
+        raise OutcomeEvidenceError("outcome source secret must be a non-empty string")
+    return hmac.new(secret.encode("utf-8"), _canonical_json(dict(material)).encode("utf-8"), hashlib.sha256).hexdigest()
 
 
 def fingerprint_outcome(value: Mapping[str, Any]) -> str:
@@ -42,24 +53,37 @@ def _parse_timestamp(value: str, field: str) -> datetime:
     return parsed.astimezone(timezone.utc)
 
 
+def _seen_ids(values: Iterable[str]) -> frozenset[str]:
+    result = frozenset(values)
+    if any(not isinstance(value, str) or not value or value != value.strip() for value in result):
+        raise OutcomeEvidenceError("seen_evidence_ids must contain exact non-empty ids")
+    return result
+
+
 def bind_outcome_evidence(
     bound_runtime_proof: Mapping[str, Any],
     runtime_observation: Mapping[str, Any],
     outcome_evidence: Mapping[str, Any],
     *,
+    trusted_outcome_keys: Mapping[str, str],
+    seen_evidence_ids: Iterable[str],
     max_outcome_delay_seconds: int = 3600,
 ) -> dict[str, Any]:
-    """Bind outcome evidence to exactly one authorized runtime execution.
+    """Bind signed outcome evidence to exactly one authorized runtime execution.
 
-    Outcome evidence is non-authoritative unless the supplied runtime observation
-    hashes to the already-bound runtime proof and the outcome repeats the same
-    deployment, expectation, session and execution identity within the allowed
-    temporal window.
+    The verifier is fail-closed. The exact runtime observation must already be
+    bound to an authorized deployment proof. Outcome evidence must then bind the
+    same deployment, expectation, session, runtime fingerprint and execution id,
+    originate from an externally trusted signing source, remain inside the time
+    window, and use an evidence id not already present in the caller's ledger.
     """
     if not isinstance(bound_runtime_proof, Mapping) or not isinstance(runtime_observation, Mapping) or not isinstance(outcome_evidence, Mapping):
         raise OutcomeEvidenceError("bound runtime proof, runtime observation and outcome evidence must be objects")
+    if not isinstance(trusted_outcome_keys, Mapping) or not trusted_outcome_keys:
+        raise OutcomeEvidenceError("trusted_outcome_keys must be a non-empty mapping")
     if not isinstance(max_outcome_delay_seconds, int) or max_outcome_delay_seconds < 0:
         raise OutcomeEvidenceError("max_outcome_delay_seconds must be a non-negative integer")
+    seen = _seen_ids(seen_evidence_ids)
     if bound_runtime_proof.get("status") != BOUND or not bound_runtime_proof.get("runtime_classification_authorized"):
         return {"status": OUTCOME_NOT_BOUND, "reason": "RUNTIME_OBSERVATION_NOT_AUTHORIZED", "outcome_evidence_authorized": False}
 
@@ -82,6 +106,7 @@ def bind_outcome_evidence(
 
     required = (
         "evidence_id",
+        "outcome_source_id",
         "execution_id",
         "observation_session_id",
         "deployment_identity_fingerprint",
@@ -90,8 +115,12 @@ def bind_outcome_evidence(
         "outcome_at",
         "outcome_type",
         "outcome_status",
+        "signature",
     )
     values = {field: _require_exact_string(outcome_evidence, field) for field in required}
+
+    if values["evidence_id"] in seen:
+        return {"status": OUTCOME_NOT_BOUND, "reason": "OUTCOME_EVIDENCE_REPLAY", "outcome_evidence_authorized": False, "evidence_id": values["evidence_id"]}
 
     bindings = (
         ("execution_id", values["execution_id"], runtime_execution, "EXECUTION_ID_MISMATCH"),
@@ -103,6 +132,13 @@ def bind_outcome_evidence(
     for field, actual, expected, reason in bindings:
         if actual != expected:
             return {"status": OUTCOME_NOT_BOUND, "reason": reason, "field": field, "outcome_evidence_authorized": False}
+
+    source_secret = trusted_outcome_keys.get(values["outcome_source_id"])
+    if not isinstance(source_secret, str) or not source_secret:
+        return {"status": OUTCOME_NOT_BOUND, "reason": "UNTRUSTED_OUTCOME_SOURCE", "outcome_evidence_authorized": False}
+    expected_signature = compute_outcome_signature(outcome_material(outcome_evidence), source_secret)
+    if not hmac.compare_digest(values["signature"], expected_signature):
+        return {"status": OUTCOME_NOT_BOUND, "reason": "INVALID_OUTCOME_SIGNATURE", "outcome_evidence_authorized": False}
 
     runtime_at = _parse_timestamp(runtime_at_value, "runtime_observed_at")
     outcome_at = _parse_timestamp(values["outcome_at"], "outcome_at")
@@ -118,9 +154,10 @@ def bind_outcome_evidence(
 
     return {
         "status": OUTCOME_BOUND,
-        "reason": "OUTCOME_BOUND_TO_AUTHORIZED_RUNTIME_EXECUTION",
+        "reason": "SIGNED_OUTCOME_BOUND_TO_AUTHORIZED_RUNTIME_EXECUTION",
         "outcome_evidence_authorized": True,
         "evidence_id": values["evidence_id"],
+        "outcome_source_id": values["outcome_source_id"],
         "execution_id": runtime_execution,
         "observation_session_id": runtime_session,
         "deployment_identity_fingerprint": deployment_fp,

--- a/deployment_identity/outcome.py
+++ b/deployment_identity/outcome.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from typing import Any, Mapping
+
+from .core import BOUND, DeploymentIdentityError, fingerprint_observation
+
+
+OUTCOME_BOUND = "OUTCOME_EVIDENCE_BOUND"
+OUTCOME_NOT_BOUND = "OUTCOME_EVIDENCE_NOT_BOUND"
+
+
+class OutcomeEvidenceError(ValueError):
+    """Raised when outcome evidence cannot be bound to one runtime execution."""
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+
+
+def fingerprint_outcome(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(dict(value)).encode("utf-8")).hexdigest()
+
+
+def _require_exact_string(value: Mapping[str, Any], field: str) -> str:
+    item = value.get(field)
+    if not isinstance(item, str) or not item or item != item.strip():
+        raise OutcomeEvidenceError(f"{field} must be an exact non-empty string")
+    return item
+
+
+def _parse_timestamp(value: str, field: str) -> datetime:
+    normalized = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise OutcomeEvidenceError(f"{field} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None:
+        raise OutcomeEvidenceError(f"{field} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def bind_outcome_evidence(
+    bound_runtime_proof: Mapping[str, Any],
+    runtime_observation: Mapping[str, Any],
+    outcome_evidence: Mapping[str, Any],
+    *,
+    max_outcome_delay_seconds: int = 3600,
+) -> dict[str, Any]:
+    """Bind outcome evidence to exactly one authorized runtime execution.
+
+    Outcome evidence is non-authoritative unless the supplied runtime observation
+    hashes to the already-bound runtime proof and the outcome repeats the same
+    deployment, expectation, session and execution identity within the allowed
+    temporal window.
+    """
+    if not isinstance(bound_runtime_proof, Mapping) or not isinstance(runtime_observation, Mapping) or not isinstance(outcome_evidence, Mapping):
+        raise OutcomeEvidenceError("bound runtime proof, runtime observation and outcome evidence must be objects")
+    if not isinstance(max_outcome_delay_seconds, int) or max_outcome_delay_seconds < 0:
+        raise OutcomeEvidenceError("max_outcome_delay_seconds must be a non-negative integer")
+    if bound_runtime_proof.get("status") != BOUND or not bound_runtime_proof.get("runtime_classification_authorized"):
+        return {"status": OUTCOME_NOT_BOUND, "reason": "RUNTIME_OBSERVATION_NOT_AUTHORIZED", "outcome_evidence_authorized": False}
+
+    runtime_fp = fingerprint_observation(runtime_observation)
+    if runtime_fp != bound_runtime_proof.get("runtime_observation_fingerprint"):
+        return {"status": OUTCOME_NOT_BOUND, "reason": "RUNTIME_OBSERVATION_FINGERPRINT_MISMATCH", "outcome_evidence_authorized": False}
+
+    runtime_session = _require_exact_string(runtime_observation, "observation_session_id")
+    runtime_execution = _require_exact_string(runtime_observation, "execution_id")
+    runtime_at_value = _require_exact_string(runtime_observation, "observed_at")
+    deployment_fp = _require_exact_string(runtime_observation, "deployment_identity_fingerprint")
+    expectation_fp = _require_exact_string(runtime_observation, "deployment_expectation_fingerprint")
+
+    if runtime_session != bound_runtime_proof.get("observation_session_id"):
+        return {"status": OUTCOME_NOT_BOUND, "reason": "BOUND_RUNTIME_SESSION_MISMATCH", "outcome_evidence_authorized": False}
+    if deployment_fp != bound_runtime_proof.get("deployment_identity_fingerprint"):
+        return {"status": OUTCOME_NOT_BOUND, "reason": "BOUND_DEPLOYMENT_FINGERPRINT_MISMATCH", "outcome_evidence_authorized": False}
+    if expectation_fp != bound_runtime_proof.get("deployment_expectation_fingerprint"):
+        return {"status": OUTCOME_NOT_BOUND, "reason": "BOUND_EXPECTATION_FINGERPRINT_MISMATCH", "outcome_evidence_authorized": False}
+
+    required = (
+        "evidence_id",
+        "execution_id",
+        "observation_session_id",
+        "deployment_identity_fingerprint",
+        "deployment_expectation_fingerprint",
+        "runtime_observation_fingerprint",
+        "outcome_at",
+        "outcome_type",
+        "outcome_status",
+    )
+    values = {field: _require_exact_string(outcome_evidence, field) for field in required}
+
+    bindings = (
+        ("execution_id", values["execution_id"], runtime_execution, "EXECUTION_ID_MISMATCH"),
+        ("observation_session_id", values["observation_session_id"], runtime_session, "OUTCOME_SESSION_MISMATCH"),
+        ("deployment_identity_fingerprint", values["deployment_identity_fingerprint"], deployment_fp, "OUTCOME_DEPLOYMENT_FINGERPRINT_MISMATCH"),
+        ("deployment_expectation_fingerprint", values["deployment_expectation_fingerprint"], expectation_fp, "OUTCOME_EXPECTATION_FINGERPRINT_MISMATCH"),
+        ("runtime_observation_fingerprint", values["runtime_observation_fingerprint"], runtime_fp, "OUTCOME_RUNTIME_FINGERPRINT_MISMATCH"),
+    )
+    for field, actual, expected, reason in bindings:
+        if actual != expected:
+            return {"status": OUTCOME_NOT_BOUND, "reason": reason, "field": field, "outcome_evidence_authorized": False}
+
+    runtime_at = _parse_timestamp(runtime_at_value, "runtime_observed_at")
+    outcome_at = _parse_timestamp(values["outcome_at"], "outcome_at")
+    delay = (outcome_at - runtime_at).total_seconds()
+    if delay < 0 or delay > max_outcome_delay_seconds:
+        return {
+            "status": OUTCOME_NOT_BOUND,
+            "reason": "OUTCOME_OUTSIDE_EXECUTION_WINDOW",
+            "outcome_evidence_authorized": False,
+            "delay_seconds": delay,
+            "max_outcome_delay_seconds": max_outcome_delay_seconds,
+        }
+
+    return {
+        "status": OUTCOME_BOUND,
+        "reason": "OUTCOME_BOUND_TO_AUTHORIZED_RUNTIME_EXECUTION",
+        "outcome_evidence_authorized": True,
+        "evidence_id": values["evidence_id"],
+        "execution_id": runtime_execution,
+        "observation_session_id": runtime_session,
+        "deployment_identity_fingerprint": deployment_fp,
+        "deployment_expectation_fingerprint": expectation_fp,
+        "runtime_observation_fingerprint": runtime_fp,
+        "outcome_evidence_fingerprint": fingerprint_outcome(outcome_evidence),
+        "outcome_type": values["outcome_type"],
+        "outcome_status": values["outcome_status"],
+    }

--- a/docs/implementation/OUTCOME_CLOSURE_V6_TASK.md
+++ b/docs/implementation/OUTCOME_CLOSURE_V6_TASK.md
@@ -1,0 +1,45 @@
+# Outcome Closure v6 completion contract
+
+Status: DEVIL'S ADVOCATE VALIDATION
+
+## Invariant
+
+```text
+Authorized Deployment != Outcome Evidence.
+Bound Runtime Observation != Outcome Evidence.
+Matching execution label != proof closure.
+Unsigned or replayed outcome != authorized evidence.
+```
+
+## Required proof chain
+
+```text
+Authorized Deployment Identity
+  -> exact bound Runtime Observation
+  -> execution identity
+  -> signed Outcome source
+  -> replay check
+  -> temporal binding
+  -> Proof-Closed Outcome Evidence
+```
+
+## Required adversarial failures
+
+- unbound runtime
+- runtime mutation after binding
+- different execution id
+- different session
+- different deployment fingerprint
+- different expectation fingerprint
+- different runtime fingerprint
+- unknown outcome source
+- forged outcome signature
+- replayed evidence id
+- outcome before runtime
+- outcome outside the governed time window
+
+## Boundary
+
+This layer proves deterministic binding and authenticated source provenance for one live outcome claim. It does not prove physical truth when the trusted outcome source or lower substrate is compromised, and it does not reinterpret `outcome_evidence/` SIMULATED_ONLY fixtures as production success.
+
+Completion requires dedicated tests, full repository regression, Unicode Guard, review-thread resolution, and merge to `main`.

--- a/tests/test_deployment_identity_outcome.py
+++ b/tests/test_deployment_identity_outcome.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import unittest
+
+from deployment_identity.core import BOUND, bind_runtime_observation, fingerprint_observation
+from deployment_identity.outcome import (
+    OUTCOME_BOUND,
+    OUTCOME_NOT_BOUND,
+    bind_outcome_evidence,
+    compute_outcome_signature,
+)
+
+
+class OutcomeClosureTests(unittest.TestCase):
+    def deployment_proof(self):
+        return {
+            "status": "DEPLOYMENT_IDENTITY_ESTABLISHED",
+            "runtime_classification_authorized": True,
+            "observation_fingerprint": "dep-fp",
+            "expectation_fingerprint": "expect-fp",
+            "identity": {
+                "observation_session_id": "session-001",
+                "observed_at": "2026-08-09T17:00:00+09:00",
+            },
+        }
+
+    def runtime(self):
+        return {
+            "deployment_identity_fingerprint": "dep-fp",
+            "deployment_expectation_fingerprint": "expect-fp",
+            "observation_session_id": "session-001",
+            "execution_id": "exec-001",
+            "observed_at": "2026-08-09T17:00:15+09:00",
+            "result": {"status": "running"},
+        }
+
+    def bound_runtime(self, runtime=None):
+        runtime = runtime or self.runtime()
+        return bind_runtime_observation(self.deployment_proof(), runtime, max_skew_seconds=30)
+
+    def outcome_keys(self):
+        return {"outcome-collector-01": "outcome-secret"}
+
+    def outcome(self, runtime=None, **overrides):
+        runtime = runtime or self.runtime()
+        material = {
+            "evidence_id": "outcome-001",
+            "outcome_source_id": "outcome-collector-01",
+            "execution_id": runtime["execution_id"],
+            "observation_session_id": runtime["observation_session_id"],
+            "deployment_identity_fingerprint": runtime["deployment_identity_fingerprint"],
+            "deployment_expectation_fingerprint": runtime["deployment_expectation_fingerprint"],
+            "runtime_observation_fingerprint": fingerprint_observation(runtime),
+            "outcome_at": "2026-08-09T17:00:25+09:00",
+            "outcome_type": "SUCCESS",
+            "outcome_status": "SUCCEEDED",
+        }
+        material.update(overrides)
+        return {**material, "signature": compute_outcome_signature(material, self.outcome_keys()["outcome-collector-01"])}
+
+    def bind(self, runtime=None, outcome=None, seen=(), max_delay=3600):
+        runtime = runtime or self.runtime()
+        outcome = outcome or self.outcome(runtime)
+        return bind_outcome_evidence(
+            self.bound_runtime(runtime),
+            runtime,
+            outcome,
+            trusted_outcome_keys=self.outcome_keys(),
+            seen_evidence_ids=seen,
+            max_outcome_delay_seconds=max_delay,
+        )
+
+    def resign(self, outcome):
+        material = {k: v for k, v in outcome.items() if k != "signature"}
+        outcome["signature"] = compute_outcome_signature(material, self.outcome_keys()["outcome-collector-01"])
+
+    def test_signed_outcome_binds_to_exact_runtime_execution(self):
+        result = self.bind()
+        self.assertEqual(result["status"], OUTCOME_BOUND)
+        self.assertTrue(result["outcome_evidence_authorized"])
+        self.assertEqual(result["execution_id"], "exec-001")
+
+    def test_unbound_runtime_cannot_authorize_outcome(self):
+        runtime = self.runtime()
+        proof = self.bound_runtime(runtime)
+        proof["status"] = "RUNTIME_OBSERVATION_NOT_BOUND"
+        result = bind_outcome_evidence(proof, runtime, self.outcome(runtime), trusted_outcome_keys=self.outcome_keys(), seen_evidence_ids=())
+        self.assertEqual(result["status"], OUTCOME_NOT_BOUND)
+        self.assertEqual(result["reason"], "RUNTIME_OBSERVATION_NOT_AUTHORIZED")
+
+    def test_runtime_mutation_after_binding_fails(self):
+        runtime = self.runtime()
+        proof = self.bound_runtime(runtime)
+        outcome = self.outcome(runtime)
+        runtime["result"] = {"status": "tampered"}
+        result = bind_outcome_evidence(proof, runtime, outcome, trusted_outcome_keys=self.outcome_keys(), seen_evidence_ids=())
+        self.assertEqual(result["reason"], "RUNTIME_OBSERVATION_FINGERPRINT_MISMATCH")
+
+    def test_outcome_from_different_execution_fails(self):
+        outcome = self.outcome(execution_id="exec-other")
+        result = self.bind(outcome=outcome)
+        self.assertEqual(result["reason"], "EXECUTION_ID_MISMATCH")
+
+    def test_outcome_from_different_session_fails(self):
+        outcome = self.outcome(observation_session_id="session-other")
+        result = self.bind(outcome=outcome)
+        self.assertEqual(result["reason"], "OUTCOME_SESSION_MISMATCH")
+
+    def test_outcome_from_different_runtime_fingerprint_fails(self):
+        outcome = self.outcome(runtime_observation_fingerprint="forged")
+        result = self.bind(outcome=outcome)
+        self.assertEqual(result["reason"], "OUTCOME_RUNTIME_FINGERPRINT_MISMATCH")
+
+    def test_outcome_from_different_deployment_fails(self):
+        outcome = self.outcome(deployment_identity_fingerprint="other-deployment")
+        result = self.bind(outcome=outcome)
+        self.assertEqual(result["reason"], "OUTCOME_DEPLOYMENT_FINGERPRINT_MISMATCH")
+
+    def test_untrusted_outcome_source_fails(self):
+        outcome = self.outcome()
+        outcome["outcome_source_id"] = "attacker"
+        material = {k: v for k, v in outcome.items() if k != "signature"}
+        outcome["signature"] = "0" * 64
+        result = self.bind(outcome=outcome)
+        self.assertEqual(result["reason"], "UNTRUSTED_OUTCOME_SOURCE")
+
+    def test_forged_outcome_signature_fails(self):
+        outcome = self.outcome()
+        outcome["signature"] = "0" * 64
+        result = self.bind(outcome=outcome)
+        self.assertEqual(result["reason"], "INVALID_OUTCOME_SIGNATURE")
+
+    def test_outcome_replay_id_fails_closed(self):
+        result = self.bind(seen={"outcome-001"})
+        self.assertEqual(result["reason"], "OUTCOME_EVIDENCE_REPLAY")
+
+    def test_outcome_before_runtime_or_too_late_fails(self):
+        before = self.outcome(outcome_at="2026-08-09T17:00:14+09:00")
+        self.assertEqual(self.bind(outcome=before)["reason"], "OUTCOME_OUTSIDE_EXECUTION_WINDOW")
+        late = self.outcome(outcome_at="2026-08-09T17:01:00+09:00")
+        self.assertEqual(self.bind(outcome=late, max_delay=30)["reason"], "OUTCOME_OUTSIDE_EXECUTION_WINDOW")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fifth adversarial hardening pass for Deployment Identity / Proof Closure.

This attacks the remaining chain gap where a valid Deployment Identity and Runtime Observation could be paired with outcome evidence from another execution, session, deployment, or modified runtime record.

New fail-closed boundary:
- live Outcome Evidence requires an already BOUND authorized runtime proof
- the supplied Runtime Observation is re-fingerprinted and must match the bound runtime fingerprint
- outcome binds deployment fingerprint, external expectation fingerprint, observation session, runtime fingerprint, and execution_id
- outcome source must be externally trusted and HMAC-signed
- reused evidence_id fails closed against a caller-supplied accepted-evidence ledger
- outcomes before the runtime observation or outside the governed delay window fail closed
- forged source, unknown source, different execution/session/deployment/runtime evidence all fail closed

Important scope limit: this proves deterministic chain binding and authenticated outcome origin, not physical truth against a compromised trusted outcome source or lower substrate. The existing outcome_evidence/ corpus remains SIMULATED_ONLY and is not reclassified as production evidence.