### PR TITLE
feat: encrypted cloud custody v0 candidate

### DIFF
--- a/.github/workflows/cloud-custody-candidate-tests.yml
+++ b/.github/workflows/cloud-custody-candidate-tests.yml
@@ -24,10 +24,10 @@ jobs:
         working-directory: thin-rts/cloud-custody
     steps:
       - uses: actions/checkout@v4
-      - name: Compile candidate
-        run: python3 -m py_compile custody.py test_custody.py
-      - name: Run pure unit tests
-        run: python3 -m unittest -v test_custody.py
+      - name: Compile candidate and Meteor attacks
+        run: python3 -m py_compile custody.py test_custody.py test_meteor_custody.py
+      - name: Run candidate plus Meteor attack suite
+        run: python3 -m unittest -v
       - name: Confirm no generated custody artifacts are tracked
         run: |
           if git ls-files '*.gpg' '*.tar.gz' '*.receipt.json' '*.preupload.json' '*.RECOVERY_CARD.md' | grep -q .; then

--- a/.github/workflows/cloud-custody-candidate-tests.yml
+++ b/.github/workflows/cloud-custody-candidate-tests.yml
@@ -1,0 +1,36 @@
+name: Cloud Custody Candidate Tests
+
+on:
+  push:
+    branches:
+      - feature/encrypted-cloud-custody-v0
+    paths:
+      - 'thin-rts/cloud-custody/**'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+  pull_request:
+    paths:
+      - 'thin-rts/cloud-custody/**'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: thin-rts/cloud-custody
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile candidate
+        run: python3 -m py_compile custody.py test_custody.py
+      - name: Run pure unit tests
+        run: python3 -m unittest -v test_custody.py
+      - name: Confirm no generated custody artifacts are tracked
+        run: |
+          if git ls-files '*.gpg' '*.tar.gz' '*.receipt.json' '*.preupload.json' '*.RECOVERY_CARD.md' | grep -q .; then
+            echo 'generated custody/recovery artifact is tracked' >&2
+            exit 1
+          fi

--- a/thin-rts/cloud-custody/.gitignore
+++ b/thin-rts/cloud-custody/.gitignore
@@ -1,0 +1,10 @@
+# Never commit generated custody artifacts or recovery material.
+work/
+recovery-package/
+*.gpg
+*.tar
+*.tar.gz
+*.receipt.json
+*.preupload.json
+*.RECOVERY_CARD.md
+__pycache__/

--- a/thin-rts/cloud-custody/AUTOPSY_0001.md
+++ b/thin-rts/cloud-custody/AUTOPSY_0001.md
@@ -1,0 +1,37 @@
+# AUTOPSY 0001 — Custody Prototype Death
+
+Observed CI run: `Cloud Custody Candidate Tests` run 8
+
+Status: `PROTOTYPE_KILLED / PATCH_REQUIRED`
+
+The first WITNESS Meteor attack produced **8 material failures out of 13 tests**. This is accepted as successful destructive evidence.
+
+## Material death causes
+
+1. restore download was not generation-bound;
+2. duplicate manifest paths were accepted;
+3. an empty evidence bundle could be packaged as success;
+4. extraction into a dirty destination could mix stale and restored material;
+5. manifest `..` escape could reference material outside the restored root;
+6. new-object upload used best-effort `--no-clobber` instead of an atomic generation-zero precondition;
+7. source evidence could collide with the reserved internal manifest filename;
+8. unmanifested extra files were silently accepted by verification.
+
+## Classification
+
+These failures do **not** prove that custom cryptography or a custom storage engine is needed.
+
+Current responsibility classification remains:
+
+- cryptography: `EXTERNALIZE` to GnuPG;
+- cloud transport/storage: `EXTERNALIZE` to Google Cloud tooling/provider for the first adapter;
+- manifest/path validation, generation binding, deterministic package/recovery verification: bounded `GLUE` candidate;
+- custom crypto / custom object store / custom key vault: `DROP`.
+
+## Darwin action
+
+Patch only the demonstrated glue gaps. Do not expand architecture.
+
+Then rerun the exact same frozen attack suite before adding new attack angles.
+
+`SAME DEATH CAUSE MUST NOT RECUR UNCHANGED.`

--- a/thin-rts/cloud-custody/AUTOPSY_0002.md
+++ b/thin-rts/cloud-custody/AUTOPSY_0002.md
@@ -1,0 +1,28 @@
+# AUTOPSY 0002 — Trust-Boundary Rotation
+
+Observed CI run: `Cloud Custody Candidate Tests` run 14
+
+Status: `PROTOTYPE_KILLED_AGAIN / PATCH_REQUIRED`
+
+The original eight death causes stayed fixed, but a rotated WITNESS attack found a second class of failures.
+
+## Material death causes
+
+1. two apparent recovery recipients could be the primary fingerprint and subkey fingerprint of the same OpenPGP key family, defeating the intended two-recipient recovery separation;
+2. free-form/newline authority text could enter custody metadata instead of a bounded opaque authority reference;
+3. GCS target validation accepted generation fragments, query-like material and control characters;
+4. upload did not bind provider transfer integrity to the local ciphertext through provider MD5 validation;
+5. upload did not send the existing provider `--content-md5` integrity check;
+6. restore attempted to read a receipt inside the public repository instead of rejecting the trust-boundary violation first.
+
+## Surviving prior fixes
+
+All eight failures from `AUTOPSY_0001.md` passed unchanged under the same workload.
+
+This is the intended Darwin behavior: inherited death causes remain in the test corpus.
+
+## Patch authorization
+
+Only the demonstrated glue gaps above are authorized for patching.
+
+No custom crypto, object store, key vault or broader platform surface is authorized.

--- a/thin-rts/cloud-custody/METEOR_ATTACK_0001.md
+++ b/thin-rts/cloud-custody/METEOR_ATTACK_0001.md
@@ -1,0 +1,92 @@
+# METEOR ATTACK 0001 — Encrypted Cloud Custody Prototype
+
+Timestamp: **2026-08-11 JST**
+
+Status: `ACTIVE / PROTOTYPE MUST DIE BEFORE IMPLEMENTATION`
+
+Method authority: WITNESS Meteor Gate.
+
+This candidate is deliberately treated as a **prototype under `/goal`**, not as an implementation entitled to survive.
+
+The burden of proof is on the candidate. Green happy-path CI is insufficient.
+
+## Frozen outcome
+
+Preserve a dispute-ready evidence bundle using existing crypto and cloud capabilities with the smallest surviving glue surface, while keeping long-term decryption secrets outside the producer/cloud trust boundary and preserving independently verifiable recovery.
+
+## Witness ordering
+
+`OUTCOME -> NECESSITY -> EXTERNAL FIRST -> REALITY -> EVIDENCE -> BUILD LAST -> RETEST`
+
+Per-responsibility verdicts remain limited to:
+
+`DROP / EXTERNALIZE / GLUE / IRREDUCIBLE_BUILD`
+
+No existing code receives a survival right because it has already been written.
+
+## Candidate under attack
+
+Current prototype composition:
+
+- deterministic packaging: Python stdlib glue;
+- content digests: SHA-256;
+- public-key encryption: external GnuPG;
+- first provider adapter: external `gcloud storage`;
+- Thin RTS glue: manifest/custody binding, approval boundary, provider metadata observation, recovery verification.
+
+## Attack set A — package identity
+
+The prototype must fail closed when:
+
+1. the evidence directory is empty;
+2. source evidence collides with the reserved internal manifest name;
+3. a manifest entry attempts `..` / absolute-path escape;
+4. duplicate manifest paths exist;
+5. restored output contains unmanifested extra files;
+6. extraction is attempted into a dirty/non-empty destination that could mix stale data with restored evidence;
+7. deterministic packaging cannot reproduce identical bytes from identical input.
+
+A verifier that only checks listed files but silently accepts extra or escaping material is dead.
+
+## Attack set B — provider race / stale substitution
+
+Cloud Storage metadata and object data are separate observations. The prototype must not claim that an unconditioned download is the recorded generation merely because a later metadata request reports that generation.
+
+Required surviving behavior:
+
+- new-object upload uses a generation precondition equivalent to `ifGenerationMatch=0`, not a best-effort existence check;
+- restore binds the data retrieval itself to the recorded immutable generation, rather than downloading an unconstrained latest object and checking metadata afterward;
+- stale/replaced generation produces FAIL/ERROR, never PASS.
+
+## Attack set C — trust-boundary collapse
+
+Before live `/goal` can reach cloud mutation:
+
+- producer has public recipient material only for selected recovery recipients;
+- producer must not hold corresponding secret-key records;
+- at least two recovery recipients remain required for the first experiment;
+- real recovery-package paths and work paths must be outside the public repository;
+- provider credentials, recovery secrets, plaintext evidence and live receipts must never become tracked repository artifacts.
+
+## Attack set D — authority
+
+Prototype construction and local destructive testing are authorized under `/goal`.
+
+The following remain separate authority boundaries:
+
+- live cloud mutation;
+- key generation/import of private recovery material onto the producer;
+- merge/promotion;
+- publication of account/bucket/project/evidence identifiers.
+
+If a boundary is reached, `/goal` must stop with `APPROVAL_REQUIRED` rather than silently cross it.
+
+## Initial verdict
+
+`PROTOTYPE_SURVIVAL = UNPROVEN`
+
+`LIVE_UPLOAD = NOT_AUTHORIZED_BY_THIS_DOCUMENT`
+
+`PROMOTION = NOT_AUTHORIZED`
+
+The test suite is intentionally expanded with red-team expectations. A red CI result is **successful Meteor evidence**, not a development failure.

--- a/thin-rts/cloud-custody/METEOR_SATURATION_CHECKPOINT_0001.md
+++ b/thin-rts/cloud-custody/METEOR_SATURATION_CHECKPOINT_0001.md
@@ -1,0 +1,58 @@
+# METEOR SATURATION CHECKPOINT 0001
+
+Timestamp: **2026-08-11 JST**
+
+Status: `STRUCTURAL_ATTACK_SATURATED_UNDER_CURRENT_EVIDENCE / LIVE_REALITY_NEXT`
+
+## What happened
+
+The custody prototype was killed twice before any live cloud write.
+
+Round 1 found eight material package/verification/provider-generation failures.
+
+Round 2 rotated to trust boundaries and found six additional material failures.
+
+The exact prior death causes were retained as regression attacks rather than discarded after repair.
+
+After the second repair, the candidate + inherited Meteor suite returned green CI.
+
+## Current surviving responsibility map
+
+- GnuPG crypto: `EXTERNALIZE`
+- Google Cloud object transport/storage for first experiment: `EXTERNALIZE`
+- deterministic package + manifest validation: `GLUE`
+- provider precondition/digest/generation binding: `GLUE`
+- authority boundary + recovery metadata binding: `GLUE`
+- custom cryptography: `DROP`
+- custom object storage: `DROP`
+- custom key vault: `DROP`
+
+No `IRREDUCIBLE_BUILD` beyond the bounded glue above has been proven.
+
+## Why the next attack must be live
+
+Further static/pure-unit rotation now risks inventing speculative architecture instead of testing reality.
+
+The next material unknowns require the actual producer environment:
+
+1. are at least two distinct recovery **primary public keys** available while their secret-key records are absent from the producer?;
+2. can `/goal` produce a deterministic bundle and ciphertext using those public recipients?;
+3. which dedicated private GCS prefix is intentionally authorized for custody testing?;
+4. does the provider accept the atomic generation-zero upload + content-MD5 contract?;
+5. can a genuinely separated recovery environment decrypt and independently verify the recorded generation, ciphertext digest, plaintext bundle digest and internal manifest?;
+6. do wrong-key, mutation, truncation, stale-generation and missing-object attacks fail closed in the live workload?;
+7. can this be reduced to near-zero manual filing without weakening authority or recovery separation?
+
+## Stop condition
+
+Pure structural attack is paused here because the next materially new evidence comes from real key/provider/recovery behavior.
+
+`SEARCH_SATURATED_UNDER_CURRENT_EVIDENCE`
+
+This is **not** completion and **not** promotion.
+
+`LIVE CLOUD WRITE = STILL APPROVAL-BOUND`
+
+`PR = DRAFT`
+
+`PROMOTION = NOT AUTHORIZED`

--- a/thin-rts/cloud-custody/README.md
+++ b/thin-rts/cloud-custody/README.md
@@ -1,0 +1,116 @@
+# Thin RTS — Encrypted Cloud Custody v0 Candidate
+
+Status: `IMPLEMENTED_CANDIDATE / NOT_YET_LIVE_VERIFIED`
+
+This directory is the smallest custom orchestration surface currently allowed to survive the Destroy Loop for encrypted evidence custody.
+
+It does **not** implement cryptography, cloud storage, key management, or a new backup engine.
+
+External responsibilities:
+
+- OpenPGP encryption/decryption: GnuPG (`gpg`)
+- first object-storage adapter: Google Cloud CLI (`gcloud storage`)
+- cloud authentication, transport, retries, IAM, provider durability: provider/tool responsibility
+- private recovery-key custody: separate operator-controlled trust boundary
+
+Thin RTS owns only:
+
+- deterministic evidence packaging;
+- SHA-256 binding before and after encryption;
+- explicit recipient/key-epoch binding;
+- refusal to encrypt when the selected recipient has a secret-key record on the producer;
+- opaque object naming;
+- upload + remote generation/size observation;
+- recovery receipt/card generation;
+- download/decrypt/manifest verification;
+- PASS / ERROR / APPROVAL_REQUIRED boundaries.
+
+## `/goal` semantics
+
+The `goal` subcommand intentionally runs until one of three boundaries:
+
+- `ERROR` — a required invariant/tool/key/target check failed;
+- `APPROVAL_REQUIRED` — local bundle + ciphertext were created and verified enough to show the exact planned remote write, but no cloud write was executed;
+- `LIVE_UPLOAD_VERIFIED` — an explicitly approved upload completed and the remote object generation/size were observed.
+
+A verified upload is **not** full completion. The next hard gate is a fresh-environment restore with a separated recovery identity.
+
+## Required separation
+
+The producer must have the public recipient keys but must not have secret-key records for those selected recipients.
+
+The candidate requires at least two recipient fingerprints for `/goal` so the first live experiment cannot silently collapse to one irreplaceable recovery path.
+
+Recovery identities must be created and stored outside the producer/server and outside the evidence-cloud trust boundary.
+
+## Input contract
+
+`--input` points at a completed evidence-bundle directory. This layer does not decide legal relevance. The input should already contain the originals/derivatives/custody/reproduction material required by the upstream legal-evidence gate.
+
+Symlinks are rejected. File paths are sorted. Tar metadata is normalized. The archive contains `RTS_BUNDLE_MANIFEST.json` with each source path, byte size and SHA-256.
+
+## Private runtime paths
+
+`--work` and `--recovery-dir` must point outside the public repository.
+
+Do not commit:
+
+- evidence originals;
+- tar/gzip bundles;
+- ciphertext generated for real evidence;
+- recovery receipts/cards tied to real cases;
+- public or private recovery-key exports;
+- provider credentials;
+- account/project/bucket identifiers unless intentionally approved for publication.
+
+## GCS target contract
+
+The first provider adapter requires a dedicated prefix such as:
+
+`gs://<user-selected-bucket>/<dedicated-private-prefix>`
+
+Bucket root is rejected.
+
+Existing unrelated render/build buckets are **not automatically authorized** as evidence-custody destinations merely because they are visible to the current credential.
+
+## Local validation
+
+Run the pure unit tests before a live experiment:
+
+`python3 -m unittest thin-rts/cloud-custody/test_custody.py`
+
+Run tool/recipient/target checks using `doctor`.
+
+Run `goal` without `--approve-live-upload` first. That produces the exact planned object URI and an `APPROVAL_REQUIRED` boundary without mutating the cloud.
+
+Only after the target and recovery-key separation are deliberately accepted should the same invocation be repeated with `--approve-live-upload`.
+
+## Fresh recovery
+
+`restore` requires a recovery receipt that records the expected provider object generation, ciphertext SHA-256, and plaintext bundle SHA-256.
+
+The restore path:
+
+`download -> verify ciphertext digest -> verify remote generation -> decrypt -> verify plaintext bundle digest -> safe extract -> verify internal manifest`
+
+Opening a decrypted file without those checks is not PASS.
+
+## Known incomplete gates
+
+This candidate does not yet prove:
+
+- real live upload/write authority to a dedicated evidence-custody prefix;
+- fresh-environment recovery;
+- alternate recovery recipient success;
+- wrong-key failure;
+- one-byte ciphertext mutation detection;
+- truncated/missing/stale object handling in a live provider workload;
+- anti-zubora scheduling/retry automation;
+- provider replacement with a second transport;
+- integration with automatic evidence triage/event/legal-watch layers.
+
+Therefore:
+
+`ENCRYPTED_CLOUD_CUSTODY = NOT_COMPLETE`
+
+`PROMOTION = NOT_AUTHORIZED`

--- a/thin-rts/cloud-custody/custody.py
+++ b/thin-rts/cloud-custody/custody.py
@@ -11,6 +11,7 @@ must remain outside the public repository.
 from __future__ import annotations
 
 import argparse
+import base64
 import gzip
 import hashlib
 import io
@@ -29,6 +30,7 @@ from typing import Iterable
 SCHEMA = "thin-rts-cloud-custody/v0"
 INTERNAL_MANIFEST = "RTS_BUNDLE_MANIFEST.json"
 FINGERPRINT_RE = re.compile(r"^[0-9A-Fa-f]{40,64}$")
+AUTHORITY_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+\-]{0,159}$")
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -46,6 +48,14 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: f.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def md5_b64_file(path: Path) -> str:
+    h = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return base64.b64encode(h.digest()).decode("ascii")
 
 
 def canonical_json_bytes(obj: object) -> bytes:
@@ -169,6 +179,12 @@ def _validate_fingerprint(value: str) -> str:
     return value.upper()
 
 
+def validate_authority_ref(value: str) -> str:
+    if not AUTHORITY_REF_RE.fullmatch(value or ""):
+        raise CustodyError("authority reference must be an opaque token, not free-form text")
+    return value
+
+
 def gpg_version() -> str:
     cp = run(["gpg", "--version"])
     return cp.stdout.splitlines()[0].strip() if cp.stdout else "gpg/version-unknown"
@@ -186,6 +202,24 @@ def gpg_public_fingerprints(query: str) -> set[str]:
     return result
 
 
+def gpg_primary_fingerprint(query: str) -> str | None:
+    cp = run(["gpg", "--batch", "--with-colons", "--fingerprint", "--list-keys", query], check=False)
+    if cp.returncode != 0:
+        return None
+    saw_pub = False
+    for line in cp.stdout.splitlines():
+        parts = line.split(":")
+        kind = parts[0] if parts else ""
+        if kind == "pub":
+            saw_pub = True
+            continue
+        if saw_pub and kind == "fpr" and len(parts) > 9 and parts[9]:
+            return parts[9].upper()
+        if kind in {"sub", "uid", "uat"} and saw_pub:
+            break
+    return None
+
+
 def gpg_has_secret_record(fingerprint: str) -> bool:
     cp = run(["gpg", "--batch", "--with-colons", "--list-secret-keys", fingerprint], check=False)
     for line in cp.stdout.splitlines():
@@ -200,10 +234,13 @@ def assert_recipient_separation(recipients: Iterable[str]) -> list[str]:
     if len(set(normalized)) != len(normalized):
         raise CustodyError("duplicate recipient fingerprint")
     for fpr in normalized:
-        if fpr not in gpg_public_fingerprints(fpr):
+        primary = gpg_primary_fingerprint(fpr)
+        if primary is None:
             raise CustodyError(f"public recipient key unavailable: {fpr}")
-        if gpg_has_secret_record(fpr):
-            raise CustodyError(f"key separation failed: producer has secret-key record for recipient {fpr}")
+        if primary != fpr:
+            raise CustodyError(f"recipient must be the primary-key fingerprint, not a subkey: {fpr}")
+        if gpg_has_secret_record(primary):
+            raise CustodyError(f"key separation failed: producer has secret-key record for recipient {primary}")
     return normalized
 
 
@@ -237,6 +274,8 @@ def decrypt_gpg(ciphertext: Path, plaintext: Path) -> None:
 def validate_gs_base(uri: str) -> str:
     if not uri.startswith("gs://"):
         raise CustodyError("GCS target must start with gs://")
+    if any(ch.isspace() for ch in uri) or "#" in uri or "?" in uri:
+        raise CustodyError("GCS target contains unsupported fragment/query/whitespace")
     tail = uri[5:].strip("/")
     if "/" not in tail:
         raise CustodyError("GCS target must include a dedicated prefix, not bucket root")
@@ -250,15 +289,22 @@ def gcs_object_uri(base: str, object_id: str) -> str:
 
 
 def gcs_upload(local: Path, remote: str) -> dict:
+    local_md5 = md5_b64_file(local)
     cp = run([
         "gcloud", "storage", "cp", str(local), remote,
         "--if-generation-match=0",
+        f"--content-md5={local_md5}",
     ], check=False)
     if cp.returncode != 0:
         raise CustodyError(f"cloud upload failed: {cp.stderr.strip() or cp.stdout.strip()}")
     meta = gcs_stat(remote)
     if not str(meta.get("generation", "")):
         raise CustodyError("remote object metadata missing generation")
+    remote_md5 = str(meta.get("md5Hash", ""))
+    if not remote_md5:
+        raise CustodyError("remote object metadata missing MD5 transfer digest")
+    if remote_md5 != local_md5:
+        raise CustodyError("remote provider MD5 does not match local ciphertext")
     return meta
 
 
@@ -427,8 +473,7 @@ def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str]
 
 
 def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_ref: str) -> dict:
-    if not authority_ref.strip():
-        raise CustodyError("live upload requires a non-empty authority reference")
+    authority_ref = validate_authority_ref(authority_ref)
     recovery_dir = assert_private_runtime_path(recovery_dir)
     remote = gcs_object_uri(gcs_base, candidate["bundle_id"])
     meta = gcs_upload(Path(candidate["ciphertext"]["path"]), remote)
@@ -440,10 +485,11 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_re
         "uri": remote,
         "generation": str(meta.get("generation", "")),
         "size": remote_size,
+        "md5": meta.get("md5Hash"),
         "update_time": meta.get("updateTime"),
-        "verification": "REMOTE_OBJECT_PRESENT_SIZE_MATCH",
+        "verification": "REMOTE_OBJECT_PRESENT_SIZE_AND_PROVIDER_MD5_MATCH",
     }
-    candidate["authority_ref"] = authority_ref.strip()
+    candidate["authority_ref"] = authority_ref
     candidate["upload_observed_at"] = now_utc()
     recovery_dir.mkdir(parents=True, exist_ok=True)
     receipt_path = recovery_dir / f"{candidate['bundle_id']}.receipt.json"
@@ -453,6 +499,7 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_re
 
 
 def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -> dict:
+    receipt_path = assert_private_runtime_path(receipt_path)
     work_dir = assert_private_runtime_path(work_dir)
     output_dir = assert_private_runtime_path(output_dir)
     receipt = json.loads(receipt_path.read_text("utf-8"))
@@ -559,11 +606,11 @@ def build_parser() -> argparse.ArgumentParser:
     goal.add_argument("--input", required=True, help="ready evidence bundle directory")
     goal.add_argument("--work", required=True, help="private local work directory outside the repository")
     goal.add_argument("--recovery-dir", required=True, help="private recovery-package output directory outside the repository")
-    goal.add_argument("--recipient", action="append", required=True, help="full OpenPGP recipient fingerprint; repeat for recovery recipients")
+    goal.add_argument("--recipient", action="append", required=True, help="full OpenPGP primary-key recipient fingerprint; repeat for recovery recipients")
     goal.add_argument("--key-epoch", required=True)
     goal.add_argument("--gcs-base", required=True, help="dedicated gs://bucket/prefix")
     goal.add_argument("--approve-live-upload", action="store_true")
-    goal.add_argument("--authority-ref", help="normalized reference to explicit live-upload authority; required with --approve-live-upload")
+    goal.add_argument("--authority-ref", help="opaque normalized reference to explicit live-upload authority; required with --approve-live-upload")
 
     restore = sub.add_parser("restore")
     restore.add_argument("--receipt", required=True)

--- a/thin-rts/cloud-custody/custody.py
+++ b/thin-rts/cloud-custody/custody.py
@@ -15,7 +15,6 @@ import gzip
 import hashlib
 import io
 import json
-import os
 from pathlib import Path, PurePosixPath
 import re
 import secrets
@@ -30,6 +29,7 @@ from typing import Iterable
 SCHEMA = "thin-rts-cloud-custody/v0"
 INTERNAL_MANIFEST = "RTS_BUNDLE_MANIFEST.json"
 FINGERPRINT_RE = re.compile(r"^[0-9A-Fa-f]{40,64}$")
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class CustodyError(RuntimeError):
@@ -65,6 +65,14 @@ def tool_path(name: str) -> str | None:
     return shutil.which(name)
 
 
+def assert_private_runtime_path(path: Path, *, repo_root: Path = REPO_ROOT) -> Path:
+    resolved = path.expanduser().resolve()
+    repo = repo_root.expanduser().resolve()
+    if resolved == repo or resolved.is_relative_to(repo):
+        raise CustodyError(f"private runtime path must be outside public repository: {resolved}")
+    return resolved
+
+
 def normalized_rel_files(root: Path) -> list[Path]:
     root = root.resolve()
     files: list[Path] = []
@@ -76,17 +84,36 @@ def normalized_rel_files(root: Path) -> list[Path]:
     return sorted(files, key=lambda p: p.relative_to(root).as_posix())
 
 
+def _validate_manifest_relpath(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise CustodyError("manifest path must be a non-empty string")
+    rel = PurePosixPath(value)
+    if rel.is_absolute() or ".." in rel.parts or value == ".":
+        raise CustodyError(f"unsafe manifest path: {value!r}")
+    if value == INTERNAL_MANIFEST:
+        raise CustodyError("reserved internal manifest path cannot be an evidence entry")
+    return rel.as_posix()
+
+
 def build_manifest(root: Path) -> dict:
     root = root.resolve()
     if not root.is_dir():
         raise CustodyError(f"input directory not found: {root}")
+
     entries = []
     for p in normalized_rel_files(root):
+        rel = p.relative_to(root).as_posix()
+        if rel == INTERNAL_MANIFEST:
+            raise CustodyError(f"source evidence collides with reserved path: {INTERNAL_MANIFEST}")
         entries.append({
-            "path": p.relative_to(root).as_posix(),
+            "path": rel,
             "size": p.stat().st_size,
             "sha256": sha256_file(p),
         })
+
+    if not entries:
+        raise CustodyError("evidence bundle is empty")
+
     return {
         "schema": SCHEMA,
         "kind": "evidence-bundle-manifest",
@@ -113,7 +140,6 @@ def create_deterministic_bundle(input_dir: Path, output_path: Path) -> dict:
     manifest_bytes = canonical_json_bytes(manifest)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write deterministic tar first, then gzip with fixed mtime and no source filename.
     with tempfile.NamedTemporaryFile(prefix="rts-custody-", suffix=".tar", delete=False) as tf:
         tar_tmp = Path(tf.name)
     try:
@@ -224,10 +250,16 @@ def gcs_object_uri(base: str, object_id: str) -> str:
 
 
 def gcs_upload(local: Path, remote: str) -> dict:
-    cp = run(["gcloud", "storage", "cp", "--no-clobber", str(local), remote], check=False)
+    cp = run([
+        "gcloud", "storage", "cp", str(local), remote,
+        "--if-generation-match=0",
+    ], check=False)
     if cp.returncode != 0:
         raise CustodyError(f"cloud upload failed: {cp.stderr.strip() or cp.stdout.strip()}")
-    return gcs_stat(remote)
+    meta = gcs_stat(remote)
+    if not str(meta.get("generation", "")):
+        raise CustodyError("remote object metadata missing generation")
+    return meta
 
 
 def gcs_stat(remote: str) -> dict:
@@ -244,22 +276,38 @@ def gcs_stat(remote: str) -> dict:
     return data
 
 
-def gcs_download(remote: str, local: Path) -> None:
+def gcs_download(remote: str, local: Path, generation: str) -> None:
+    if not generation or not generation.isdigit():
+        raise CustodyError("recorded remote generation must be numeric")
     local.parent.mkdir(parents=True, exist_ok=True)
-    cp = run(["gcloud", "storage", "cp", remote, str(local)], check=False)
+    cp = run([
+        "gcloud", "storage", "cp", remote, str(local),
+        f"--if-generation-match={generation}",
+    ], check=False)
     if cp.returncode != 0:
         local.unlink(missing_ok=True)
-        raise CustodyError(f"cloud download failed: {cp.stderr.strip() or cp.stdout.strip()}")
+        raise CustodyError(f"cloud download failed or generation changed: {cp.stderr.strip() or cp.stdout.strip()}")
 
 
 def safe_extract_tar_gz(archive: Path, output_dir: Path) -> None:
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise CustodyError(f"restore destination is not a directory: {output_dir}")
+        if any(output_dir.iterdir()):
+            raise CustodyError(f"restore destination must be empty: {output_dir}")
+    else:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
     root = output_dir.resolve()
     with tarfile.open(archive, "r:gz") as tar:
+        seen = set()
         for member in tar.getmembers():
             member_path = PurePosixPath(member.name)
             if member_path.is_absolute() or ".." in member_path.parts:
                 raise CustodyError(f"unsafe archive member: {member.name}")
+            if member.name in seen:
+                raise CustodyError(f"duplicate archive member: {member.name}")
+            seen.add(member.name)
             if member.issym() or member.islnk() or member.isdev():
                 raise CustodyError(f"unsupported archive member type: {member.name}")
             target = (root / Path(*member_path.parts)).resolve()
@@ -269,24 +317,69 @@ def safe_extract_tar_gz(archive: Path, output_dir: Path) -> None:
 
 
 def verify_extracted_tree(root: Path) -> dict:
+    root = root.resolve()
     manifest_path = root / INTERNAL_MANIFEST
-    if not manifest_path.is_file():
-        raise CustodyError("internal manifest missing")
-    manifest = json.loads(manifest_path.read_text("utf-8"))
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise CustodyError("internal manifest missing or unsafe")
+
+    try:
+        manifest = json.loads(manifest_path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise CustodyError("internal manifest is unreadable or invalid JSON") from e
+
     if manifest.get("schema") != SCHEMA:
         raise CustodyError("manifest schema mismatch")
+    if manifest.get("kind") != "evidence-bundle-manifest" or manifest.get("hash") != "sha256":
+        raise CustodyError("manifest kind/hash contract mismatch")
+
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise CustodyError("manifest entries must be a non-empty list")
+
+    expected_paths: set[str] = set()
     failures = []
-    for entry in manifest.get("entries", []):
-        rel = entry.get("path", "")
-        p = root / rel
-        if not p.is_file():
-            failures.append({"path": rel, "reason": "missing"})
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise CustodyError("manifest entry must be an object")
+        rel = _validate_manifest_relpath(entry.get("path"))
+        if rel in expected_paths:
+            raise CustodyError(f"duplicate manifest path: {rel}")
+        expected_paths.add(rel)
+
+        p = (root / Path(*PurePosixPath(rel).parts)).resolve()
+        if p != root and root not in p.parents:
+            raise CustodyError(f"manifest path escapes restored root: {rel}")
+        if not p.is_file() or p.is_symlink():
+            failures.append({"path": rel, "reason": "missing_or_unsafe"})
             continue
+
         actual_size = p.stat().st_size
         actual_hash = sha256_file(p)
         if actual_size != entry.get("size") or actual_hash != entry.get("sha256"):
             failures.append({"path": rel, "reason": "digest_or_size_mismatch"})
-    return {"status": "PASS" if not failures else "FAIL", "failures": failures, "entries": len(manifest.get("entries", []))}
+
+    actual_paths = {
+        p.relative_to(root).as_posix()
+        for p in normalized_rel_files(root)
+        if p.relative_to(root).as_posix() != INTERNAL_MANIFEST
+    }
+    for rel in sorted(actual_paths - expected_paths):
+        failures.append({"path": rel, "reason": "unmanifested_extra"})
+    for rel in sorted(expected_paths - actual_paths):
+        if not any(f.get("path") == rel for f in failures):
+            failures.append({"path": rel, "reason": "missing"})
+
+    return {"status": "PASS" if not failures else "FAIL", "failures": failures, "entries": len(entries)}
+
+
+def verify_bundle_archive(archive: Path) -> dict:
+    with tempfile.TemporaryDirectory(prefix="rts-custody-selfverify-") as td:
+        out = Path(td) / "restored"
+        safe_extract_tar_gz(archive, out)
+        result = verify_extracted_tree(out)
+        if result["status"] != "PASS":
+            raise CustodyError(f"deterministic bundle self-verification failed: {result['failures']}")
+        return result
 
 
 def make_recovery_card(receipt: dict, path: Path) -> None:
@@ -298,6 +391,7 @@ def make_recovery_card(receipt: dict, path: Path) -> None:
         f"Bundle ID: `{receipt['bundle_id']}`",
         f"Ciphertext SHA-256: `{receipt['ciphertext']['sha256']}`",
         f"Remote generation: `{receipt['provider'].get('generation', 'UNKNOWN')}`",
+        f"Authority ref: `{receipt.get('authority_ref', 'NOT_RECORDED')}`",
         "",
         "Recovery requires:",
         "- this recovery receipt/card;",
@@ -312,11 +406,13 @@ def make_recovery_card(receipt: dict, path: Path) -> None:
 
 
 def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str], key_epoch: str) -> dict:
+    work_dir = assert_private_runtime_path(work_dir)
     work_dir.mkdir(parents=True, exist_ok=True)
     object_id = secrets.token_hex(16)
     archive = work_dir / f"{object_id}.tar.gz"
     ciphertext = work_dir / f"{object_id}.gpg"
     bundle = create_deterministic_bundle(input_dir, archive)
+    verify_bundle_archive(archive)
     enc = encrypt_gpg(archive, ciphertext, recipients)
     return {
         "schema": SCHEMA,
@@ -330,7 +426,10 @@ def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str]
     }
 
 
-def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
+def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_ref: str) -> dict:
+    if not authority_ref.strip():
+        raise CustodyError("live upload requires a non-empty authority reference")
+    recovery_dir = assert_private_runtime_path(recovery_dir)
     remote = gcs_object_uri(gcs_base, candidate["bundle_id"])
     meta = gcs_upload(Path(candidate["ciphertext"]["path"]), remote)
     remote_size = int(meta.get("size", -1))
@@ -344,6 +443,7 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
         "update_time": meta.get("updateTime"),
         "verification": "REMOTE_OBJECT_PRESENT_SIZE_MATCH",
     }
+    candidate["authority_ref"] = authority_ref.strip()
     candidate["upload_observed_at"] = now_utc()
     recovery_dir.mkdir(parents=True, exist_ok=True)
     receipt_path = recovery_dir / f"{candidate['bundle_id']}.receipt.json"
@@ -353,6 +453,8 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
 
 
 def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -> dict:
+    work_dir = assert_private_runtime_path(work_dir)
+    output_dir = assert_private_runtime_path(output_dir)
     receipt = json.loads(receipt_path.read_text("utf-8"))
     if receipt.get("schema") != SCHEMA:
         raise CustodyError("receipt schema mismatch")
@@ -361,15 +463,16 @@ def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -
     if not remote or not generation:
         raise CustodyError("receipt does not contain a verified remote object generation")
 
-    work_dir.mkdir(parents=True, exist_ok=True)
-    ciphertext = work_dir / f"restore-{receipt['bundle_id']}.gpg"
-    archive = work_dir / f"restore-{receipt['bundle_id']}.tar.gz"
-    gcs_download(remote, ciphertext)
-    if sha256_file(ciphertext) != receipt["ciphertext"]["sha256"]:
-        raise CustodyError("ciphertext digest mismatch")
     meta = gcs_stat(remote)
     if str(meta.get("generation", "")) != generation:
         raise CustodyError("remote object generation mismatch / possible stale or replaced object")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    ciphertext = work_dir / f"restore-{receipt['bundle_id']}.gpg"
+    archive = work_dir / f"restore-{receipt['bundle_id']}.tar.gz"
+    gcs_download(remote, ciphertext, generation)
+    if sha256_file(ciphertext) != receipt["ciphertext"]["sha256"]:
+        raise CustodyError("ciphertext digest mismatch")
     decrypt_gpg(ciphertext, archive)
     if sha256_file(archive) != receipt["plaintext"]["sha256"]:
         raise CustodyError("decrypted bundle digest mismatch")
@@ -377,7 +480,7 @@ def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -
     verify = verify_extracted_tree(output_dir)
     if verify["status"] != "PASS":
         raise CustodyError(f"manifest verification failed: {verify['failures']}")
-    return {"status": "PASS", "bundle_id": receipt["bundle_id"], "verified_entries": verify["entries"]}
+    return {"status": "PASS", "bundle_id": receipt["bundle_id"], "verified_entries": verify["entries"], "generation": generation}
 
 
 def doctor(recipients: list[str] | None = None, gcs_base: str | None = None) -> dict:
@@ -407,8 +510,9 @@ def cmd_goal(args: argparse.Namespace) -> int:
         print(json.dumps({"goal": "ERROR", "reason": "at least two separated recovery recipients are required for this candidate"}, indent=2))
         return 2
 
-    candidate = build_local_candidate(Path(args.input), Path(args.work), args.recipient, args.key_epoch)
-    recovery_dir = Path(args.recovery_dir)
+    work_dir = assert_private_runtime_path(Path(args.work))
+    recovery_dir = assert_private_runtime_path(Path(args.recovery_dir))
+    candidate = build_local_candidate(Path(args.input), work_dir, args.recipient, args.key_epoch)
     recovery_dir.mkdir(parents=True, exist_ok=True)
     local_receipt = recovery_dir / f"{candidate['bundle_id']}.preupload.json"
     write_json(local_receipt, candidate)
@@ -416,7 +520,7 @@ def cmd_goal(args: argparse.Namespace) -> int:
     if not args.approve_live_upload:
         print(json.dumps({
             "goal": "APPROVAL_REQUIRED",
-            "reason": "local deterministic bundle and public-key ciphertext created; live provider write not executed",
+            "reason": "local deterministic bundle and public-key ciphertext created and self-verified; live provider write not executed",
             "bundle_id": candidate["bundle_id"],
             "ciphertext_sha256": candidate["ciphertext"]["sha256"],
             "planned_remote": gcs_object_uri(args.gcs_base, candidate["bundle_id"]),
@@ -424,11 +528,19 @@ def cmd_goal(args: argparse.Namespace) -> int:
         }, ensure_ascii=False, indent=2))
         return 3
 
-    uploaded = live_upload(candidate, args.gcs_base, recovery_dir)
+    if not args.authority_ref:
+        print(json.dumps({
+            "goal": "APPROVAL_REQUIRED",
+            "reason": "--approve-live-upload was supplied but no explicit --authority-ref was recorded",
+        }, ensure_ascii=False, indent=2))
+        return 3
+
+    uploaded = live_upload(candidate, args.gcs_base, recovery_dir, args.authority_ref)
     print(json.dumps({
         "goal": "LIVE_UPLOAD_VERIFIED",
         "bundle_id": uploaded["bundle_id"],
         "remote_generation": uploaded["provider"].get("generation"),
+        "authority_ref": uploaded.get("authority_ref"),
         "next_gate": "fresh-environment restore using separated recovery identity",
         "full_completion": "NOT_COMPLETE",
     }, ensure_ascii=False, indent=2))
@@ -451,6 +563,7 @@ def build_parser() -> argparse.ArgumentParser:
     goal.add_argument("--key-epoch", required=True)
     goal.add_argument("--gcs-base", required=True, help="dedicated gs://bucket/prefix")
     goal.add_argument("--approve-live-upload", action="store_true")
+    goal.add_argument("--authority-ref", help="normalized reference to explicit live-upload authority; required with --approve-live-upload")
 
     restore = sub.add_parser("restore")
     restore.add_argument("--receipt", required=True)

--- a/thin-rts/cloud-custody/custody.py
+++ b/thin-rts/cloud-custody/custody.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Thin RTS encrypted cloud custody candidate.
+
+No custom cryptography. This module orchestrates standard tar/gzip semantics implemented
+with Python stdlib, GnuPG for public-key encryption, and Google Cloud CLI for the first
+provider adapter.
+
+Generated evidence, ciphertext, receipts, recovery material, and provider credentials
+must remain outside the public repository.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from typing import Iterable
+
+SCHEMA = "thin-rts-cloud-custody/v0"
+INTERNAL_MANIFEST = "RTS_BUNDLE_MANIFEST.json"
+FINGERPRINT_RE = re.compile(r"^[0-9A-Fa-f]{40,64}$")
+
+
+class CustodyError(RuntimeError):
+    pass
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def canonical_json_bytes(obj: object) -> bytes:
+    return (json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_json_bytes(obj))
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=check)
+
+
+def tool_path(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def normalized_rel_files(root: Path) -> list[Path]:
+    root = root.resolve()
+    files: list[Path] = []
+    for p in root.rglob("*"):
+        if p.is_symlink():
+            raise CustodyError(f"symlink rejected from evidence bundle: {p}")
+        if p.is_file():
+            files.append(p)
+    return sorted(files, key=lambda p: p.relative_to(root).as_posix())
+
+
+def build_manifest(root: Path) -> dict:
+    root = root.resolve()
+    if not root.is_dir():
+        raise CustodyError(f"input directory not found: {root}")
+    entries = []
+    for p in normalized_rel_files(root):
+        entries.append({
+            "path": p.relative_to(root).as_posix(),
+            "size": p.stat().st_size,
+            "sha256": sha256_file(p),
+        })
+    return {
+        "schema": SCHEMA,
+        "kind": "evidence-bundle-manifest",
+        "hash": "sha256",
+        "entries": entries,
+    }
+
+
+def _normalized_tarinfo(name: str, size: int, mode: int = 0o644) -> tarfile.TarInfo:
+    ti = tarfile.TarInfo(name=name)
+    ti.size = size
+    ti.mode = mode
+    ti.uid = 0
+    ti.gid = 0
+    ti.uname = ""
+    ti.gname = ""
+    ti.mtime = 0
+    return ti
+
+
+def create_deterministic_bundle(input_dir: Path, output_path: Path) -> dict:
+    input_dir = input_dir.resolve()
+    manifest = build_manifest(input_dir)
+    manifest_bytes = canonical_json_bytes(manifest)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write deterministic tar first, then gzip with fixed mtime and no source filename.
+    with tempfile.NamedTemporaryFile(prefix="rts-custody-", suffix=".tar", delete=False) as tf:
+        tar_tmp = Path(tf.name)
+    try:
+        with tarfile.open(tar_tmp, "w", format=tarfile.PAX_FORMAT) as tar:
+            for p in normalized_rel_files(input_dir):
+                rel = p.relative_to(input_dir).as_posix()
+                data = p.read_bytes()
+                tar.addfile(_normalized_tarinfo(rel, len(data)), io.BytesIO(data))
+            tar.addfile(_normalized_tarinfo(INTERNAL_MANIFEST, len(manifest_bytes)), io.BytesIO(manifest_bytes))
+        with tar_tmp.open("rb") as src, output_path.open("wb") as raw:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as gz:
+                shutil.copyfileobj(src, gz)
+    finally:
+        tar_tmp.unlink(missing_ok=True)
+
+    return {
+        "manifest": manifest,
+        "archive": str(output_path),
+        "archive_sha256": sha256_file(output_path),
+        "archive_size": output_path.stat().st_size,
+    }
+
+
+def _validate_fingerprint(value: str) -> str:
+    if not FINGERPRINT_RE.fullmatch(value):
+        raise CustodyError("recipient must be a full hexadecimal OpenPGP fingerprint")
+    return value.upper()
+
+
+def gpg_version() -> str:
+    cp = run(["gpg", "--version"])
+    return cp.stdout.splitlines()[0].strip() if cp.stdout else "gpg/version-unknown"
+
+
+def gpg_public_fingerprints(query: str) -> set[str]:
+    cp = run(["gpg", "--batch", "--with-colons", "--fingerprint", "--list-keys", query], check=False)
+    if cp.returncode != 0:
+        return set()
+    result = set()
+    for line in cp.stdout.splitlines():
+        parts = line.split(":")
+        if parts and parts[0] == "fpr" and len(parts) > 9 and parts[9]:
+            result.add(parts[9].upper())
+    return result
+
+
+def gpg_has_secret_record(fingerprint: str) -> bool:
+    cp = run(["gpg", "--batch", "--with-colons", "--list-secret-keys", fingerprint], check=False)
+    for line in cp.stdout.splitlines():
+        kind = line.split(":", 1)[0]
+        if kind in {"sec", "ssb"}:
+            return True
+    return False
+
+
+def assert_recipient_separation(recipients: Iterable[str]) -> list[str]:
+    normalized = [_validate_fingerprint(r) for r in recipients]
+    if len(set(normalized)) != len(normalized):
+        raise CustodyError("duplicate recipient fingerprint")
+    for fpr in normalized:
+        if fpr not in gpg_public_fingerprints(fpr):
+            raise CustodyError(f"public recipient key unavailable: {fpr}")
+        if gpg_has_secret_record(fpr):
+            raise CustodyError(f"key separation failed: producer has secret-key record for recipient {fpr}")
+    return normalized
+
+
+def encrypt_gpg(plaintext: Path, ciphertext: Path, recipients: list[str]) -> dict:
+    recipients = assert_recipient_separation(recipients)
+    ciphertext.parent.mkdir(parents=True, exist_ok=True)
+    cmd = ["gpg", "--batch", "--yes", "--no-default-recipient", "--output", str(ciphertext), "--encrypt"]
+    for fpr in recipients:
+        cmd.extend(["--recipient", fpr])
+    cmd.append(str(plaintext))
+    cp = run(cmd, check=False)
+    if cp.returncode != 0:
+        raise CustodyError(f"gpg encryption failed: {cp.stderr.strip()}")
+    return {
+        "tool": gpg_version(),
+        "format": "OpenPGP",
+        "recipients": recipients,
+        "ciphertext_sha256": sha256_file(ciphertext),
+        "ciphertext_size": ciphertext.stat().st_size,
+    }
+
+
+def decrypt_gpg(ciphertext: Path, plaintext: Path) -> None:
+    plaintext.parent.mkdir(parents=True, exist_ok=True)
+    cp = run(["gpg", "--batch", "--yes", "--output", str(plaintext), "--decrypt", str(ciphertext)], check=False)
+    if cp.returncode != 0:
+        plaintext.unlink(missing_ok=True)
+        raise CustodyError(f"gpg decryption failed: {cp.stderr.strip()}")
+
+
+def validate_gs_base(uri: str) -> str:
+    if not uri.startswith("gs://"):
+        raise CustodyError("GCS target must start with gs://")
+    tail = uri[5:].strip("/")
+    if "/" not in tail:
+        raise CustodyError("GCS target must include a dedicated prefix, not bucket root")
+    if ".." in PurePosixPath(tail).parts:
+        raise CustodyError("invalid GCS target")
+    return "gs://" + tail
+
+
+def gcs_object_uri(base: str, object_id: str) -> str:
+    return f"{validate_gs_base(base)}/{object_id}.gpg"
+
+
+def gcs_upload(local: Path, remote: str) -> dict:
+    cp = run(["gcloud", "storage", "cp", "--no-clobber", str(local), remote], check=False)
+    if cp.returncode != 0:
+        raise CustodyError(f"cloud upload failed: {cp.stderr.strip() or cp.stdout.strip()}")
+    return gcs_stat(remote)
+
+
+def gcs_stat(remote: str) -> dict:
+    cp = run([
+        "gcloud", "storage", "objects", "describe", remote,
+        "--format=json(name,bucket,generation,size,updateTime,md5Hash,crc32c)",
+    ], check=False)
+    if cp.returncode != 0:
+        raise CustodyError(f"remote object describe failed: {cp.stderr.strip() or cp.stdout.strip()}")
+    try:
+        data = json.loads(cp.stdout)
+    except json.JSONDecodeError as e:
+        raise CustodyError("remote object metadata was not valid JSON") from e
+    return data
+
+
+def gcs_download(remote: str, local: Path) -> None:
+    local.parent.mkdir(parents=True, exist_ok=True)
+    cp = run(["gcloud", "storage", "cp", remote, str(local)], check=False)
+    if cp.returncode != 0:
+        local.unlink(missing_ok=True)
+        raise CustodyError(f"cloud download failed: {cp.stderr.strip() or cp.stdout.strip()}")
+
+
+def safe_extract_tar_gz(archive: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root = output_dir.resolve()
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            member_path = PurePosixPath(member.name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise CustodyError(f"unsafe archive member: {member.name}")
+            if member.issym() or member.islnk() or member.isdev():
+                raise CustodyError(f"unsupported archive member type: {member.name}")
+            target = (root / Path(*member_path.parts)).resolve()
+            if target != root and root not in target.parents:
+                raise CustodyError(f"archive escapes output directory: {member.name}")
+        tar.extractall(root, filter="data")
+
+
+def verify_extracted_tree(root: Path) -> dict:
+    manifest_path = root / INTERNAL_MANIFEST
+    if not manifest_path.is_file():
+        raise CustodyError("internal manifest missing")
+    manifest = json.loads(manifest_path.read_text("utf-8"))
+    if manifest.get("schema") != SCHEMA:
+        raise CustodyError("manifest schema mismatch")
+    failures = []
+    for entry in manifest.get("entries", []):
+        rel = entry.get("path", "")
+        p = root / rel
+        if not p.is_file():
+            failures.append({"path": rel, "reason": "missing"})
+            continue
+        actual_size = p.stat().st_size
+        actual_hash = sha256_file(p)
+        if actual_size != entry.get("size") or actual_hash != entry.get("sha256"):
+            failures.append({"path": rel, "reason": "digest_or_size_mismatch"})
+    return {"status": "PASS" if not failures else "FAIL", "failures": failures, "entries": len(manifest.get("entries", []))}
+
+
+def make_recovery_card(receipt: dict, path: Path) -> None:
+    lines = [
+        "# Thin RTS Recovery Card",
+        "",
+        f"Schema: `{receipt['schema']}`",
+        f"Key epoch: `{receipt['key_epoch']}`",
+        f"Bundle ID: `{receipt['bundle_id']}`",
+        f"Ciphertext SHA-256: `{receipt['ciphertext']['sha256']}`",
+        f"Remote generation: `{receipt['provider'].get('generation', 'UNKNOWN')}`",
+        "",
+        "Recovery requires:",
+        "- this recovery receipt/card;",
+        "- the separated OpenPGP recovery identity for the matching key epoch;",
+        "- GnuPG;",
+        "- access to the recorded provider object or an equivalent transported copy.",
+        "",
+        "A successful restore is not 'file opened'. It must verify ciphertext digest, plaintext bundle digest, and the internal manifest.",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str], key_epoch: str) -> dict:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    object_id = secrets.token_hex(16)
+    archive = work_dir / f"{object_id}.tar.gz"
+    ciphertext = work_dir / f"{object_id}.gpg"
+    bundle = create_deterministic_bundle(input_dir, archive)
+    enc = encrypt_gpg(archive, ciphertext, recipients)
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "bundle_id": object_id,
+        "key_epoch": key_epoch,
+        "plaintext": {"sha256": bundle["archive_sha256"], "size": bundle["archive_size"]},
+        "ciphertext": {"path": str(ciphertext), "sha256": enc["ciphertext_sha256"], "size": enc["ciphertext_size"], "format": enc["format"], "tool": enc["tool"]},
+        "recipients": enc["recipients"],
+        "provider": {"type": "gcs", "status": "NOT_UPLOADED"},
+    }
+
+
+def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
+    remote = gcs_object_uri(gcs_base, candidate["bundle_id"])
+    meta = gcs_upload(Path(candidate["ciphertext"]["path"]), remote)
+    remote_size = int(meta.get("size", -1))
+    if remote_size != int(candidate["ciphertext"]["size"]):
+        raise CustodyError(f"remote size mismatch: expected {candidate['ciphertext']['size']} got {remote_size}")
+    candidate["provider"] = {
+        "type": "gcs",
+        "uri": remote,
+        "generation": str(meta.get("generation", "")),
+        "size": remote_size,
+        "update_time": meta.get("updateTime"),
+        "verification": "REMOTE_OBJECT_PRESENT_SIZE_MATCH",
+    }
+    candidate["upload_observed_at"] = now_utc()
+    recovery_dir.mkdir(parents=True, exist_ok=True)
+    receipt_path = recovery_dir / f"{candidate['bundle_id']}.receipt.json"
+    write_json(receipt_path, candidate)
+    make_recovery_card(candidate, recovery_dir / f"{candidate['bundle_id']}.RECOVERY_CARD.md")
+    return candidate
+
+
+def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -> dict:
+    receipt = json.loads(receipt_path.read_text("utf-8"))
+    if receipt.get("schema") != SCHEMA:
+        raise CustodyError("receipt schema mismatch")
+    remote = receipt.get("provider", {}).get("uri")
+    generation = str(receipt.get("provider", {}).get("generation", ""))
+    if not remote or not generation:
+        raise CustodyError("receipt does not contain a verified remote object generation")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    ciphertext = work_dir / f"restore-{receipt['bundle_id']}.gpg"
+    archive = work_dir / f"restore-{receipt['bundle_id']}.tar.gz"
+    gcs_download(remote, ciphertext)
+    if sha256_file(ciphertext) != receipt["ciphertext"]["sha256"]:
+        raise CustodyError("ciphertext digest mismatch")
+    meta = gcs_stat(remote)
+    if str(meta.get("generation", "")) != generation:
+        raise CustodyError("remote object generation mismatch / possible stale or replaced object")
+    decrypt_gpg(ciphertext, archive)
+    if sha256_file(archive) != receipt["plaintext"]["sha256"]:
+        raise CustodyError("decrypted bundle digest mismatch")
+    safe_extract_tar_gz(archive, output_dir)
+    verify = verify_extracted_tree(output_dir)
+    if verify["status"] != "PASS":
+        raise CustodyError(f"manifest verification failed: {verify['failures']}")
+    return {"status": "PASS", "bundle_id": receipt["bundle_id"], "verified_entries": verify["entries"]}
+
+
+def doctor(recipients: list[str] | None = None, gcs_base: str | None = None) -> dict:
+    tools = {name: tool_path(name) for name in ("gpg", "gcloud")}
+    errors = [f"missing tool: {name}" for name, path in tools.items() if not path]
+    result: dict = {"schema": SCHEMA, "tools": tools, "errors": errors}
+    if recipients:
+        try:
+            result["recipients"] = assert_recipient_separation(recipients)
+        except CustodyError as e:
+            errors.append(str(e))
+    if gcs_base:
+        try:
+            result["gcs_base"] = validate_gs_base(gcs_base)
+        except CustodyError as e:
+            errors.append(str(e))
+    result["status"] = "PASS" if not errors else "ERROR"
+    return result
+
+
+def cmd_goal(args: argparse.Namespace) -> int:
+    d = doctor(args.recipient, args.gcs_base)
+    if d["status"] != "PASS":
+        print(json.dumps({"goal": "ERROR", "detail": d}, ensure_ascii=False, indent=2))
+        return 2
+    if len(args.recipient) < 2:
+        print(json.dumps({"goal": "ERROR", "reason": "at least two separated recovery recipients are required for this candidate"}, indent=2))
+        return 2
+
+    candidate = build_local_candidate(Path(args.input), Path(args.work), args.recipient, args.key_epoch)
+    recovery_dir = Path(args.recovery_dir)
+    recovery_dir.mkdir(parents=True, exist_ok=True)
+    local_receipt = recovery_dir / f"{candidate['bundle_id']}.preupload.json"
+    write_json(local_receipt, candidate)
+
+    if not args.approve_live_upload:
+        print(json.dumps({
+            "goal": "APPROVAL_REQUIRED",
+            "reason": "local deterministic bundle and public-key ciphertext created; live provider write not executed",
+            "bundle_id": candidate["bundle_id"],
+            "ciphertext_sha256": candidate["ciphertext"]["sha256"],
+            "planned_remote": gcs_object_uri(args.gcs_base, candidate["bundle_id"]),
+            "preupload_receipt": str(local_receipt),
+        }, ensure_ascii=False, indent=2))
+        return 3
+
+    uploaded = live_upload(candidate, args.gcs_base, recovery_dir)
+    print(json.dumps({
+        "goal": "LIVE_UPLOAD_VERIFIED",
+        "bundle_id": uploaded["bundle_id"],
+        "remote_generation": uploaded["provider"].get("generation"),
+        "next_gate": "fresh-environment restore using separated recovery identity",
+        "full_completion": "NOT_COMPLETE",
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Thin RTS encrypted cloud custody candidate")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    doc = sub.add_parser("doctor")
+    doc.add_argument("--recipient", action="append", default=[])
+    doc.add_argument("--gcs-base")
+
+    goal = sub.add_parser("goal", help="run until approval is required, an error occurs, or a verified live upload completes")
+    goal.add_argument("--input", required=True, help="ready evidence bundle directory")
+    goal.add_argument("--work", required=True, help="private local work directory outside the repository")
+    goal.add_argument("--recovery-dir", required=True, help="private recovery-package output directory outside the repository")
+    goal.add_argument("--recipient", action="append", required=True, help="full OpenPGP recipient fingerprint; repeat for recovery recipients")
+    goal.add_argument("--key-epoch", required=True)
+    goal.add_argument("--gcs-base", required=True, help="dedicated gs://bucket/prefix")
+    goal.add_argument("--approve-live-upload", action="store_true")
+
+    restore = sub.add_parser("restore")
+    restore.add_argument("--receipt", required=True)
+    restore.add_argument("--output", required=True)
+    restore.add_argument("--work", required=True)
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "doctor":
+            result = doctor(args.recipient, args.gcs_base)
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0 if result["status"] == "PASS" else 2
+        if args.command == "goal":
+            return cmd_goal(args)
+        if args.command == "restore":
+            result = restore_from_receipt(Path(args.receipt), Path(args.output), Path(args.work))
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+    except CustodyError as e:
+        print(json.dumps({"goal": "ERROR", "error": str(e)}, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/thin-rts/cloud-custody/test_custody.py
+++ b/thin-rts/cloud-custody/test_custody.py
@@ -1,0 +1,63 @@
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+import custody
+
+
+class CustodyPureTests(unittest.TestCase):
+    def test_deterministic_bundle(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            (root / "a.txt").write_text("alpha\n", encoding="utf-8")
+            (root / "nested").mkdir()
+            (root / "nested" / "b.bin").write_bytes(b"beta\x00")
+            out1 = Path(td) / "one.tar.gz"
+            out2 = Path(td) / "two.tar.gz"
+            r1 = custody.create_deterministic_bundle(root, out1)
+            r2 = custody.create_deterministic_bundle(root, out2)
+            self.assertEqual(r1["archive_sha256"], r2["archive_sha256"])
+            self.assertEqual(out1.read_bytes(), out2.read_bytes())
+
+    def test_manifest_verification_detects_mutation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            (root / "evidence.txt").write_text("original", encoding="utf-8")
+            archive = Path(td) / "bundle.tar.gz"
+            custody.create_deterministic_bundle(root, archive)
+            extracted = Path(td) / "out"
+            custody.safe_extract_tar_gz(archive, extracted)
+            self.assertEqual(custody.verify_extracted_tree(extracted)["status"], "PASS")
+            (extracted / "evidence.txt").write_text("mutated", encoding="utf-8")
+            self.assertEqual(custody.verify_extracted_tree(extracted)["status"], "FAIL")
+
+    def test_safe_extract_rejects_parent_escape(self):
+        with tempfile.TemporaryDirectory() as td:
+            archive = Path(td) / "evil.tar.gz"
+            with tarfile.open(archive, "w:gz") as tar:
+                payload = b"evil"
+                ti = tarfile.TarInfo("../escape.txt")
+                ti.size = len(payload)
+                tar.addfile(ti, io.BytesIO(payload))
+            with self.assertRaises(custody.CustodyError):
+                custody.safe_extract_tar_gz(archive, Path(td) / "out")
+
+    def test_gcs_target_requires_prefix(self):
+        with self.assertRaises(custody.CustodyError):
+            custody.validate_gs_base("gs://bucket")
+        self.assertEqual(custody.validate_gs_base("gs://bucket/private/custody"), "gs://bucket/private/custody")
+
+    def test_full_fingerprint_required(self):
+        with self.assertRaises(custody.CustodyError):
+            custody._validate_fingerprint("DEADBEEF")
+        value = "A" * 40
+        self.assertEqual(custody._validate_fingerprint(value), value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thin-rts/cloud-custody/test_meteor_custody.py
+++ b/thin-rts/cloud-custody/test_meteor_custody.py
@@ -109,7 +109,10 @@ class CustodyMeteorAttackTests(unittest.TestCase):
             calls.append(cmd)
             if "describe" in cmd:
                 return subprocess.CompletedProcess(
-                    cmd, 0, stdout='{"generation":"1","size":"3"}', stderr=""
+                    cmd,
+                    0,
+                    stdout='{"generation":"1","size":"3","md5Hash":"kAFQmDzST7DWlj99KOF/cg=="}',
+                    stderr="",
                 )
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 

--- a/thin-rts/cloud-custody/test_meteor_custody.py
+++ b/thin-rts/cloud-custody/test_meteor_custody.py
@@ -1,0 +1,132 @@
+import inspect
+import io
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+
+import custody
+
+
+class CustodyMeteorAttackTests(unittest.TestCase):
+    def _write_manifest(self, root: Path, entries: list[dict]) -> None:
+        payload = {
+            "schema": custody.SCHEMA,
+            "kind": "evidence-bundle-manifest",
+            "hash": "sha256",
+            "entries": entries,
+        }
+        (root / custody.INTERNAL_MANIFEST).write_text(
+            json.dumps(payload, sort_keys=True), encoding="utf-8"
+        )
+
+    def test_empty_evidence_bundle_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            with self.assertRaises(custody.CustodyError):
+                custody.create_deterministic_bundle(root, Path(td) / "bundle.tar.gz")
+
+    def test_reserved_internal_manifest_name_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            (root / custody.INTERNAL_MANIFEST).write_text("source collision", encoding="utf-8")
+            with self.assertRaises(custody.CustodyError):
+                custody.create_deterministic_bundle(root, Path(td) / "bundle.tar.gz")
+
+    def test_manifest_parent_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "restored"
+            root.mkdir()
+            outside = base / "outside.txt"
+            outside.write_text("outside", encoding="utf-8")
+            self._write_manifest(
+                root,
+                [{
+                    "path": "../outside.txt",
+                    "size": outside.stat().st_size,
+                    "sha256": custody.sha256_file(outside),
+                }],
+            )
+            with self.assertRaises(custody.CustodyError):
+                custody.verify_extracted_tree(root)
+
+    def test_unmanifested_extra_file_makes_verification_fail(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "evidence.txt"
+            evidence.write_text("evidence", encoding="utf-8")
+            self._write_manifest(
+                root,
+                [{
+                    "path": "evidence.txt",
+                    "size": evidence.stat().st_size,
+                    "sha256": custody.sha256_file(evidence),
+                }],
+            )
+            (root / "stale-extra.txt").write_text("stale", encoding="utf-8")
+            result = custody.verify_extracted_tree(root)
+            self.assertEqual(result["status"], "FAIL")
+
+    def test_duplicate_manifest_paths_are_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "evidence.txt"
+            evidence.write_text("evidence", encoding="utf-8")
+            entry = {
+                "path": "evidence.txt",
+                "size": evidence.stat().st_size,
+                "sha256": custody.sha256_file(evidence),
+            }
+            self._write_manifest(root, [entry, dict(entry)])
+            with self.assertRaises(custody.CustodyError):
+                custody.verify_extracted_tree(root)
+
+    def test_extract_into_dirty_destination_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            archive = base / "bundle.tar.gz"
+            with tarfile.open(archive, "w:gz") as tar:
+                payload = b"fresh"
+                ti = tarfile.TarInfo("fresh.txt")
+                ti.size = len(payload)
+                tar.addfile(ti, io.BytesIO(payload))
+            out = base / "out"
+            out.mkdir()
+            (out / "stale.txt").write_text("stale", encoding="utf-8")
+            with self.assertRaises(custody.CustodyError):
+                custody.safe_extract_tar_gz(archive, out)
+
+    def test_new_object_upload_uses_generation_zero_precondition(self):
+        calls = []
+
+        def fake_run(cmd, *, check=True):
+            calls.append(cmd)
+            if "describe" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout='{"generation":"1","size":"3"}', stderr=""
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as td:
+            local = Path(td) / "x.gpg"
+            local.write_bytes(b"abc")
+            with mock.patch.object(custody, "run", side_effect=fake_run):
+                custody.gcs_upload(local, "gs://bucket/private/x.gpg")
+
+        upload_cmd = calls[0]
+        self.assertIn("--if-generation-match=0", upload_cmd)
+        self.assertNotIn("--no-clobber", upload_cmd)
+
+    def test_download_api_requires_recorded_generation(self):
+        params = inspect.signature(custody.gcs_download).parameters
+        self.assertIn("generation", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thin-rts/cloud-custody/test_meteor_custody_round2.py
+++ b/thin-rts/cloud-custody/test_meteor_custody_round2.py
@@ -1,0 +1,136 @@
+import hashlib
+import base64
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import custody
+
+
+class CustodyMeteorRound2Tests(unittest.TestCase):
+    def test_two_recipients_cannot_be_primary_and_subkey_of_same_key(self):
+        primary = "A" * 40
+        subkey = "B" * 40
+        public_listing = (
+            "pub::::::::::\n"
+            f"fpr:::::::::{primary}:\n"
+            "sub::::::::::\n"
+            f"fpr:::::::::{subkey}:\n"
+        )
+
+        def fake_run(cmd, *, check=True):
+            if "--list-secret-keys" in cmd:
+                return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="")
+            if "--list-keys" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout=public_listing, stderr="")
+            raise AssertionError(cmd)
+
+        with mock.patch.object(custody, "run", side_effect=fake_run):
+            with self.assertRaises(custody.CustodyError):
+                custody.assert_recipient_separation([primary, subkey])
+
+    def test_authority_ref_rejects_free_text_and_newlines(self):
+        candidate = {
+            "schema": custody.SCHEMA,
+            "bundle_id": "a" * 32,
+            "key_epoch": "epoch-1",
+            "plaintext": {"sha256": "0" * 64, "size": 1},
+            "ciphertext": {
+                "path": "/tmp/fake.gpg",
+                "sha256": "1" * 64,
+                "size": 1,
+                "format": "OpenPGP",
+                "tool": "gpg",
+            },
+            "recipients": ["A" * 40, "C" * 40],
+            "provider": {"type": "gcs", "status": "NOT_UPLOADED"},
+        }
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch.object(
+                custody,
+                "gcs_upload",
+                return_value={"generation": "1", "size": "1", "updateTime": "now"},
+            ):
+                with self.assertRaises(custody.CustodyError):
+                    custody.live_upload(
+                        candidate,
+                        "gs://bucket/private",
+                        Path(td),
+                        "approved\nraw private wording",
+                    )
+
+    def test_gcs_target_rejects_generation_fragment_or_control_chars(self):
+        for value in (
+            "gs://bucket/private#123",
+            "gs://bucket/private?x=1",
+            "gs://bucket/private\nother",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(custody.CustodyError):
+                    custody.validate_gs_base(value)
+
+    def test_upload_binds_provider_md5_to_local_ciphertext(self):
+        calls = []
+
+        def fake_run(cmd, *, check=True):
+            calls.append(cmd)
+            if "describe" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout='{"generation":"1","size":"3","md5Hash":"WRONG"}',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as td:
+            local = Path(td) / "cipher.gpg"
+            local.write_bytes(b"abc")
+            with mock.patch.object(custody, "run", side_effect=fake_run):
+                with self.assertRaises(custody.CustodyError):
+                    custody.gcs_upload(local, "gs://bucket/private/x.gpg")
+
+    def test_upload_sends_content_md5_for_provider_transfer_check(self):
+        calls = []
+
+        def fake_run(cmd, *, check=True):
+            calls.append(cmd)
+            if "describe" in cmd:
+                local_md5 = base64.b64encode(hashlib.md5(b"abc").digest()).decode("ascii")
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=(
+                        '{"generation":"1","size":"3","md5Hash":"'
+                        + local_md5
+                        + '"}'
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as td:
+            local = Path(td) / "cipher.gpg"
+            local.write_bytes(b"abc")
+            with mock.patch.object(custody, "run", side_effect=fake_run):
+                custody.gcs_upload(local, "gs://bucket/private/x.gpg")
+
+        upload_cmd = calls[0]
+        self.assertTrue(any(arg.startswith("--content-md5=") for arg in upload_cmd))
+
+    def test_restore_rejects_receipt_inside_public_repository_before_read(self):
+        inside_repo = custody.REPO_ROOT / "DO_NOT_CREATE.receipt.json"
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            with self.assertRaises(custody.CustodyError):
+                custody.restore_from_receipt(
+                    inside_repo,
+                    base / "restore",
+                    base / "work",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
**SUPERSEDED / ABSORBED BY #318 — 新RTS（仮称） Continuity / Recovery v0.**

This prototype remains preserved as historical METEOR evidence. Its Cloud Custody implementation and inherited death causes were composed into #318, subjected to additional continuity/fresh-recovery attacks, and the surviving contract/reference occupants were adopted there. Do not delete this PR: its two destructive rounds are part of the regression lineage.

---

Implements the external-first encrypted cloud custody **prototype** under `/goal`, using the WITNESS method. It is deliberately not treated as an implementation entitled to survive.

WITNESS/Meteor status:
- Round 1 killed the prototype on 8 material package/verification/provider-generation failures.
- The exact death causes were retained as regression attacks and patched with bounded glue only.
- Round 2 rotated to trust boundaries and killed it again on 6 additional material failures.
- Those causes were also retained and patched without adding custom crypto, object storage, or a key vault.
- Current candidate + inherited Meteor suite is green after the second repair.
- Structural attack is now `SEARCH_SATURATED_UNDER_CURRENT_EVIDENCE`; the next materially new evidence requires the live producer/key/provider/recovery environment.

Externalized responsibilities:
- GnuPG: public-key crypto
- Google Cloud tooling/provider: first object-storage transport

Surviving Thin RTS glue is limited to deterministic package/manifest validation, provider precondition/digest/generation binding, authority boundaries, recovery metadata, and independent verification orchestration.

No live cloud write has been performed by this branch. `/goal` must stop at `APPROVAL_REQUIRED` before a live upload unless explicit authority is supplied and recorded as an opaque authority reference.

This PR remains historical evidence only; promotion occurred through #318 after additional continuity/recovery validation.