### PR TITLE
feat: 新RTS（仮称） continuity and recovery v0

### DIFF
--- a/.github/workflows/cloud-custody-candidate-tests.yml
+++ b/.github/workflows/cloud-custody-candidate-tests.yml
@@ -24,10 +24,10 @@ jobs:
         working-directory: thin-rts/cloud-custody
     steps:
       - uses: actions/checkout@v4
-      - name: Compile candidate
-        run: python3 -m py_compile custody.py test_custody.py
-      - name: Run pure unit tests
-        run: python3 -m unittest -v test_custody.py
+      - name: Compile candidate and Meteor attacks
+        run: python3 -m py_compile custody.py test_custody.py test_meteor_custody.py
+      - name: Run candidate plus Meteor attack suite
+        run: python3 -m unittest -v
       - name: Confirm no generated custody artifacts are tracked
         run: |
           if git ls-files '*.gpg' '*.tar.gz' '*.receipt.json' '*.preupload.json' '*.RECOVERY_CARD.md' | grep -q .; then

--- a/.github/workflows/cloud-custody-candidate-tests.yml
+++ b/.github/workflows/cloud-custody-candidate-tests.yml
@@ -1,32 +1,38 @@
 name: Cloud Custody Candidate Tests
 
 on:
-  push:
-    branches:
-      - feature/encrypted-cloud-custody-v0
-    paths:
-      - 'thin-rts/cloud-custody/**'
-      - '.github/workflows/cloud-custody-candidate-tests.yml'
   pull_request:
     paths:
       - 'thin-rts/cloud-custody/**'
+      - 'thin-rts/continuity/**'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+  push:
+    branches:
+      - feature/new-rts-continuity-recovery-v0
+    paths:
+      - 'thin-rts/cloud-custody/**'
+      - 'thin-rts/continuity/**'
       - '.github/workflows/cloud-custody-candidate-tests.yml'
 
 permissions:
   contents: read
 
 jobs:
-  unit:
+  inherited-cloud-custody:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 8
     defaults:
       run:
         working-directory: thin-rts/cloud-custody
     steps:
-      - uses: actions/checkout@v4
-      - name: Compile candidate and Meteor attacks
-        run: python3 -m py_compile custody.py test_custody.py test_meteor_custody.py
-      - name: Run candidate plus Meteor attack suite
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Compile candidate and inherited Meteor attacks
+        run: python3 -m py_compile custody.py test_custody.py test_meteor_custody.py test_meteor_custody_round2.py
+      - name: Run inherited Cloud Custody candidate plus Meteor suite
         run: python3 -m unittest -v
       - name: Confirm no generated custody artifacts are tracked
         run: |

--- a/.github/workflows/cloud-custody-candidate-tests.yml
+++ b/.github/workflows/cloud-custody-candidate-tests.yml
@@ -1,0 +1,36 @@
+name: Cloud Custody Candidate Tests
+
+on:
+  push:
+    branches:
+      - feature/encrypted-cloud-custody-v0
+    paths:
+      - 'thin-rts/cloud-custody/**'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+  pull_request:
+    paths:
+      - 'thin-rts/cloud-custody/**'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    defaults:
+      run:
+        working-directory: thin-rts/cloud-custody
+    steps:
+      - uses: actions/checkout@v4
+      - name: Compile candidate
+        run: python3 -m py_compile custody.py test_custody.py
+      - name: Run pure unit tests
+        run: python3 -m unittest -v test_custody.py
+      - name: Confirm no generated custody artifacts are tracked
+        run: |
+          if git ls-files '*.gpg' '*.tar.gz' '*.receipt.json' '*.preupload.json' '*.RECOVERY_CARD.md' | grep -q .; then
+            echo 'generated custody/recovery artifact is tracked' >&2
+            exit 1
+          fi

--- a/.github/workflows/continuity-recovery-candidate-tests.yml
+++ b/.github/workflows/continuity-recovery-candidate-tests.yml
@@ -30,15 +30,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Compile continuity candidate and tests
-        working-directory: thin-rts/continuity
-        run: python3 -m py_compile continuity.py test_continuity.py test_continuity_custody_integration.py
-
-      - name: Run Continuity Meteor regressions
-        working-directory: thin-rts/continuity
-        run: python3 -m unittest -v test_continuity.py
-
-      - name: Exercise provider-neutral capture on the actual PR repository
+      - name: Exercise provider-neutral capture on the untouched PR repository
         run: |
           ROOT="$RUNNER_TEMP/new-rts-continuity-live"
           mkdir -p "$ROOT"
@@ -48,6 +40,14 @@ jobs:
             --restore-root "$ROOT/restore" \
             --receipt "$ROOT/recovery-drill.json"
           test -s "$ROOT/recovery-drill.json"
+
+      - name: Compile continuity candidate and tests
+        working-directory: thin-rts/continuity
+        run: python3 -m py_compile continuity.py test_continuity.py test_continuity_custody_integration.py
+
+      - name: Run Continuity Meteor regressions
+        working-directory: thin-rts/continuity
+        run: python3 -m unittest -v test_continuity.py
 
   encrypted-alternate-domain-drill:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuity-recovery-candidate-tests.yml
+++ b/.github/workflows/continuity-recovery-candidate-tests.yml
@@ -1,0 +1,64 @@
+name: Continuity Recovery Candidate Tests
+
+on:
+  pull_request:
+    paths:
+      - 'thin-rts/continuity/**'
+      - 'thin-rts/cloud-custody/**'
+      - '.github/workflows/continuity-recovery-candidate-tests.yml'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+  push:
+    branches:
+      - feature/new-rts-continuity-recovery-v0
+    paths:
+      - 'thin-rts/continuity/**'
+      - 'thin-rts/cloud-custody/**'
+      - '.github/workflows/continuity-recovery-candidate-tests.yml'
+      - '.github/workflows/cloud-custody-candidate-tests.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  continuity-meteor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    steps:
+      - name: Checkout complete Git history
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Compile continuity candidate and tests
+        working-directory: thin-rts/continuity
+        run: python3 -m py_compile continuity.py test_continuity.py test_continuity_custody_integration.py
+
+      - name: Run Continuity Meteor regressions
+        working-directory: thin-rts/continuity
+        run: python3 -m unittest -v test_continuity.py
+
+      - name: Exercise provider-neutral capture on the actual PR repository
+        run: |
+          ROOT="$RUNNER_TEMP/new-rts-continuity-live"
+          mkdir -p "$ROOT"
+          python3 thin-rts/continuity/continuity.py goal \
+            --repo "$GITHUB_WORKSPACE" \
+            --output "$ROOT/capsule" \
+            --restore-root "$ROOT/restore" \
+            --receipt "$ROOT/recovery-drill.json"
+          test -s "$ROOT/recovery-drill.json"
+
+  encrypted-alternate-domain-drill:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Prove real GPG alternate-domain recovery
+        working-directory: thin-rts/continuity
+        run: python3 -m unittest -v test_continuity_custody_integration.py

--- a/thin-rts/cloud-custody/.gitignore
+++ b/thin-rts/cloud-custody/.gitignore
@@ -1,0 +1,10 @@
+# Never commit generated custody artifacts or recovery material.
+work/
+recovery-package/
+*.gpg
+*.tar
+*.tar.gz
+*.receipt.json
+*.preupload.json
+*.RECOVERY_CARD.md
+__pycache__/

--- a/thin-rts/cloud-custody/AUTOPSY_0001.md
+++ b/thin-rts/cloud-custody/AUTOPSY_0001.md
@@ -1,0 +1,37 @@
+# AUTOPSY 0001 — Custody Prototype Death
+
+Observed CI run: `Cloud Custody Candidate Tests` run 8
+
+Status: `PROTOTYPE_KILLED / PATCH_REQUIRED`
+
+The first WITNESS Meteor attack produced **8 material failures out of 13 tests**. This is accepted as successful destructive evidence.
+
+## Material death causes
+
+1. restore download was not generation-bound;
+2. duplicate manifest paths were accepted;
+3. an empty evidence bundle could be packaged as success;
+4. extraction into a dirty destination could mix stale and restored material;
+5. manifest `..` escape could reference material outside the restored root;
+6. new-object upload used best-effort `--no-clobber` instead of an atomic generation-zero precondition;
+7. source evidence could collide with the reserved internal manifest filename;
+8. unmanifested extra files were silently accepted by verification.
+
+## Classification
+
+These failures do **not** prove that custom cryptography or a custom storage engine is needed.
+
+Current responsibility classification remains:
+
+- cryptography: `EXTERNALIZE` to GnuPG;
+- cloud transport/storage: `EXTERNALIZE` to Google Cloud tooling/provider for the first adapter;
+- manifest/path validation, generation binding, deterministic package/recovery verification: bounded `GLUE` candidate;
+- custom crypto / custom object store / custom key vault: `DROP`.
+
+## Darwin action
+
+Patch only the demonstrated glue gaps. Do not expand architecture.
+
+Then rerun the exact same frozen attack suite before adding new attack angles.
+
+`SAME DEATH CAUSE MUST NOT RECUR UNCHANGED.`

--- a/thin-rts/cloud-custody/AUTOPSY_0002.md
+++ b/thin-rts/cloud-custody/AUTOPSY_0002.md
@@ -1,0 +1,28 @@
+# AUTOPSY 0002 — Trust-Boundary Rotation
+
+Observed CI run: `Cloud Custody Candidate Tests` run 14
+
+Status: `PROTOTYPE_KILLED_AGAIN / PATCH_REQUIRED`
+
+The original eight death causes stayed fixed, but a rotated WITNESS attack found a second class of failures.
+
+## Material death causes
+
+1. two apparent recovery recipients could be the primary fingerprint and subkey fingerprint of the same OpenPGP key family, defeating the intended two-recipient recovery separation;
+2. free-form/newline authority text could enter custody metadata instead of a bounded opaque authority reference;
+3. GCS target validation accepted generation fragments, query-like material and control characters;
+4. upload did not bind provider transfer integrity to the local ciphertext through provider MD5 validation;
+5. upload did not send the existing provider `--content-md5` integrity check;
+6. restore attempted to read a receipt inside the public repository instead of rejecting the trust-boundary violation first.
+
+## Surviving prior fixes
+
+All eight failures from `AUTOPSY_0001.md` passed unchanged under the same workload.
+
+This is the intended Darwin behavior: inherited death causes remain in the test corpus.
+
+## Patch authorization
+
+Only the demonstrated glue gaps above are authorized for patching.
+
+No custom crypto, object store, key vault or broader platform surface is authorized.

--- a/thin-rts/cloud-custody/METEOR_ATTACK_0001.md
+++ b/thin-rts/cloud-custody/METEOR_ATTACK_0001.md
@@ -1,0 +1,92 @@
+# METEOR ATTACK 0001 — Encrypted Cloud Custody Prototype
+
+Timestamp: **2026-08-11 JST**
+
+Status: `ACTIVE / PROTOTYPE MUST DIE BEFORE IMPLEMENTATION`
+
+Method authority: WITNESS Meteor Gate.
+
+This candidate is deliberately treated as a **prototype under `/goal`**, not as an implementation entitled to survive.
+
+The burden of proof is on the candidate. Green happy-path CI is insufficient.
+
+## Frozen outcome
+
+Preserve a dispute-ready evidence bundle using existing crypto and cloud capabilities with the smallest surviving glue surface, while keeping long-term decryption secrets outside the producer/cloud trust boundary and preserving independently verifiable recovery.
+
+## Witness ordering
+
+`OUTCOME -> NECESSITY -> EXTERNAL FIRST -> REALITY -> EVIDENCE -> BUILD LAST -> RETEST`
+
+Per-responsibility verdicts remain limited to:
+
+`DROP / EXTERNALIZE / GLUE / IRREDUCIBLE_BUILD`
+
+No existing code receives a survival right because it has already been written.
+
+## Candidate under attack
+
+Current prototype composition:
+
+- deterministic packaging: Python stdlib glue;
+- content digests: SHA-256;
+- public-key encryption: external GnuPG;
+- first provider adapter: external `gcloud storage`;
+- Thin RTS glue: manifest/custody binding, approval boundary, provider metadata observation, recovery verification.
+
+## Attack set A — package identity
+
+The prototype must fail closed when:
+
+1. the evidence directory is empty;
+2. source evidence collides with the reserved internal manifest name;
+3. a manifest entry attempts `..` / absolute-path escape;
+4. duplicate manifest paths exist;
+5. restored output contains unmanifested extra files;
+6. extraction is attempted into a dirty/non-empty destination that could mix stale data with restored evidence;
+7. deterministic packaging cannot reproduce identical bytes from identical input.
+
+A verifier that only checks listed files but silently accepts extra or escaping material is dead.
+
+## Attack set B — provider race / stale substitution
+
+Cloud Storage metadata and object data are separate observations. The prototype must not claim that an unconditioned download is the recorded generation merely because a later metadata request reports that generation.
+
+Required surviving behavior:
+
+- new-object upload uses a generation precondition equivalent to `ifGenerationMatch=0`, not a best-effort existence check;
+- restore binds the data retrieval itself to the recorded immutable generation, rather than downloading an unconstrained latest object and checking metadata afterward;
+- stale/replaced generation produces FAIL/ERROR, never PASS.
+
+## Attack set C — trust-boundary collapse
+
+Before live `/goal` can reach cloud mutation:
+
+- producer has public recipient material only for selected recovery recipients;
+- producer must not hold corresponding secret-key records;
+- at least two recovery recipients remain required for the first experiment;
+- real recovery-package paths and work paths must be outside the public repository;
+- provider credentials, recovery secrets, plaintext evidence and live receipts must never become tracked repository artifacts.
+
+## Attack set D — authority
+
+Prototype construction and local destructive testing are authorized under `/goal`.
+
+The following remain separate authority boundaries:
+
+- live cloud mutation;
+- key generation/import of private recovery material onto the producer;
+- merge/promotion;
+- publication of account/bucket/project/evidence identifiers.
+
+If a boundary is reached, `/goal` must stop with `APPROVAL_REQUIRED` rather than silently cross it.
+
+## Initial verdict
+
+`PROTOTYPE_SURVIVAL = UNPROVEN`
+
+`LIVE_UPLOAD = NOT_AUTHORIZED_BY_THIS_DOCUMENT`
+
+`PROMOTION = NOT_AUTHORIZED`
+
+The test suite is intentionally expanded with red-team expectations. A red CI result is **successful Meteor evidence**, not a development failure.

--- a/thin-rts/cloud-custody/METEOR_SATURATION_CHECKPOINT_0001.md
+++ b/thin-rts/cloud-custody/METEOR_SATURATION_CHECKPOINT_0001.md
@@ -1,0 +1,58 @@
+# METEOR SATURATION CHECKPOINT 0001
+
+Timestamp: **2026-08-11 JST**
+
+Status: `STRUCTURAL_ATTACK_SATURATED_UNDER_CURRENT_EVIDENCE / LIVE_REALITY_NEXT`
+
+## What happened
+
+The custody prototype was killed twice before any live cloud write.
+
+Round 1 found eight material package/verification/provider-generation failures.
+
+Round 2 rotated to trust boundaries and found six additional material failures.
+
+The exact prior death causes were retained as regression attacks rather than discarded after repair.
+
+After the second repair, the candidate + inherited Meteor suite returned green CI.
+
+## Current surviving responsibility map
+
+- GnuPG crypto: `EXTERNALIZE`
+- Google Cloud object transport/storage for first experiment: `EXTERNALIZE`
+- deterministic package + manifest validation: `GLUE`
+- provider precondition/digest/generation binding: `GLUE`
+- authority boundary + recovery metadata binding: `GLUE`
+- custom cryptography: `DROP`
+- custom object storage: `DROP`
+- custom key vault: `DROP`
+
+No `IRREDUCIBLE_BUILD` beyond the bounded glue above has been proven.
+
+## Why the next attack must be live
+
+Further static/pure-unit rotation now risks inventing speculative architecture instead of testing reality.
+
+The next material unknowns require the actual producer environment:
+
+1. are at least two distinct recovery **primary public keys** available while their secret-key records are absent from the producer?;
+2. can `/goal` produce a deterministic bundle and ciphertext using those public recipients?;
+3. which dedicated private GCS prefix is intentionally authorized for custody testing?;
+4. does the provider accept the atomic generation-zero upload + content-MD5 contract?;
+5. can a genuinely separated recovery environment decrypt and independently verify the recorded generation, ciphertext digest, plaintext bundle digest and internal manifest?;
+6. do wrong-key, mutation, truncation, stale-generation and missing-object attacks fail closed in the live workload?;
+7. can this be reduced to near-zero manual filing without weakening authority or recovery separation?
+
+## Stop condition
+
+Pure structural attack is paused here because the next materially new evidence comes from real key/provider/recovery behavior.
+
+`SEARCH_SATURATED_UNDER_CURRENT_EVIDENCE`
+
+This is **not** completion and **not** promotion.
+
+`LIVE CLOUD WRITE = STILL APPROVAL-BOUND`
+
+`PR = DRAFT`
+
+`PROMOTION = NOT AUTHORIZED`

--- a/thin-rts/cloud-custody/README.md
+++ b/thin-rts/cloud-custody/README.md
@@ -1,0 +1,116 @@
+# Thin RTS — Encrypted Cloud Custody v0 Candidate
+
+Status: `IMPLEMENTED_CANDIDATE / NOT_YET_LIVE_VERIFIED`
+
+This directory is the smallest custom orchestration surface currently allowed to survive the Destroy Loop for encrypted evidence custody.
+
+It does **not** implement cryptography, cloud storage, key management, or a new backup engine.
+
+External responsibilities:
+
+- OpenPGP encryption/decryption: GnuPG (`gpg`)
+- first object-storage adapter: Google Cloud CLI (`gcloud storage`)
+- cloud authentication, transport, retries, IAM, provider durability: provider/tool responsibility
+- private recovery-key custody: separate operator-controlled trust boundary
+
+Thin RTS owns only:
+
+- deterministic evidence packaging;
+- SHA-256 binding before and after encryption;
+- explicit recipient/key-epoch binding;
+- refusal to encrypt when the selected recipient has a secret-key record on the producer;
+- opaque object naming;
+- upload + remote generation/size observation;
+- recovery receipt/card generation;
+- download/decrypt/manifest verification;
+- PASS / ERROR / APPROVAL_REQUIRED boundaries.
+
+## `/goal` semantics
+
+The `goal` subcommand intentionally runs until one of three boundaries:
+
+- `ERROR` — a required invariant/tool/key/target check failed;
+- `APPROVAL_REQUIRED` — local bundle + ciphertext were created and verified enough to show the exact planned remote write, but no cloud write was executed;
+- `LIVE_UPLOAD_VERIFIED` — an explicitly approved upload completed and the remote object generation/size were observed.
+
+A verified upload is **not** full completion. The next hard gate is a fresh-environment restore with a separated recovery identity.
+
+## Required separation
+
+The producer must have the public recipient keys but must not have secret-key records for those selected recipients.
+
+The candidate requires at least two recipient fingerprints for `/goal` so the first live experiment cannot silently collapse to one irreplaceable recovery path.
+
+Recovery identities must be created and stored outside the producer/server and outside the evidence-cloud trust boundary.
+
+## Input contract
+
+`--input` points at a completed evidence-bundle directory. This layer does not decide legal relevance. The input should already contain the originals/derivatives/custody/reproduction material required by the upstream legal-evidence gate.
+
+Symlinks are rejected. File paths are sorted. Tar metadata is normalized. The archive contains `RTS_BUNDLE_MANIFEST.json` with each source path, byte size and SHA-256.
+
+## Private runtime paths
+
+`--work` and `--recovery-dir` must point outside the public repository.
+
+Do not commit:
+
+- evidence originals;
+- tar/gzip bundles;
+- ciphertext generated for real evidence;
+- recovery receipts/cards tied to real cases;
+- public or private recovery-key exports;
+- provider credentials;
+- account/project/bucket identifiers unless intentionally approved for publication.
+
+## GCS target contract
+
+The first provider adapter requires a dedicated prefix such as:
+
+`gs://<user-selected-bucket>/<dedicated-private-prefix>`
+
+Bucket root is rejected.
+
+Existing unrelated render/build buckets are **not automatically authorized** as evidence-custody destinations merely because they are visible to the current credential.
+
+## Local validation
+
+Run the pure unit tests before a live experiment:
+
+`python3 -m unittest thin-rts/cloud-custody/test_custody.py`
+
+Run tool/recipient/target checks using `doctor`.
+
+Run `goal` without `--approve-live-upload` first. That produces the exact planned object URI and an `APPROVAL_REQUIRED` boundary without mutating the cloud.
+
+Only after the target and recovery-key separation are deliberately accepted should the same invocation be repeated with `--approve-live-upload`.
+
+## Fresh recovery
+
+`restore` requires a recovery receipt that records the expected provider object generation, ciphertext SHA-256, and plaintext bundle SHA-256.
+
+The restore path:
+
+`download -> verify ciphertext digest -> verify remote generation -> decrypt -> verify plaintext bundle digest -> safe extract -> verify internal manifest`
+
+Opening a decrypted file without those checks is not PASS.
+
+## Known incomplete gates
+
+This candidate does not yet prove:
+
+- real live upload/write authority to a dedicated evidence-custody prefix;
+- fresh-environment recovery;
+- alternate recovery recipient success;
+- wrong-key failure;
+- one-byte ciphertext mutation detection;
+- truncated/missing/stale object handling in a live provider workload;
+- anti-zubora scheduling/retry automation;
+- provider replacement with a second transport;
+- integration with automatic evidence triage/event/legal-watch layers.
+
+Therefore:
+
+`ENCRYPTED_CLOUD_CUSTODY = NOT_COMPLETE`
+
+`PROMOTION = NOT_AUTHORIZED`

--- a/thin-rts/cloud-custody/custody.py
+++ b/thin-rts/cloud-custody/custody.py
@@ -11,6 +11,7 @@ must remain outside the public repository.
 from __future__ import annotations
 
 import argparse
+import base64
 import gzip
 import hashlib
 import io
@@ -29,6 +30,7 @@ from typing import Iterable
 SCHEMA = "thin-rts-cloud-custody/v0"
 INTERNAL_MANIFEST = "RTS_BUNDLE_MANIFEST.json"
 FINGERPRINT_RE = re.compile(r"^[0-9A-Fa-f]{40,64}$")
+AUTHORITY_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/@+\-]{0,159}$")
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -46,6 +48,14 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: f.read(1024 * 1024), b""):
             h.update(chunk)
     return h.hexdigest()
+
+
+def md5_b64_file(path: Path) -> str:
+    h = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return base64.b64encode(h.digest()).decode("ascii")
 
 
 def canonical_json_bytes(obj: object) -> bytes:
@@ -169,6 +179,12 @@ def _validate_fingerprint(value: str) -> str:
     return value.upper()
 
 
+def validate_authority_ref(value: str) -> str:
+    if not AUTHORITY_REF_RE.fullmatch(value or ""):
+        raise CustodyError("authority reference must be an opaque token, not free-form text")
+    return value
+
+
 def gpg_version() -> str:
     cp = run(["gpg", "--version"])
     return cp.stdout.splitlines()[0].strip() if cp.stdout else "gpg/version-unknown"
@@ -186,6 +202,24 @@ def gpg_public_fingerprints(query: str) -> set[str]:
     return result
 
 
+def gpg_primary_fingerprint(query: str) -> str | None:
+    cp = run(["gpg", "--batch", "--with-colons", "--fingerprint", "--list-keys", query], check=False)
+    if cp.returncode != 0:
+        return None
+    saw_pub = False
+    for line in cp.stdout.splitlines():
+        parts = line.split(":")
+        kind = parts[0] if parts else ""
+        if kind == "pub":
+            saw_pub = True
+            continue
+        if saw_pub and kind == "fpr" and len(parts) > 9 and parts[9]:
+            return parts[9].upper()
+        if kind in {"sub", "uid", "uat"} and saw_pub:
+            break
+    return None
+
+
 def gpg_has_secret_record(fingerprint: str) -> bool:
     cp = run(["gpg", "--batch", "--with-colons", "--list-secret-keys", fingerprint], check=False)
     for line in cp.stdout.splitlines():
@@ -200,10 +234,13 @@ def assert_recipient_separation(recipients: Iterable[str]) -> list[str]:
     if len(set(normalized)) != len(normalized):
         raise CustodyError("duplicate recipient fingerprint")
     for fpr in normalized:
-        if fpr not in gpg_public_fingerprints(fpr):
+        primary = gpg_primary_fingerprint(fpr)
+        if primary is None:
             raise CustodyError(f"public recipient key unavailable: {fpr}")
-        if gpg_has_secret_record(fpr):
-            raise CustodyError(f"key separation failed: producer has secret-key record for recipient {fpr}")
+        if primary != fpr:
+            raise CustodyError(f"recipient must be the primary-key fingerprint, not a subkey: {fpr}")
+        if gpg_has_secret_record(primary):
+            raise CustodyError(f"key separation failed: producer has secret-key record for recipient {primary}")
     return normalized
 
 
@@ -237,6 +274,8 @@ def decrypt_gpg(ciphertext: Path, plaintext: Path) -> None:
 def validate_gs_base(uri: str) -> str:
     if not uri.startswith("gs://"):
         raise CustodyError("GCS target must start with gs://")
+    if any(ch.isspace() for ch in uri) or "#" in uri or "?" in uri:
+        raise CustodyError("GCS target contains unsupported fragment/query/whitespace")
     tail = uri[5:].strip("/")
     if "/" not in tail:
         raise CustodyError("GCS target must include a dedicated prefix, not bucket root")
@@ -250,15 +289,22 @@ def gcs_object_uri(base: str, object_id: str) -> str:
 
 
 def gcs_upload(local: Path, remote: str) -> dict:
+    local_md5 = md5_b64_file(local)
     cp = run([
         "gcloud", "storage", "cp", str(local), remote,
         "--if-generation-match=0",
+        f"--content-md5={local_md5}",
     ], check=False)
     if cp.returncode != 0:
         raise CustodyError(f"cloud upload failed: {cp.stderr.strip() or cp.stdout.strip()}")
     meta = gcs_stat(remote)
     if not str(meta.get("generation", "")):
         raise CustodyError("remote object metadata missing generation")
+    remote_md5 = str(meta.get("md5Hash", ""))
+    if not remote_md5:
+        raise CustodyError("remote object metadata missing MD5 transfer digest")
+    if remote_md5 != local_md5:
+        raise CustodyError("remote provider MD5 does not match local ciphertext")
     return meta
 
 
@@ -427,8 +473,7 @@ def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str]
 
 
 def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_ref: str) -> dict:
-    if not authority_ref.strip():
-        raise CustodyError("live upload requires a non-empty authority reference")
+    authority_ref = validate_authority_ref(authority_ref)
     recovery_dir = assert_private_runtime_path(recovery_dir)
     remote = gcs_object_uri(gcs_base, candidate["bundle_id"])
     meta = gcs_upload(Path(candidate["ciphertext"]["path"]), remote)
@@ -440,10 +485,11 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_re
         "uri": remote,
         "generation": str(meta.get("generation", "")),
         "size": remote_size,
+        "md5": meta.get("md5Hash"),
         "update_time": meta.get("updateTime"),
-        "verification": "REMOTE_OBJECT_PRESENT_SIZE_MATCH",
+        "verification": "REMOTE_OBJECT_PRESENT_SIZE_AND_PROVIDER_MD5_MATCH",
     }
-    candidate["authority_ref"] = authority_ref.strip()
+    candidate["authority_ref"] = authority_ref
     candidate["upload_observed_at"] = now_utc()
     recovery_dir.mkdir(parents=True, exist_ok=True)
     receipt_path = recovery_dir / f"{candidate['bundle_id']}.receipt.json"
@@ -453,6 +499,7 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_re
 
 
 def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -> dict:
+    receipt_path = assert_private_runtime_path(receipt_path)
     work_dir = assert_private_runtime_path(work_dir)
     output_dir = assert_private_runtime_path(output_dir)
     receipt = json.loads(receipt_path.read_text("utf-8"))
@@ -559,11 +606,11 @@ def build_parser() -> argparse.ArgumentParser:
     goal.add_argument("--input", required=True, help="ready evidence bundle directory")
     goal.add_argument("--work", required=True, help="private local work directory outside the repository")
     goal.add_argument("--recovery-dir", required=True, help="private recovery-package output directory outside the repository")
-    goal.add_argument("--recipient", action="append", required=True, help="full OpenPGP recipient fingerprint; repeat for recovery recipients")
+    goal.add_argument("--recipient", action="append", required=True, help="full OpenPGP primary-key recipient fingerprint; repeat for recovery recipients")
     goal.add_argument("--key-epoch", required=True)
     goal.add_argument("--gcs-base", required=True, help="dedicated gs://bucket/prefix")
     goal.add_argument("--approve-live-upload", action="store_true")
-    goal.add_argument("--authority-ref", help="normalized reference to explicit live-upload authority; required with --approve-live-upload")
+    goal.add_argument("--authority-ref", help="opaque normalized reference to explicit live-upload authority; required with --approve-live-upload")
 
     restore = sub.add_parser("restore")
     restore.add_argument("--receipt", required=True)

--- a/thin-rts/cloud-custody/custody.py
+++ b/thin-rts/cloud-custody/custody.py
@@ -15,7 +15,6 @@ import gzip
 import hashlib
 import io
 import json
-import os
 from pathlib import Path, PurePosixPath
 import re
 import secrets
@@ -30,6 +29,7 @@ from typing import Iterable
 SCHEMA = "thin-rts-cloud-custody/v0"
 INTERNAL_MANIFEST = "RTS_BUNDLE_MANIFEST.json"
 FINGERPRINT_RE = re.compile(r"^[0-9A-Fa-f]{40,64}$")
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 class CustodyError(RuntimeError):
@@ -65,6 +65,14 @@ def tool_path(name: str) -> str | None:
     return shutil.which(name)
 
 
+def assert_private_runtime_path(path: Path, *, repo_root: Path = REPO_ROOT) -> Path:
+    resolved = path.expanduser().resolve()
+    repo = repo_root.expanduser().resolve()
+    if resolved == repo or resolved.is_relative_to(repo):
+        raise CustodyError(f"private runtime path must be outside public repository: {resolved}")
+    return resolved
+
+
 def normalized_rel_files(root: Path) -> list[Path]:
     root = root.resolve()
     files: list[Path] = []
@@ -76,17 +84,36 @@ def normalized_rel_files(root: Path) -> list[Path]:
     return sorted(files, key=lambda p: p.relative_to(root).as_posix())
 
 
+def _validate_manifest_relpath(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise CustodyError("manifest path must be a non-empty string")
+    rel = PurePosixPath(value)
+    if rel.is_absolute() or ".." in rel.parts or value == ".":
+        raise CustodyError(f"unsafe manifest path: {value!r}")
+    if value == INTERNAL_MANIFEST:
+        raise CustodyError("reserved internal manifest path cannot be an evidence entry")
+    return rel.as_posix()
+
+
 def build_manifest(root: Path) -> dict:
     root = root.resolve()
     if not root.is_dir():
         raise CustodyError(f"input directory not found: {root}")
+
     entries = []
     for p in normalized_rel_files(root):
+        rel = p.relative_to(root).as_posix()
+        if rel == INTERNAL_MANIFEST:
+            raise CustodyError(f"source evidence collides with reserved path: {INTERNAL_MANIFEST}")
         entries.append({
-            "path": p.relative_to(root).as_posix(),
+            "path": rel,
             "size": p.stat().st_size,
             "sha256": sha256_file(p),
         })
+
+    if not entries:
+        raise CustodyError("evidence bundle is empty")
+
     return {
         "schema": SCHEMA,
         "kind": "evidence-bundle-manifest",
@@ -113,7 +140,6 @@ def create_deterministic_bundle(input_dir: Path, output_path: Path) -> dict:
     manifest_bytes = canonical_json_bytes(manifest)
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    # Write deterministic tar first, then gzip with fixed mtime and no source filename.
     with tempfile.NamedTemporaryFile(prefix="rts-custody-", suffix=".tar", delete=False) as tf:
         tar_tmp = Path(tf.name)
     try:
@@ -224,10 +250,16 @@ def gcs_object_uri(base: str, object_id: str) -> str:
 
 
 def gcs_upload(local: Path, remote: str) -> dict:
-    cp = run(["gcloud", "storage", "cp", "--no-clobber", str(local), remote], check=False)
+    cp = run([
+        "gcloud", "storage", "cp", str(local), remote,
+        "--if-generation-match=0",
+    ], check=False)
     if cp.returncode != 0:
         raise CustodyError(f"cloud upload failed: {cp.stderr.strip() or cp.stdout.strip()}")
-    return gcs_stat(remote)
+    meta = gcs_stat(remote)
+    if not str(meta.get("generation", "")):
+        raise CustodyError("remote object metadata missing generation")
+    return meta
 
 
 def gcs_stat(remote: str) -> dict:
@@ -244,22 +276,38 @@ def gcs_stat(remote: str) -> dict:
     return data
 
 
-def gcs_download(remote: str, local: Path) -> None:
+def gcs_download(remote: str, local: Path, generation: str) -> None:
+    if not generation or not generation.isdigit():
+        raise CustodyError("recorded remote generation must be numeric")
     local.parent.mkdir(parents=True, exist_ok=True)
-    cp = run(["gcloud", "storage", "cp", remote, str(local)], check=False)
+    cp = run([
+        "gcloud", "storage", "cp", remote, str(local),
+        f"--if-generation-match={generation}",
+    ], check=False)
     if cp.returncode != 0:
         local.unlink(missing_ok=True)
-        raise CustodyError(f"cloud download failed: {cp.stderr.strip() or cp.stdout.strip()}")
+        raise CustodyError(f"cloud download failed or generation changed: {cp.stderr.strip() or cp.stdout.strip()}")
 
 
 def safe_extract_tar_gz(archive: Path, output_dir: Path) -> None:
-    output_dir.mkdir(parents=True, exist_ok=True)
+    if output_dir.exists():
+        if not output_dir.is_dir():
+            raise CustodyError(f"restore destination is not a directory: {output_dir}")
+        if any(output_dir.iterdir()):
+            raise CustodyError(f"restore destination must be empty: {output_dir}")
+    else:
+        output_dir.mkdir(parents=True, exist_ok=True)
+
     root = output_dir.resolve()
     with tarfile.open(archive, "r:gz") as tar:
+        seen = set()
         for member in tar.getmembers():
             member_path = PurePosixPath(member.name)
             if member_path.is_absolute() or ".." in member_path.parts:
                 raise CustodyError(f"unsafe archive member: {member.name}")
+            if member.name in seen:
+                raise CustodyError(f"duplicate archive member: {member.name}")
+            seen.add(member.name)
             if member.issym() or member.islnk() or member.isdev():
                 raise CustodyError(f"unsupported archive member type: {member.name}")
             target = (root / Path(*member_path.parts)).resolve()
@@ -269,24 +317,69 @@ def safe_extract_tar_gz(archive: Path, output_dir: Path) -> None:
 
 
 def verify_extracted_tree(root: Path) -> dict:
+    root = root.resolve()
     manifest_path = root / INTERNAL_MANIFEST
-    if not manifest_path.is_file():
-        raise CustodyError("internal manifest missing")
-    manifest = json.loads(manifest_path.read_text("utf-8"))
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise CustodyError("internal manifest missing or unsafe")
+
+    try:
+        manifest = json.loads(manifest_path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise CustodyError("internal manifest is unreadable or invalid JSON") from e
+
     if manifest.get("schema") != SCHEMA:
         raise CustodyError("manifest schema mismatch")
+    if manifest.get("kind") != "evidence-bundle-manifest" or manifest.get("hash") != "sha256":
+        raise CustodyError("manifest kind/hash contract mismatch")
+
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise CustodyError("manifest entries must be a non-empty list")
+
+    expected_paths: set[str] = set()
     failures = []
-    for entry in manifest.get("entries", []):
-        rel = entry.get("path", "")
-        p = root / rel
-        if not p.is_file():
-            failures.append({"path": rel, "reason": "missing"})
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise CustodyError("manifest entry must be an object")
+        rel = _validate_manifest_relpath(entry.get("path"))
+        if rel in expected_paths:
+            raise CustodyError(f"duplicate manifest path: {rel}")
+        expected_paths.add(rel)
+
+        p = (root / Path(*PurePosixPath(rel).parts)).resolve()
+        if p != root and root not in p.parents:
+            raise CustodyError(f"manifest path escapes restored root: {rel}")
+        if not p.is_file() or p.is_symlink():
+            failures.append({"path": rel, "reason": "missing_or_unsafe"})
             continue
+
         actual_size = p.stat().st_size
         actual_hash = sha256_file(p)
         if actual_size != entry.get("size") or actual_hash != entry.get("sha256"):
             failures.append({"path": rel, "reason": "digest_or_size_mismatch"})
-    return {"status": "PASS" if not failures else "FAIL", "failures": failures, "entries": len(manifest.get("entries", []))}
+
+    actual_paths = {
+        p.relative_to(root).as_posix()
+        for p in normalized_rel_files(root)
+        if p.relative_to(root).as_posix() != INTERNAL_MANIFEST
+    }
+    for rel in sorted(actual_paths - expected_paths):
+        failures.append({"path": rel, "reason": "unmanifested_extra"})
+    for rel in sorted(expected_paths - actual_paths):
+        if not any(f.get("path") == rel for f in failures):
+            failures.append({"path": rel, "reason": "missing"})
+
+    return {"status": "PASS" if not failures else "FAIL", "failures": failures, "entries": len(entries)}
+
+
+def verify_bundle_archive(archive: Path) -> dict:
+    with tempfile.TemporaryDirectory(prefix="rts-custody-selfverify-") as td:
+        out = Path(td) / "restored"
+        safe_extract_tar_gz(archive, out)
+        result = verify_extracted_tree(out)
+        if result["status"] != "PASS":
+            raise CustodyError(f"deterministic bundle self-verification failed: {result['failures']}")
+        return result
 
 
 def make_recovery_card(receipt: dict, path: Path) -> None:
@@ -298,6 +391,7 @@ def make_recovery_card(receipt: dict, path: Path) -> None:
         f"Bundle ID: `{receipt['bundle_id']}`",
         f"Ciphertext SHA-256: `{receipt['ciphertext']['sha256']}`",
         f"Remote generation: `{receipt['provider'].get('generation', 'UNKNOWN')}`",
+        f"Authority ref: `{receipt.get('authority_ref', 'NOT_RECORDED')}`",
         "",
         "Recovery requires:",
         "- this recovery receipt/card;",
@@ -312,11 +406,13 @@ def make_recovery_card(receipt: dict, path: Path) -> None:
 
 
 def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str], key_epoch: str) -> dict:
+    work_dir = assert_private_runtime_path(work_dir)
     work_dir.mkdir(parents=True, exist_ok=True)
     object_id = secrets.token_hex(16)
     archive = work_dir / f"{object_id}.tar.gz"
     ciphertext = work_dir / f"{object_id}.gpg"
     bundle = create_deterministic_bundle(input_dir, archive)
+    verify_bundle_archive(archive)
     enc = encrypt_gpg(archive, ciphertext, recipients)
     return {
         "schema": SCHEMA,
@@ -330,7 +426,10 @@ def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str]
     }
 
 
-def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
+def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path, authority_ref: str) -> dict:
+    if not authority_ref.strip():
+        raise CustodyError("live upload requires a non-empty authority reference")
+    recovery_dir = assert_private_runtime_path(recovery_dir)
     remote = gcs_object_uri(gcs_base, candidate["bundle_id"])
     meta = gcs_upload(Path(candidate["ciphertext"]["path"]), remote)
     remote_size = int(meta.get("size", -1))
@@ -344,6 +443,7 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
         "update_time": meta.get("updateTime"),
         "verification": "REMOTE_OBJECT_PRESENT_SIZE_MATCH",
     }
+    candidate["authority_ref"] = authority_ref.strip()
     candidate["upload_observed_at"] = now_utc()
     recovery_dir.mkdir(parents=True, exist_ok=True)
     receipt_path = recovery_dir / f"{candidate['bundle_id']}.receipt.json"
@@ -353,6 +453,8 @@ def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
 
 
 def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -> dict:
+    work_dir = assert_private_runtime_path(work_dir)
+    output_dir = assert_private_runtime_path(output_dir)
     receipt = json.loads(receipt_path.read_text("utf-8"))
     if receipt.get("schema") != SCHEMA:
         raise CustodyError("receipt schema mismatch")
@@ -361,15 +463,16 @@ def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -
     if not remote or not generation:
         raise CustodyError("receipt does not contain a verified remote object generation")
 
-    work_dir.mkdir(parents=True, exist_ok=True)
-    ciphertext = work_dir / f"restore-{receipt['bundle_id']}.gpg"
-    archive = work_dir / f"restore-{receipt['bundle_id']}.tar.gz"
-    gcs_download(remote, ciphertext)
-    if sha256_file(ciphertext) != receipt["ciphertext"]["sha256"]:
-        raise CustodyError("ciphertext digest mismatch")
     meta = gcs_stat(remote)
     if str(meta.get("generation", "")) != generation:
         raise CustodyError("remote object generation mismatch / possible stale or replaced object")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    ciphertext = work_dir / f"restore-{receipt['bundle_id']}.gpg"
+    archive = work_dir / f"restore-{receipt['bundle_id']}.tar.gz"
+    gcs_download(remote, ciphertext, generation)
+    if sha256_file(ciphertext) != receipt["ciphertext"]["sha256"]:
+        raise CustodyError("ciphertext digest mismatch")
     decrypt_gpg(ciphertext, archive)
     if sha256_file(archive) != receipt["plaintext"]["sha256"]:
         raise CustodyError("decrypted bundle digest mismatch")
@@ -377,7 +480,7 @@ def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -
     verify = verify_extracted_tree(output_dir)
     if verify["status"] != "PASS":
         raise CustodyError(f"manifest verification failed: {verify['failures']}")
-    return {"status": "PASS", "bundle_id": receipt["bundle_id"], "verified_entries": verify["entries"]}
+    return {"status": "PASS", "bundle_id": receipt["bundle_id"], "verified_entries": verify["entries"], "generation": generation}
 
 
 def doctor(recipients: list[str] | None = None, gcs_base: str | None = None) -> dict:
@@ -407,8 +510,9 @@ def cmd_goal(args: argparse.Namespace) -> int:
         print(json.dumps({"goal": "ERROR", "reason": "at least two separated recovery recipients are required for this candidate"}, indent=2))
         return 2
 
-    candidate = build_local_candidate(Path(args.input), Path(args.work), args.recipient, args.key_epoch)
-    recovery_dir = Path(args.recovery_dir)
+    work_dir = assert_private_runtime_path(Path(args.work))
+    recovery_dir = assert_private_runtime_path(Path(args.recovery_dir))
+    candidate = build_local_candidate(Path(args.input), work_dir, args.recipient, args.key_epoch)
     recovery_dir.mkdir(parents=True, exist_ok=True)
     local_receipt = recovery_dir / f"{candidate['bundle_id']}.preupload.json"
     write_json(local_receipt, candidate)
@@ -416,7 +520,7 @@ def cmd_goal(args: argparse.Namespace) -> int:
     if not args.approve_live_upload:
         print(json.dumps({
             "goal": "APPROVAL_REQUIRED",
-            "reason": "local deterministic bundle and public-key ciphertext created; live provider write not executed",
+            "reason": "local deterministic bundle and public-key ciphertext created and self-verified; live provider write not executed",
             "bundle_id": candidate["bundle_id"],
             "ciphertext_sha256": candidate["ciphertext"]["sha256"],
             "planned_remote": gcs_object_uri(args.gcs_base, candidate["bundle_id"]),
@@ -424,11 +528,19 @@ def cmd_goal(args: argparse.Namespace) -> int:
         }, ensure_ascii=False, indent=2))
         return 3
 
-    uploaded = live_upload(candidate, args.gcs_base, recovery_dir)
+    if not args.authority_ref:
+        print(json.dumps({
+            "goal": "APPROVAL_REQUIRED",
+            "reason": "--approve-live-upload was supplied but no explicit --authority-ref was recorded",
+        }, ensure_ascii=False, indent=2))
+        return 3
+
+    uploaded = live_upload(candidate, args.gcs_base, recovery_dir, args.authority_ref)
     print(json.dumps({
         "goal": "LIVE_UPLOAD_VERIFIED",
         "bundle_id": uploaded["bundle_id"],
         "remote_generation": uploaded["provider"].get("generation"),
+        "authority_ref": uploaded.get("authority_ref"),
         "next_gate": "fresh-environment restore using separated recovery identity",
         "full_completion": "NOT_COMPLETE",
     }, ensure_ascii=False, indent=2))
@@ -451,6 +563,7 @@ def build_parser() -> argparse.ArgumentParser:
     goal.add_argument("--key-epoch", required=True)
     goal.add_argument("--gcs-base", required=True, help="dedicated gs://bucket/prefix")
     goal.add_argument("--approve-live-upload", action="store_true")
+    goal.add_argument("--authority-ref", help="normalized reference to explicit live-upload authority; required with --approve-live-upload")
 
     restore = sub.add_parser("restore")
     restore.add_argument("--receipt", required=True)

--- a/thin-rts/cloud-custody/custody.py
+++ b/thin-rts/cloud-custody/custody.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""Thin RTS encrypted cloud custody candidate.
+
+No custom cryptography. This module orchestrates standard tar/gzip semantics implemented
+with Python stdlib, GnuPG for public-key encryption, and Google Cloud CLI for the first
+provider adapter.
+
+Generated evidence, ciphertext, receipts, recovery material, and provider credentials
+must remain outside the public repository.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+from typing import Iterable
+
+SCHEMA = "thin-rts-cloud-custody/v0"
+INTERNAL_MANIFEST = "RTS_BUNDLE_MANIFEST.json"
+FINGERPRINT_RE = re.compile(r"^[0-9A-Fa-f]{40,64}$")
+
+
+class CustodyError(RuntimeError):
+    pass
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def canonical_json_bytes(obj: object) -> bytes:
+    return (json.dumps(obj, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def write_json(path: Path, obj: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_json_bytes(obj))
+
+
+def run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(cmd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=check)
+
+
+def tool_path(name: str) -> str | None:
+    return shutil.which(name)
+
+
+def normalized_rel_files(root: Path) -> list[Path]:
+    root = root.resolve()
+    files: list[Path] = []
+    for p in root.rglob("*"):
+        if p.is_symlink():
+            raise CustodyError(f"symlink rejected from evidence bundle: {p}")
+        if p.is_file():
+            files.append(p)
+    return sorted(files, key=lambda p: p.relative_to(root).as_posix())
+
+
+def build_manifest(root: Path) -> dict:
+    root = root.resolve()
+    if not root.is_dir():
+        raise CustodyError(f"input directory not found: {root}")
+    entries = []
+    for p in normalized_rel_files(root):
+        entries.append({
+            "path": p.relative_to(root).as_posix(),
+            "size": p.stat().st_size,
+            "sha256": sha256_file(p),
+        })
+    return {
+        "schema": SCHEMA,
+        "kind": "evidence-bundle-manifest",
+        "hash": "sha256",
+        "entries": entries,
+    }
+
+
+def _normalized_tarinfo(name: str, size: int, mode: int = 0o644) -> tarfile.TarInfo:
+    ti = tarfile.TarInfo(name=name)
+    ti.size = size
+    ti.mode = mode
+    ti.uid = 0
+    ti.gid = 0
+    ti.uname = ""
+    ti.gname = ""
+    ti.mtime = 0
+    return ti
+
+
+def create_deterministic_bundle(input_dir: Path, output_path: Path) -> dict:
+    input_dir = input_dir.resolve()
+    manifest = build_manifest(input_dir)
+    manifest_bytes = canonical_json_bytes(manifest)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Write deterministic tar first, then gzip with fixed mtime and no source filename.
+    with tempfile.NamedTemporaryFile(prefix="rts-custody-", suffix=".tar", delete=False) as tf:
+        tar_tmp = Path(tf.name)
+    try:
+        with tarfile.open(tar_tmp, "w", format=tarfile.PAX_FORMAT) as tar:
+            for p in normalized_rel_files(input_dir):
+                rel = p.relative_to(input_dir).as_posix()
+                data = p.read_bytes()
+                tar.addfile(_normalized_tarinfo(rel, len(data)), io.BytesIO(data))
+            tar.addfile(_normalized_tarinfo(INTERNAL_MANIFEST, len(manifest_bytes)), io.BytesIO(manifest_bytes))
+        with tar_tmp.open("rb") as src, output_path.open("wb") as raw:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as gz:
+                shutil.copyfileobj(src, gz)
+    finally:
+        tar_tmp.unlink(missing_ok=True)
+
+    return {
+        "manifest": manifest,
+        "archive": str(output_path),
+        "archive_sha256": sha256_file(output_path),
+        "archive_size": output_path.stat().st_size,
+    }
+
+
+def _validate_fingerprint(value: str) -> str:
+    if not FINGERPRINT_RE.fullmatch(value):
+        raise CustodyError("recipient must be a full hexadecimal OpenPGP fingerprint")
+    return value.upper()
+
+
+def gpg_version() -> str:
+    cp = run(["gpg", "--version"])
+    return cp.stdout.splitlines()[0].strip() if cp.stdout else "gpg/version-unknown"
+
+
+def gpg_public_fingerprints(query: str) -> set[str]:
+    cp = run(["gpg", "--batch", "--with-colons", "--fingerprint", "--list-keys", query], check=False)
+    if cp.returncode != 0:
+        return set()
+    result = set()
+    for line in cp.stdout.splitlines():
+        parts = line.split(":")
+        if parts and parts[0] == "fpr" and len(parts) > 9 and parts[9]:
+            result.add(parts[9].upper())
+    return result
+
+
+def gpg_has_secret_record(fingerprint: str) -> bool:
+    cp = run(["gpg", "--batch", "--with-colons", "--list-secret-keys", fingerprint], check=False)
+    for line in cp.stdout.splitlines():
+        kind = line.split(":", 1)[0]
+        if kind in {"sec", "ssb"}:
+            return True
+    return False
+
+
+def assert_recipient_separation(recipients: Iterable[str]) -> list[str]:
+    normalized = [_validate_fingerprint(r) for r in recipients]
+    if len(set(normalized)) != len(normalized):
+        raise CustodyError("duplicate recipient fingerprint")
+    for fpr in normalized:
+        if fpr not in gpg_public_fingerprints(fpr):
+            raise CustodyError(f"public recipient key unavailable: {fpr}")
+        if gpg_has_secret_record(fpr):
+            raise CustodyError(f"key separation failed: producer has secret-key record for recipient {fpr}")
+    return normalized
+
+
+def encrypt_gpg(plaintext: Path, ciphertext: Path, recipients: list[str]) -> dict:
+    recipients = assert_recipient_separation(recipients)
+    ciphertext.parent.mkdir(parents=True, exist_ok=True)
+    cmd = ["gpg", "--batch", "--yes", "--no-default-recipient", "--output", str(ciphertext), "--encrypt"]
+    for fpr in recipients:
+        cmd.extend(["--recipient", fpr])
+    cmd.append(str(plaintext))
+    cp = run(cmd, check=False)
+    if cp.returncode != 0:
+        raise CustodyError(f"gpg encryption failed: {cp.stderr.strip()}")
+    return {
+        "tool": gpg_version(),
+        "format": "OpenPGP",
+        "recipients": recipients,
+        "ciphertext_sha256": sha256_file(ciphertext),
+        "ciphertext_size": ciphertext.stat().st_size,
+    }
+
+
+def decrypt_gpg(ciphertext: Path, plaintext: Path) -> None:
+    plaintext.parent.mkdir(parents=True, exist_ok=True)
+    cp = run(["gpg", "--batch", "--yes", "--output", str(plaintext), "--decrypt", str(ciphertext)], check=False)
+    if cp.returncode != 0:
+        plaintext.unlink(missing_ok=True)
+        raise CustodyError(f"gpg decryption failed: {cp.stderr.strip()}")
+
+
+def validate_gs_base(uri: str) -> str:
+    if not uri.startswith("gs://"):
+        raise CustodyError("GCS target must start with gs://")
+    tail = uri[5:].strip("/")
+    if "/" not in tail:
+        raise CustodyError("GCS target must include a dedicated prefix, not bucket root")
+    if ".." in PurePosixPath(tail).parts:
+        raise CustodyError("invalid GCS target")
+    return "gs://" + tail
+
+
+def gcs_object_uri(base: str, object_id: str) -> str:
+    return f"{validate_gs_base(base)}/{object_id}.gpg"
+
+
+def gcs_upload(local: Path, remote: str) -> dict:
+    cp = run(["gcloud", "storage", "cp", "--no-clobber", str(local), remote], check=False)
+    if cp.returncode != 0:
+        raise CustodyError(f"cloud upload failed: {cp.stderr.strip() or cp.stdout.strip()}")
+    return gcs_stat(remote)
+
+
+def gcs_stat(remote: str) -> dict:
+    cp = run([
+        "gcloud", "storage", "objects", "describe", remote,
+        "--format=json(name,bucket,generation,size,updateTime,md5Hash,crc32c)",
+    ], check=False)
+    if cp.returncode != 0:
+        raise CustodyError(f"remote object describe failed: {cp.stderr.strip() or cp.stdout.strip()}")
+    try:
+        data = json.loads(cp.stdout)
+    except json.JSONDecodeError as e:
+        raise CustodyError("remote object metadata was not valid JSON") from e
+    return data
+
+
+def gcs_download(remote: str, local: Path) -> None:
+    local.parent.mkdir(parents=True, exist_ok=True)
+    cp = run(["gcloud", "storage", "cp", remote, str(local)], check=False)
+    if cp.returncode != 0:
+        local.unlink(missing_ok=True)
+        raise CustodyError(f"cloud download failed: {cp.stderr.strip() or cp.stdout.strip()}")
+
+
+def safe_extract_tar_gz(archive: Path, output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    root = output_dir.resolve()
+    with tarfile.open(archive, "r:gz") as tar:
+        for member in tar.getmembers():
+            member_path = PurePosixPath(member.name)
+            if member_path.is_absolute() or ".." in member_path.parts:
+                raise CustodyError(f"unsafe archive member: {member.name}")
+            if member.issym() or member.islnk() or member.isdev():
+                raise CustodyError(f"unsupported archive member type: {member.name}")
+            target = (root / Path(*member_path.parts)).resolve()
+            if target != root and root not in target.parents:
+                raise CustodyError(f"archive escapes output directory: {member.name}")
+        tar.extractall(root, filter="data")
+
+
+def verify_extracted_tree(root: Path) -> dict:
+    manifest_path = root / INTERNAL_MANIFEST
+    if not manifest_path.is_file():
+        raise CustodyError("internal manifest missing")
+    manifest = json.loads(manifest_path.read_text("utf-8"))
+    if manifest.get("schema") != SCHEMA:
+        raise CustodyError("manifest schema mismatch")
+    failures = []
+    for entry in manifest.get("entries", []):
+        rel = entry.get("path", "")
+        p = root / rel
+        if not p.is_file():
+            failures.append({"path": rel, "reason": "missing"})
+            continue
+        actual_size = p.stat().st_size
+        actual_hash = sha256_file(p)
+        if actual_size != entry.get("size") or actual_hash != entry.get("sha256"):
+            failures.append({"path": rel, "reason": "digest_or_size_mismatch"})
+    return {"status": "PASS" if not failures else "FAIL", "failures": failures, "entries": len(manifest.get("entries", []))}
+
+
+def make_recovery_card(receipt: dict, path: Path) -> None:
+    lines = [
+        "# Thin RTS Recovery Card",
+        "",
+        f"Schema: `{receipt['schema']}`",
+        f"Key epoch: `{receipt['key_epoch']}`",
+        f"Bundle ID: `{receipt['bundle_id']}`",
+        f"Ciphertext SHA-256: `{receipt['ciphertext']['sha256']}`",
+        f"Remote generation: `{receipt['provider'].get('generation', 'UNKNOWN')}`",
+        "",
+        "Recovery requires:",
+        "- this recovery receipt/card;",
+        "- the separated OpenPGP recovery identity for the matching key epoch;",
+        "- GnuPG;",
+        "- access to the recorded provider object or an equivalent transported copy.",
+        "",
+        "A successful restore is not 'file opened'. It must verify ciphertext digest, plaintext bundle digest, and the internal manifest.",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def build_local_candidate(input_dir: Path, work_dir: Path, recipients: list[str], key_epoch: str) -> dict:
+    work_dir.mkdir(parents=True, exist_ok=True)
+    object_id = secrets.token_hex(16)
+    archive = work_dir / f"{object_id}.tar.gz"
+    ciphertext = work_dir / f"{object_id}.gpg"
+    bundle = create_deterministic_bundle(input_dir, archive)
+    enc = encrypt_gpg(archive, ciphertext, recipients)
+    return {
+        "schema": SCHEMA,
+        "created_at": now_utc(),
+        "bundle_id": object_id,
+        "key_epoch": key_epoch,
+        "plaintext": {"sha256": bundle["archive_sha256"], "size": bundle["archive_size"]},
+        "ciphertext": {"path": str(ciphertext), "sha256": enc["ciphertext_sha256"], "size": enc["ciphertext_size"], "format": enc["format"], "tool": enc["tool"]},
+        "recipients": enc["recipients"],
+        "provider": {"type": "gcs", "status": "NOT_UPLOADED"},
+    }
+
+
+def live_upload(candidate: dict, gcs_base: str, recovery_dir: Path) -> dict:
+    remote = gcs_object_uri(gcs_base, candidate["bundle_id"])
+    meta = gcs_upload(Path(candidate["ciphertext"]["path"]), remote)
+    remote_size = int(meta.get("size", -1))
+    if remote_size != int(candidate["ciphertext"]["size"]):
+        raise CustodyError(f"remote size mismatch: expected {candidate['ciphertext']['size']} got {remote_size}")
+    candidate["provider"] = {
+        "type": "gcs",
+        "uri": remote,
+        "generation": str(meta.get("generation", "")),
+        "size": remote_size,
+        "update_time": meta.get("updateTime"),
+        "verification": "REMOTE_OBJECT_PRESENT_SIZE_MATCH",
+    }
+    candidate["upload_observed_at"] = now_utc()
+    recovery_dir.mkdir(parents=True, exist_ok=True)
+    receipt_path = recovery_dir / f"{candidate['bundle_id']}.receipt.json"
+    write_json(receipt_path, candidate)
+    make_recovery_card(candidate, recovery_dir / f"{candidate['bundle_id']}.RECOVERY_CARD.md")
+    return candidate
+
+
+def restore_from_receipt(receipt_path: Path, output_dir: Path, work_dir: Path) -> dict:
+    receipt = json.loads(receipt_path.read_text("utf-8"))
+    if receipt.get("schema") != SCHEMA:
+        raise CustodyError("receipt schema mismatch")
+    remote = receipt.get("provider", {}).get("uri")
+    generation = str(receipt.get("provider", {}).get("generation", ""))
+    if not remote or not generation:
+        raise CustodyError("receipt does not contain a verified remote object generation")
+
+    work_dir.mkdir(parents=True, exist_ok=True)
+    ciphertext = work_dir / f"restore-{receipt['bundle_id']}.gpg"
+    archive = work_dir / f"restore-{receipt['bundle_id']}.tar.gz"
+    gcs_download(remote, ciphertext)
+    if sha256_file(ciphertext) != receipt["ciphertext"]["sha256"]:
+        raise CustodyError("ciphertext digest mismatch")
+    meta = gcs_stat(remote)
+    if str(meta.get("generation", "")) != generation:
+        raise CustodyError("remote object generation mismatch / possible stale or replaced object")
+    decrypt_gpg(ciphertext, archive)
+    if sha256_file(archive) != receipt["plaintext"]["sha256"]:
+        raise CustodyError("decrypted bundle digest mismatch")
+    safe_extract_tar_gz(archive, output_dir)
+    verify = verify_extracted_tree(output_dir)
+    if verify["status"] != "PASS":
+        raise CustodyError(f"manifest verification failed: {verify['failures']}")
+    return {"status": "PASS", "bundle_id": receipt["bundle_id"], "verified_entries": verify["entries"]}
+
+
+def doctor(recipients: list[str] | None = None, gcs_base: str | None = None) -> dict:
+    tools = {name: tool_path(name) for name in ("gpg", "gcloud")}
+    errors = [f"missing tool: {name}" for name, path in tools.items() if not path]
+    result: dict = {"schema": SCHEMA, "tools": tools, "errors": errors}
+    if recipients:
+        try:
+            result["recipients"] = assert_recipient_separation(recipients)
+        except CustodyError as e:
+            errors.append(str(e))
+    if gcs_base:
+        try:
+            result["gcs_base"] = validate_gs_base(gcs_base)
+        except CustodyError as e:
+            errors.append(str(e))
+    result["status"] = "PASS" if not errors else "ERROR"
+    return result
+
+
+def cmd_goal(args: argparse.Namespace) -> int:
+    d = doctor(args.recipient, args.gcs_base)
+    if d["status"] != "PASS":
+        print(json.dumps({"goal": "ERROR", "detail": d}, ensure_ascii=False, indent=2))
+        return 2
+    if len(args.recipient) < 2:
+        print(json.dumps({"goal": "ERROR", "reason": "at least two separated recovery recipients are required for this candidate"}, indent=2))
+        return 2
+
+    candidate = build_local_candidate(Path(args.input), Path(args.work), args.recipient, args.key_epoch)
+    recovery_dir = Path(args.recovery_dir)
+    recovery_dir.mkdir(parents=True, exist_ok=True)
+    local_receipt = recovery_dir / f"{candidate['bundle_id']}.preupload.json"
+    write_json(local_receipt, candidate)
+
+    if not args.approve_live_upload:
+        print(json.dumps({
+            "goal": "APPROVAL_REQUIRED",
+            "reason": "local deterministic bundle and public-key ciphertext created; live provider write not executed",
+            "bundle_id": candidate["bundle_id"],
+            "ciphertext_sha256": candidate["ciphertext"]["sha256"],
+            "planned_remote": gcs_object_uri(args.gcs_base, candidate["bundle_id"]),
+            "preupload_receipt": str(local_receipt),
+        }, ensure_ascii=False, indent=2))
+        return 3
+
+    uploaded = live_upload(candidate, args.gcs_base, recovery_dir)
+    print(json.dumps({
+        "goal": "LIVE_UPLOAD_VERIFIED",
+        "bundle_id": uploaded["bundle_id"],
+        "remote_generation": uploaded["provider"].get("generation"),
+        "next_gate": "fresh-environment restore using separated recovery identity",
+        "full_completion": "NOT_COMPLETE",
+    }, ensure_ascii=False, indent=2))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Thin RTS encrypted cloud custody candidate")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    doc = sub.add_parser("doctor")
+    doc.add_argument("--recipient", action="append", default=[])
+    doc.add_argument("--gcs-base")
+
+    goal = sub.add_parser("goal", help="run until approval is required, an error occurs, or a verified live upload completes")
+    goal.add_argument("--input", required=True, help="ready evidence bundle directory")
+    goal.add_argument("--work", required=True, help="private local work directory outside the repository")
+    goal.add_argument("--recovery-dir", required=True, help="private recovery-package output directory outside the repository")
+    goal.add_argument("--recipient", action="append", required=True, help="full OpenPGP recipient fingerprint; repeat for recovery recipients")
+    goal.add_argument("--key-epoch", required=True)
+    goal.add_argument("--gcs-base", required=True, help="dedicated gs://bucket/prefix")
+    goal.add_argument("--approve-live-upload", action="store_true")
+
+    restore = sub.add_parser("restore")
+    restore.add_argument("--receipt", required=True)
+    restore.add_argument("--output", required=True)
+    restore.add_argument("--work", required=True)
+    return p
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "doctor":
+            result = doctor(args.recipient, args.gcs_base)
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0 if result["status"] == "PASS" else 2
+        if args.command == "goal":
+            return cmd_goal(args)
+        if args.command == "restore":
+            result = restore_from_receipt(Path(args.receipt), Path(args.output), Path(args.work))
+            print(json.dumps(result, ensure_ascii=False, indent=2))
+            return 0
+    except CustodyError as e:
+        print(json.dumps({"goal": "ERROR", "error": str(e)}, ensure_ascii=False, indent=2), file=sys.stderr)
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/thin-rts/cloud-custody/test_custody.py
+++ b/thin-rts/cloud-custody/test_custody.py
@@ -1,0 +1,63 @@
+import io
+import json
+from pathlib import Path
+import tarfile
+import tempfile
+import unittest
+
+import custody
+
+
+class CustodyPureTests(unittest.TestCase):
+    def test_deterministic_bundle(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            (root / "a.txt").write_text("alpha\n", encoding="utf-8")
+            (root / "nested").mkdir()
+            (root / "nested" / "b.bin").write_bytes(b"beta\x00")
+            out1 = Path(td) / "one.tar.gz"
+            out2 = Path(td) / "two.tar.gz"
+            r1 = custody.create_deterministic_bundle(root, out1)
+            r2 = custody.create_deterministic_bundle(root, out2)
+            self.assertEqual(r1["archive_sha256"], r2["archive_sha256"])
+            self.assertEqual(out1.read_bytes(), out2.read_bytes())
+
+    def test_manifest_verification_detects_mutation(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            (root / "evidence.txt").write_text("original", encoding="utf-8")
+            archive = Path(td) / "bundle.tar.gz"
+            custody.create_deterministic_bundle(root, archive)
+            extracted = Path(td) / "out"
+            custody.safe_extract_tar_gz(archive, extracted)
+            self.assertEqual(custody.verify_extracted_tree(extracted)["status"], "PASS")
+            (extracted / "evidence.txt").write_text("mutated", encoding="utf-8")
+            self.assertEqual(custody.verify_extracted_tree(extracted)["status"], "FAIL")
+
+    def test_safe_extract_rejects_parent_escape(self):
+        with tempfile.TemporaryDirectory() as td:
+            archive = Path(td) / "evil.tar.gz"
+            with tarfile.open(archive, "w:gz") as tar:
+                payload = b"evil"
+                ti = tarfile.TarInfo("../escape.txt")
+                ti.size = len(payload)
+                tar.addfile(ti, io.BytesIO(payload))
+            with self.assertRaises(custody.CustodyError):
+                custody.safe_extract_tar_gz(archive, Path(td) / "out")
+
+    def test_gcs_target_requires_prefix(self):
+        with self.assertRaises(custody.CustodyError):
+            custody.validate_gs_base("gs://bucket")
+        self.assertEqual(custody.validate_gs_base("gs://bucket/private/custody"), "gs://bucket/private/custody")
+
+    def test_full_fingerprint_required(self):
+        with self.assertRaises(custody.CustodyError):
+            custody._validate_fingerprint("DEADBEEF")
+        value = "A" * 40
+        self.assertEqual(custody._validate_fingerprint(value), value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thin-rts/cloud-custody/test_meteor_custody.py
+++ b/thin-rts/cloud-custody/test_meteor_custody.py
@@ -109,7 +109,10 @@ class CustodyMeteorAttackTests(unittest.TestCase):
             calls.append(cmd)
             if "describe" in cmd:
                 return subprocess.CompletedProcess(
-                    cmd, 0, stdout='{"generation":"1","size":"3"}', stderr=""
+                    cmd,
+                    0,
+                    stdout='{"generation":"1","size":"3","md5Hash":"kAFQmDzST7DWlj99KOF/cg=="}',
+                    stderr="",
                 )
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 

--- a/thin-rts/cloud-custody/test_meteor_custody.py
+++ b/thin-rts/cloud-custody/test_meteor_custody.py
@@ -1,0 +1,132 @@
+import inspect
+import io
+import json
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from unittest import mock
+
+import custody
+
+
+class CustodyMeteorAttackTests(unittest.TestCase):
+    def _write_manifest(self, root: Path, entries: list[dict]) -> None:
+        payload = {
+            "schema": custody.SCHEMA,
+            "kind": "evidence-bundle-manifest",
+            "hash": "sha256",
+            "entries": entries,
+        }
+        (root / custody.INTERNAL_MANIFEST).write_text(
+            json.dumps(payload, sort_keys=True), encoding="utf-8"
+        )
+
+    def test_empty_evidence_bundle_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            with self.assertRaises(custody.CustodyError):
+                custody.create_deterministic_bundle(root, Path(td) / "bundle.tar.gz")
+
+    def test_reserved_internal_manifest_name_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "input"
+            root.mkdir()
+            (root / custody.INTERNAL_MANIFEST).write_text("source collision", encoding="utf-8")
+            with self.assertRaises(custody.CustodyError):
+                custody.create_deterministic_bundle(root, Path(td) / "bundle.tar.gz")
+
+    def test_manifest_parent_escape_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            root = base / "restored"
+            root.mkdir()
+            outside = base / "outside.txt"
+            outside.write_text("outside", encoding="utf-8")
+            self._write_manifest(
+                root,
+                [{
+                    "path": "../outside.txt",
+                    "size": outside.stat().st_size,
+                    "sha256": custody.sha256_file(outside),
+                }],
+            )
+            with self.assertRaises(custody.CustodyError):
+                custody.verify_extracted_tree(root)
+
+    def test_unmanifested_extra_file_makes_verification_fail(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "evidence.txt"
+            evidence.write_text("evidence", encoding="utf-8")
+            self._write_manifest(
+                root,
+                [{
+                    "path": "evidence.txt",
+                    "size": evidence.stat().st_size,
+                    "sha256": custody.sha256_file(evidence),
+                }],
+            )
+            (root / "stale-extra.txt").write_text("stale", encoding="utf-8")
+            result = custody.verify_extracted_tree(root)
+            self.assertEqual(result["status"], "FAIL")
+
+    def test_duplicate_manifest_paths_are_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            evidence = root / "evidence.txt"
+            evidence.write_text("evidence", encoding="utf-8")
+            entry = {
+                "path": "evidence.txt",
+                "size": evidence.stat().st_size,
+                "sha256": custody.sha256_file(evidence),
+            }
+            self._write_manifest(root, [entry, dict(entry)])
+            with self.assertRaises(custody.CustodyError):
+                custody.verify_extracted_tree(root)
+
+    def test_extract_into_dirty_destination_is_rejected(self):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            archive = base / "bundle.tar.gz"
+            with tarfile.open(archive, "w:gz") as tar:
+                payload = b"fresh"
+                ti = tarfile.TarInfo("fresh.txt")
+                ti.size = len(payload)
+                tar.addfile(ti, io.BytesIO(payload))
+            out = base / "out"
+            out.mkdir()
+            (out / "stale.txt").write_text("stale", encoding="utf-8")
+            with self.assertRaises(custody.CustodyError):
+                custody.safe_extract_tar_gz(archive, out)
+
+    def test_new_object_upload_uses_generation_zero_precondition(self):
+        calls = []
+
+        def fake_run(cmd, *, check=True):
+            calls.append(cmd)
+            if "describe" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd, 0, stdout='{"generation":"1","size":"3"}', stderr=""
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as td:
+            local = Path(td) / "x.gpg"
+            local.write_bytes(b"abc")
+            with mock.patch.object(custody, "run", side_effect=fake_run):
+                custody.gcs_upload(local, "gs://bucket/private/x.gpg")
+
+        upload_cmd = calls[0]
+        self.assertIn("--if-generation-match=0", upload_cmd)
+        self.assertNotIn("--no-clobber", upload_cmd)
+
+    def test_download_api_requires_recorded_generation(self):
+        params = inspect.signature(custody.gcs_download).parameters
+        self.assertIn("generation", params)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thin-rts/cloud-custody/test_meteor_custody_round2.py
+++ b/thin-rts/cloud-custody/test_meteor_custody_round2.py
@@ -1,0 +1,136 @@
+import hashlib
+import base64
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest import mock
+
+import custody
+
+
+class CustodyMeteorRound2Tests(unittest.TestCase):
+    def test_two_recipients_cannot_be_primary_and_subkey_of_same_key(self):
+        primary = "A" * 40
+        subkey = "B" * 40
+        public_listing = (
+            "pub::::::::::\n"
+            f"fpr:::::::::{primary}:\n"
+            "sub::::::::::\n"
+            f"fpr:::::::::{subkey}:\n"
+        )
+
+        def fake_run(cmd, *, check=True):
+            if "--list-secret-keys" in cmd:
+                return subprocess.CompletedProcess(cmd, 2, stdout="", stderr="")
+            if "--list-keys" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout=public_listing, stderr="")
+            raise AssertionError(cmd)
+
+        with mock.patch.object(custody, "run", side_effect=fake_run):
+            with self.assertRaises(custody.CustodyError):
+                custody.assert_recipient_separation([primary, subkey])
+
+    def test_authority_ref_rejects_free_text_and_newlines(self):
+        candidate = {
+            "schema": custody.SCHEMA,
+            "bundle_id": "a" * 32,
+            "key_epoch": "epoch-1",
+            "plaintext": {"sha256": "0" * 64, "size": 1},
+            "ciphertext": {
+                "path": "/tmp/fake.gpg",
+                "sha256": "1" * 64,
+                "size": 1,
+                "format": "OpenPGP",
+                "tool": "gpg",
+            },
+            "recipients": ["A" * 40, "C" * 40],
+            "provider": {"type": "gcs", "status": "NOT_UPLOADED"},
+        }
+        with tempfile.TemporaryDirectory() as td:
+            with mock.patch.object(
+                custody,
+                "gcs_upload",
+                return_value={"generation": "1", "size": "1", "updateTime": "now"},
+            ):
+                with self.assertRaises(custody.CustodyError):
+                    custody.live_upload(
+                        candidate,
+                        "gs://bucket/private",
+                        Path(td),
+                        "approved\nraw private wording",
+                    )
+
+    def test_gcs_target_rejects_generation_fragment_or_control_chars(self):
+        for value in (
+            "gs://bucket/private#123",
+            "gs://bucket/private?x=1",
+            "gs://bucket/private\nother",
+        ):
+            with self.subTest(value=value):
+                with self.assertRaises(custody.CustodyError):
+                    custody.validate_gs_base(value)
+
+    def test_upload_binds_provider_md5_to_local_ciphertext(self):
+        calls = []
+
+        def fake_run(cmd, *, check=True):
+            calls.append(cmd)
+            if "describe" in cmd:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout='{"generation":"1","size":"3","md5Hash":"WRONG"}',
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as td:
+            local = Path(td) / "cipher.gpg"
+            local.write_bytes(b"abc")
+            with mock.patch.object(custody, "run", side_effect=fake_run):
+                with self.assertRaises(custody.CustodyError):
+                    custody.gcs_upload(local, "gs://bucket/private/x.gpg")
+
+    def test_upload_sends_content_md5_for_provider_transfer_check(self):
+        calls = []
+
+        def fake_run(cmd, *, check=True):
+            calls.append(cmd)
+            if "describe" in cmd:
+                local_md5 = base64.b64encode(hashlib.md5(b"abc").digest()).decode("ascii")
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout=(
+                        '{"generation":"1","size":"3","md5Hash":"'
+                        + local_md5
+                        + '"}'
+                    ),
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with tempfile.TemporaryDirectory() as td:
+            local = Path(td) / "cipher.gpg"
+            local.write_bytes(b"abc")
+            with mock.patch.object(custody, "run", side_effect=fake_run):
+                custody.gcs_upload(local, "gs://bucket/private/x.gpg")
+
+        upload_cmd = calls[0]
+        self.assertTrue(any(arg.startswith("--content-md5=") for arg in upload_cmd))
+
+    def test_restore_rejects_receipt_inside_public_repository_before_read(self):
+        inside_repo = custody.REPO_ROOT / "DO_NOT_CREATE.receipt.json"
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            with self.assertRaises(custody.CustodyError):
+                custody.restore_from_receipt(
+                    inside_repo,
+                    base / "restore",
+                    base / "work",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thin-rts/continuity/GOAL_RESULT_V0_1.md
+++ b/thin-rts/continuity/GOAL_RESULT_V0_1.md
@@ -1,0 +1,114 @@
+# /goal Result — 新RTS（仮称） Continuity / Recovery v0.1
+
+Status: `ADOPT / FINAL-CI-RECHECK`
+
+## Goal
+
+Make 新RTS（仮称） resilient to loss, corruption or lockout of an external management substrate without recreating a giant custom platform.
+
+## WITNESS decomposition
+
+Durable responsibilities:
+
+1. provider-neutral Tier-0 capture;
+2. explicit provider-only metadata export contract;
+3. integrity-bound fresh reconstruction;
+4. separated recovery identity;
+5. more than one recovery path for protected backup material;
+6. permanent inheritance of observed recovery death causes.
+
+Responsibilities rejected from the base system:
+
+- custom cloud/source host/object store;
+- custom cryptography/key vault;
+- universal backup cadence/retention;
+- mandatory preservation of cheap derived state;
+- claiming physical independence from two logical labels.
+
+## ULTIMATE LOOP / METEOR result
+
+### Round 1
+
+Focused unit attacks were green, but real integration killed the candidate on:
+
+- validator-created worktree dirt before live capture;
+- GPG unattended encryption trust not established for newly imported exact-fingerprint recipients;
+- earlier validator helper collision with `unittest.TestCase.run`.
+
+The workload was not weakened.
+
+Repairs:
+
+- capture untouched real repository before validator/build mutation;
+- bind local GPG owner-trust to the exact selected full primary fingerprints while keeping private recovery identities outside the producer;
+- repair the validator lifecycle collision.
+
+### Round 2
+
+Observed GitHub evidence on head `1a936c40f832ca776204af7ffe43fcd844059b52`:
+
+- Continuity Recovery Candidate Tests run #6: `SUCCESS`;
+- real RTS PR repository capture/drill: `PASS`;
+- provider-neutral Git bundle size: `5,701,092` bytes;
+- bundle SHA-256: `8efd6e01be3656034f9ee99a69344f1040f6f47201122b7ea91d373fa6dfad14`;
+- captured/restored refs: `103`;
+- fresh mirror `git fsck`: `PASS`;
+- restored code execution: `NOT_PERFORMED`;
+- focused Continuity Meteor regressions: `10/10 PASS`;
+- real two-recipient GPG alternate-domain recovery: `PASS`;
+- wrong unrelated recovery identity: rejected as required;
+- inherited Cloud Custody Candidate Tests run #27: `SUCCESS`;
+- Unicode Guard and independent Semgrep on the same head: `SUCCESS`.
+
+## Strength assessment
+
+No perfect-security percentage is assigned.
+
+| Surface | Current assessment |
+|---|---|
+| Tier-0 Git history/ref reproducibility | `STRONG_UNDER_CURRENT_EVIDENCE` |
+| Partial/incomplete capture rejection | `STRONG_UNDER_CURRENT_EVIDENCE` |
+| Backup tamper detection | `STRONG_UNDER_CURRENT_EVIDENCE` |
+| Fresh non-executing recovery proof | `STRONG_UNDER_CURRENT_EVIDENCE` |
+| Encrypted alternate-domain failover semantics | `STRONG_UNDER_CURRENT_EVIDENCE` |
+| Provider-neutral Git exitability | `STRONG_UNDER_CURRENT_EVIDENCE` |
+| Provider-only metadata export | `CONTRACT_PROVEN / LIVE_ADAPTER_DEPLOYMENT_DEPENDENT` |
+| Real provider/device/region independence | `OPERATIONAL_EVIDENCE_REQUIRED` |
+| Cadence / RPO / retention / offline-WORM | `SITUATIONAL_POLICY` |
+
+## Priority rule
+
+Base-system effort is spent first on:
+
+`SAFETY > REPRODUCIBILITY > RECOVERABILITY > EXITABILITY > DECLARED FAILURE-DOMAIN RESILIENCE`
+
+Tier-1/Tier-2 completeness is allowed to lose against simplicity, cost and speed as long as Tier-0 invariants remain intact.
+
+A situational requirement becomes hard only when the workload declares it critical. Example: if a legal/evidence workload requires WORM + 24h RPO + two providers, those become fail-closed requirements for that workload; they do not automatically become permanent weight for every use of 新RTS（仮称）.
+
+## Adoption verdict
+
+`ADOPT`
+
+Adopt:
+
+- the Continuity / Recovery contract;
+- Tier-0/Tier-1/Tier-2 preservation policy;
+- provider export attestation/scope contract;
+- fresh-recovery proof requirement;
+- alternate-recovery/failure-domain semantics;
+- all observed Meteor death causes as permanent regression memory.
+
+Keep replaceable:
+
+- Python implementation;
+- local filesystem replica adapter;
+- GnuPG/OpenPGP occupant;
+- GCS/provider transport occupant;
+- future provider metadata exporter.
+
+## Final guard
+
+This result authorizes merge only if the documentation-only final head re-runs the same security, inherited custody and continuity CI without new failures.
+
+A final-head failure reopens METEOR. It must not be waived to preserve the adoption decision.

--- a/thin-rts/continuity/METEOR_AUTOPSY_0001.md
+++ b/thin-rts/continuity/METEOR_AUTOPSY_0001.md
@@ -1,0 +1,116 @@
+# METEOR AUTOPSY 0001 — Continuity / Recovery Attack Surface
+
+Status: `ATTACK_CORPUS_FROZEN / AWAITING_CI`
+
+Target: 新RTS（仮称） Continuity / Recovery v0 candidate, composed with inherited Encrypted Cloud Custody v0.
+
+## Raison d'être attack
+
+Candidate responsibility survives only if this narrower statement remains necessary:
+
+> Critical state must be able to leave a failed external substrate and reconstruct elsewhere with bounded integrity evidence.
+
+Killed responsibilities:
+
+- build a new cloud;
+- build a new source host;
+- build custom cryptography;
+- build a custom key vault;
+- preserve every artifact forever;
+- define one universal backup interval for every workload.
+
+## Frozen Meteor attacks
+
+### M-01 — dirty working tree
+
+A committed-history backup that silently drops uncommitted/untracked Tier-0 work is a false PASS.
+
+Required result: `BLOCK`.
+
+### M-02 — shallow or partial/promisor clone
+
+A bundle created from missing history/objects can be internally consistent but incomplete.
+
+Required result: `BLOCK`.
+
+### M-03 — Git LFS or submodule external state
+
+A repository bundle can preserve only pointers/references while real content lives elsewhere.
+
+Required result: `BLOCK unless separately exported`.
+
+### M-04 — provider-only metadata omitted
+
+Issues, PR decisions, rulesets/settings and similar provider state are not contained in ordinary Git history.
+
+Required result: caller may declare provider scopes Tier 0; missing declared scopes => `BLOCK`.
+
+### M-05 — secret material contaminates metadata export
+
+A convenient provider export must not turn backup custody into credential exfiltration.
+
+Required result: exporter must explicitly attest `secret_values_excluded=true`; otherwise `BLOCK`.
+
+### M-06 — bundle / manifest / provider export tamper
+
+Required result: digest/ref/manifest mismatch => `BLOCK`.
+
+### M-07 — stale restore destination
+
+Restoring into a dirty destination can mix old and recovered state.
+
+Required result: `BLOCK`.
+
+### M-08 — fake redundancy
+
+Two replica labels that point to the same or nested local root are not two local failure domains.
+
+Required result: `BLOCK`.
+
+External note: distinct paths still do not prove distinct physical/providers. Production independence needs external evidence.
+
+### M-09 — one replica corrupted
+
+Required result: corrupted domain => `BLOCK`; healthy domain remains independently recoverable.
+
+### M-10 — primary storage domain disappears
+
+Required result: alternate domain alone can return the exact protected artifact.
+
+### M-11 — wrong recovery identity
+
+Required result: encrypted backup cannot be decrypted by an unrelated recovery identity.
+
+### M-12 — fresh separated recovery
+
+Generate two real OpenPGP recovery identities, expose only their public keys to the producer, encrypt the continuity capsule, destroy the primary replica domain, recover from the alternate replica, decrypt using only the alternate private identity, then reconstruct the Git mirror and verify refs/fsck.
+
+Required result: `PASS` without executing restored project code.
+
+### M-13 — validator self-corruption
+
+The first test prototype accidentally overrode `unittest.TestCase.run`, making the validation harness itself invalid.
+
+Required result: retain this as process regression: validation code must not replace framework lifecycle methods accidentally; CI discovery must execute the intended tests.
+
+## Strength semantics
+
+Passing this corpus does **not** mean perfect resilience. It proves only the frozen responsibilities above.
+
+Remaining situational decisions include:
+
+- actual backup cadence / recovery-point objective;
+- retention;
+- which provider metadata scopes are Tier 0;
+- which real second provider/device/account constitutes an independent failure domain;
+- geographic separation;
+- offline/WORM copy requirements;
+- recovery-key operational custody.
+
+Those should be tightened when the workload justifies them rather than bloating the base system pre-emptively.
+
+## Promotion rule
+
+`METEOR GREEN + INHERITED CLOUD-CUSTODY GREEN + REAL GPG ALTERNATE-DOMAIN DRILL GREEN -> CONTRACT MAY BE ADOPTED`
+
+Any newly observed material miss becomes an inherited regression for future DARWIN occupants.

--- a/thin-rts/continuity/METEOR_AUTOPSY_0001.md
+++ b/thin-rts/continuity/METEOR_AUTOPSY_0001.md
@@ -1,116 +1,112 @@
-# METEOR AUTOPSY 0001 — Continuity / Recovery Attack Surface
+# METEOR AUTOPSY 0001 — Continuity / Recovery
 
-Status: `ATTACK_CORPUS_FROZEN / AWAITING_CI`
+Status: `ROUND_2_GREEN / DEATH_CAUSES_INHERITED`
 
-Target: 新RTS（仮称） Continuity / Recovery v0 candidate, composed with inherited Encrypted Cloud Custody v0.
+Target: 新RTS（仮称） Continuity / Recovery v0, composed with Encrypted Cloud Custody v0.
 
-## Raison d'être attack
+## Raison d'être verdict
 
-Candidate responsibility survives only if this narrower statement remains necessary:
+`SURVIVES`
 
-> Critical state must be able to leave a failed external substrate and reconstruct elsewhere with bounded integrity evidence.
+The surviving responsibility is narrow:
+
+> Critical Tier-0 state must be able to leave a failed external substrate and reconstruct elsewhere with bounded integrity evidence.
 
 Killed responsibilities:
 
-- build a new cloud;
-- build a new source host;
-- build custom cryptography;
-- build a custom key vault;
-- preserve every artifact forever;
-- define one universal backup interval for every workload.
+- new cloud/source host/object store;
+- custom cryptography/key vault;
+- preserve everything forever;
+- one universal backup interval/retention policy;
+- pretend that two labels prove physical independence.
 
 ## Frozen Meteor attacks
 
-### M-01 — dirty working tree
+The inherited regression corpus now requires:
 
-A committed-history backup that silently drops uncommitted/untracked Tier-0 work is a false PASS.
+- dirty/untracked working tree => `BLOCK`;
+- shallow or partial/promisor clone => `BLOCK`;
+- LFS/submodule state without a separate export => `BLOCK`;
+- required provider-metadata export/scope missing => `BLOCK`;
+- provider export that does not attest secret-value exclusion => `BLOCK`;
+- bundle/manifest/provider-export tamper => `BLOCK`;
+- dirty restore destination => `BLOCK`;
+- one/fake/nested replica domain => `BLOCK`;
+- corrupt replica => `BLOCK` for that domain while a healthy domain remains usable;
+- primary replica disappearance => alternate domain must recover exact protected bytes;
+- wrong recovery identity => decrypt must fail;
+- fresh alternate recovery identity + alternate replica => decrypt + manifest verify + Git mirror reconstruction + `git fsck` + exact refs => `PASS`;
+- restored project code must not execute during verification.
 
-Required result: `BLOCK`.
+## Observed Meteor Round 1 — prototype killed
 
-### M-02 — shallow or partial/promisor clone
+The focused unit corpus passed, but the real integration surface produced two material failures.
 
-A bundle created from missing history/objects can be internally consistent but incomplete.
+### Death C-01 — validator mutated the source before capture
 
-Required result: `BLOCK`.
+`py_compile` created validation artifacts before the live repository capture. The continuity gate correctly saw a dirty/untracked tree and refused to claim a complete snapshot.
 
-### M-03 — Git LFS or submodule external state
+Repair:
 
-A repository bundle can preserve only pointers/references while real content lives elsewhere.
+- run the real repository continuity capture **before** any validator/build step can mutate the worktree;
+- do not weaken the dirty-tree invariant.
 
-Required result: `BLOCK unless separately exported`.
+### Death C-02 — exact OpenPGP recipient still lacked unattended trust binding
 
-### M-04 — provider-only metadata omitted
+The producer contained only the two public recovery keys and correctly had no secret-key records, but GnuPG refused unattended encryption because the newly imported UIDs had no local certification trust.
 
-Issues, PR decisions, rulesets/settings and similar provider state are not contained in ordinary Git history.
+The custody contract already selected recipients by exact full primary fingerprint, so the repair was not to trust a name/UID or disable key separation.
 
-Required result: caller may declare provider scopes Tier 0; missing declared scopes => `BLOCK`.
+Repair:
 
-### M-05 — secret material contaminates metadata export
+- explicitly bind producer owner-trust to the exact selected full fingerprints before unattended encryption;
+- private recovery identities remain outside the producer;
+- wrong unrelated recovery identity must still fail decryption.
 
-A convenient provider export must not turn backup custody into credential exfiltration.
+### Death C-03 — validator lifecycle collision
 
-Required result: exporter must explicitly attest `secret_values_excluded=true`; otherwise `BLOCK`.
+The first test prototype accidentally named a helper `run`, overriding `unittest.TestCase.run`.
 
-### M-06 — bundle / manifest / provider export tamper
+Repair:
 
-Required result: digest/ref/manifest mismatch => `BLOCK`.
+- rename the helper and retain actual unittest discovery/execution as a process regression.
 
-### M-07 — stale restore destination
+## Observed Meteor Round 2 — survived
 
-Restoring into a dirty destination can mix old and recovered state.
+GitHub Actions `Continuity Recovery Candidate Tests` run #6:
 
-Required result: `BLOCK`.
+- actual PR repository capture on untouched worktree: `PASS`;
+- provider-neutral Git bundle: 5,701,092 bytes;
+- bundle SHA-256: `8efd6e01be3656034f9ee99a69344f1040f6f47201122b7ea91d373fa6dfad14`;
+- captured/restored refs: `103`;
+- fresh mirror `git fsck`: `PASS`;
+- restored project code execution: `NOT_PERFORMED`;
+- 10 focused Continuity Meteor regressions: `PASS`;
+- real two-recipient GPG alternate-domain recovery: `PASS`;
+- wrong recovery identity failure regression: `PASS`.
 
-### M-08 — fake redundancy
+Inherited `Cloud Custody Candidate Tests` run #27: `PASS`.
 
-Two replica labels that point to the same or nested local root are not two local failure domains.
+Unicode Guard / independent Semgrep on the same head: `PASS`.
 
-Required result: `BLOCK`.
+## Strength classification
 
-External note: distinct paths still do not prove distinct physical/providers. Production independence needs external evidence.
+No universal “100% safe” claim is made.
 
-### M-09 — one replica corrupted
+- Tier-0 Git reproducibility: `STRONG_UNDER_CURRENT_EVIDENCE`;
+- incomplete/tampered snapshot rejection: `STRONG_UNDER_CURRENT_EVIDENCE`;
+- encrypted alternate-domain failover semantics: `STRONG_UNDER_CURRENT_EVIDENCE`;
+- provider-neutral Git exitability: `STRONG_UNDER_CURRENT_EVIDENCE`;
+- provider-only metadata exitability: `CONTRACT_PROVEN / LIVE_EXPORTER_DEPLOYMENT_DEPENDENT`;
+- real physical/provider/geographic independence: `OPERATIONAL_EVIDENCE_REQUIRED`;
+- cadence/RPO/retention/offline-WORM requirements: `SITUATIONAL_POLICY`.
 
-Required result: corrupted domain => `BLOCK`; healthy domain remains independently recoverable.
+## Promotion verdict
 
-### M-10 — primary storage domain disappears
+`ADOPT_CONTRACT`
 
-Required result: alternate domain alone can return the exact protected artifact.
+Adopt the hard invariants, Tier policy, regression deaths, and current reference occupants into 新RTS（仮称）.
 
-### M-11 — wrong recovery identity
+Do **not** convert situational controls into mandatory base-system weight. When a workload declares a provider metadata scope, RPO, WORM requirement, or real failure-domain requirement critical, that declared requirement becomes fail-closed for that workload.
 
-Required result: encrypted backup cannot be decrypted by an unrelated recovery identity.
-
-### M-12 — fresh separated recovery
-
-Generate two real OpenPGP recovery identities, expose only their public keys to the producer, encrypt the continuity capsule, destroy the primary replica domain, recover from the alternate replica, decrypt using only the alternate private identity, then reconstruct the Git mirror and verify refs/fsck.
-
-Required result: `PASS` without executing restored project code.
-
-### M-13 — validator self-corruption
-
-The first test prototype accidentally overrode `unittest.TestCase.run`, making the validation harness itself invalid.
-
-Required result: retain this as process regression: validation code must not replace framework lifecycle methods accidentally; CI discovery must execute the intended tests.
-
-## Strength semantics
-
-Passing this corpus does **not** mean perfect resilience. It proves only the frozen responsibilities above.
-
-Remaining situational decisions include:
-
-- actual backup cadence / recovery-point objective;
-- retention;
-- which provider metadata scopes are Tier 0;
-- which real second provider/device/account constitutes an independent failure domain;
-- geographic separation;
-- offline/WORM copy requirements;
-- recovery-key operational custody.
-
-Those should be tightened when the workload justifies them rather than bloating the base system pre-emptively.
-
-## Promotion rule
-
-`METEOR GREEN + INHERITED CLOUD-CUSTODY GREEN + REAL GPG ALTERNATE-DOMAIN DRILL GREEN -> CONTRACT MAY BE ADOPTED`
-
-Any newly observed material miss becomes an inherited regression for future DARWIN occupants.
+Any future material miss becomes inherited regression memory for the next DARWIN occupant.

--- a/thin-rts/continuity/README.md
+++ b/thin-rts/continuity/README.md
@@ -1,0 +1,132 @@
+# 新RTS（仮称） — Continuity / Recovery v0
+
+Status: `METEOR_CANDIDATE / NOT_YET_PROMOTED`
+
+This component exists for one reason:
+
+> A critical external substrate may disappear, be corrupted, lock the operator out, or become untrustworthy. 新RTS（仮称） must still preserve enough trusted state to reconstruct its Tier-0 responsibilities somewhere else.
+
+It is **not** a new cloud, source host, key vault, scheduler, database, or backup platform.
+
+## What matters most
+
+Hard invariants are intentionally few:
+
+1. **Safety** — hostile/tampered backup material must not be silently trusted or executed.
+2. **Reproducibility** — Tier-0 state must reconstruct to the same committed Git refs/history and declared provider metadata.
+3. **Recoverability** — a backup is not PASS until a fresh reconstruction drill succeeds.
+4. **Exitability** — critical state must have a provider-neutral representation, not only a provider-native copy.
+5. **Failure-domain separation** — protected backup material must have more than one recovery path, and one failed/corrupt path must not poison the other.
+
+Everything else is situational and may be dropped when cost/complexity exceeds value.
+
+## Priority / discard policy
+
+### Tier 0 — must survive
+
+- committed Git objects and refs containing the current system, invariants, specs and regression capsules;
+- provider-only metadata explicitly declared necessary for governance/reconstruction (for example issues/PR records or repository rules);
+- integrity manifests, recovery receipts and key-epoch/recipient identity metadata;
+- the ability to obtain the separately held recovery identity/key needed to decrypt the protected backup.
+
+Secret values themselves are **not** placed into the provider metadata export. Recovery secrets belong to a separate trust boundary.
+
+### Tier 1 — preserve when useful
+
+- expensive-to-regenerate analysis results;
+- selected build/release artifacts;
+- derived indexes or reports.
+
+Tier 1 loss may hurt time/cost but must not make Tier-0 reconstruction impossible.
+
+### Tier 2 — disposable
+
+- caches;
+- downloaded dependencies that can be re-fetched;
+- temporary build/work directories;
+- cheap derived state.
+
+Do not turn Tier 2 into a reason to build another platform.
+
+## Provider-neutral Git capture
+
+`continuity.py capture` creates a Git bundle plus a continuity manifest.
+
+Before capture it fails closed on known partial-custody states:
+
+- dirty/untracked working tree;
+- shallow clone;
+- partial/promisor clone;
+- Git submodules without a separate export;
+- Git LFS declarations without a separate export;
+- source Git object corruption.
+
+A self-consistent *partial* backup is more dangerous than an explicit failure, so these cases are rejected rather than silently omitted.
+
+## Provider metadata export contract
+
+Git alone does not preserve provider-only state such as issue/PR conversations or repository/ruleset settings.
+
+新RTS（仮称） does not own provider scrapers. Instead, an external exporter may supply a directory containing `EXPORT_ATTESTATION.json`:
+
+```json
+{
+  "schema": "new-rts-provisional-platform-export-attestation/v0",
+  "producer_id": "provider-exporter:...",
+  "captured_at": "...",
+  "secret_values_excluded": true,
+  "scope": ["issues", "pull_requests", "repository_rules"]
+}
+```
+
+The caller decides which scopes are Tier 0 for the current provider. If a required scope is absent, capture fails closed.
+
+This keeps the continuity contract stable while provider adapters remain replaceable.
+
+## Fresh recovery drill
+
+`continuity.py drill`:
+
+1. verifies hashes and manifests;
+2. verifies the Git bundle;
+3. clones it into a new mirror repository;
+4. runs `git fsck --full`;
+5. requires the restored refs to equal the captured refs;
+6. verifies optional platform-export content;
+7. **does not execute restored project code**.
+
+`BACKUP_EXISTS != RECOVERY_PROVEN`
+
+## Encryption and recovery identity
+
+Encryption remains externalized to the existing encrypted Cloud Custody candidate (GnuPG/OpenPGP). The producer receives public recovery keys; private recovery identities remain outside the producer/provider trust boundary.
+
+The continuity integration test performs a real two-recipient GPG encryption, destroys the primary storage domain, recovers ciphertext only from the alternate domain, decrypts using only the alternate recovery identity, and runs the fresh Git reconstruction drill.
+
+## Replica contract
+
+`replicate` is a thin local reference adapter for an already protected/opaque artifact. It requires at least two declared failure-domain IDs and non-overlapping local paths, verifies SHA-256 after each copy, and writes a receipt.
+
+Important limitation:
+
+> Two labels or two paths do not prove physical/provider independence.
+
+Production independence requires external evidence that the domains really differ (provider/account/device/region/control plane as appropriate). The local adapter exists to test failover semantics without inventing a cloud platform.
+
+## What is deliberately cut
+
+- custom cryptography;
+- custom object store;
+- custom source host;
+- custom secret vault;
+- always-on backup daemon;
+- mandatory one-size-fits-all retention/freshness schedule;
+- automatic preservation of every Tier-1/Tier-2 artifact.
+
+Freshness/retention are policy inputs because acceptable recovery age depends on the workload. A stale backup may be degraded evidence, but emergency recovery should not destroy the last surviving copy merely because a universal timer expired.
+
+## `/goal` adoption rule
+
+The **contract** may be promoted after inherited Cloud Custody regressions plus Continuity Meteor attacks and the real alternate-domain GPG recovery drill are green.
+
+Concrete Python/file adapters remain replaceable DARWIN occupants. A better external tool may replace them if it preserves all inherited death causes and the same Tier-0 evidence contract.

--- a/thin-rts/continuity/README.md
+++ b/thin-rts/continuity/README.md
@@ -1,24 +1,24 @@
 # 新RTS（仮称） — Continuity / Recovery v0
 
-Status: `METEOR_CANDIDATE / NOT_YET_PROMOTED`
+Status: `ADOPTED_CONTRACT / REFERENCE_OCCUPANTS`
 
 This component exists for one reason:
 
-> A critical external substrate may disappear, be corrupted, lock the operator out, or become untrustworthy. 新RTS（仮称） must still preserve enough trusted state to reconstruct its Tier-0 responsibilities somewhere else.
+> A critical external substrate may disappear, be corrupted, lock the operator out, or become untrustworthy. 新RTS（仮称） must still preserve enough trusted Tier-0 state to reconstruct its critical responsibilities somewhere else.
 
 It is **not** a new cloud, source host, key vault, scheduler, database, or backup platform.
 
-## What matters most
+## Hard invariants
 
-Hard invariants are intentionally few:
+Only the high-value invariants are base-system requirements:
 
 1. **Safety** — hostile/tampered backup material must not be silently trusted or executed.
 2. **Reproducibility** — Tier-0 state must reconstruct to the same committed Git refs/history and declared provider metadata.
-3. **Recoverability** — a backup is not PASS until a fresh reconstruction drill succeeds.
-4. **Exitability** — critical state must have a provider-neutral representation, not only a provider-native copy.
-5. **Failure-domain separation** — protected backup material must have more than one recovery path, and one failed/corrupt path must not poison the other.
+3. **Recoverability** — a backup is not proven until a fresh reconstruction drill succeeds.
+4. **Exitability** — critical state needs a provider-neutral representation, not only a provider-native copy.
+5. **Failure-domain separation** — protected backup material needs more than one recovery path; one failed/corrupt path must not poison another.
 
-Everything else is situational and may be dropped when cost/complexity exceeds value.
+Everything else is situational policy. Do not bloat the base system to chase a fictional universal 100% score.
 
 ## Priority / discard policy
 
@@ -27,9 +27,9 @@ Everything else is situational and may be dropped when cost/complexity exceeds v
 - committed Git objects and refs containing the current system, invariants, specs and regression capsules;
 - provider-only metadata explicitly declared necessary for governance/reconstruction (for example issues/PR records or repository rules);
 - integrity manifests, recovery receipts and key-epoch/recipient identity metadata;
-- the ability to obtain the separately held recovery identity/key needed to decrypt the protected backup.
+- access to separately held recovery identities/keys needed to decrypt protected backups.
 
-Secret values themselves are **not** placed into the provider metadata export. Recovery secrets belong to a separate trust boundary.
+Secret values themselves are **not** placed into provider metadata exports. Recovery secrets belong to a separate trust boundary.
 
 ### Tier 1 — preserve when useful
 
@@ -37,7 +37,7 @@ Secret values themselves are **not** placed into the provider metadata export. R
 - selected build/release artifacts;
 - derived indexes or reports.
 
-Tier 1 loss may hurt time/cost but must not make Tier-0 reconstruction impossible.
+Tier 1 loss may cost time/money but must not make Tier-0 reconstruction impossible.
 
 ### Tier 2 — disposable
 
@@ -52,7 +52,7 @@ Do not turn Tier 2 into a reason to build another platform.
 
 `continuity.py capture` creates a Git bundle plus a continuity manifest.
 
-Before capture it fails closed on known partial-custody states:
+It fails closed on known partial-custody states:
 
 - dirty/untracked working tree;
 - shallow clone;
@@ -61,13 +61,13 @@ Before capture it fails closed on known partial-custody states:
 - Git LFS declarations without a separate export;
 - source Git object corruption.
 
-A self-consistent *partial* backup is more dangerous than an explicit failure, so these cases are rejected rather than silently omitted.
+A self-consistent *partial* backup is more dangerous than an explicit failure, so these states are rejected rather than silently omitted.
 
 ## Provider metadata export contract
 
-Git alone does not preserve provider-only state such as issue/PR conversations or repository/ruleset settings.
+Git does not preserve provider-only state such as issue/PR conversations or repository/ruleset settings.
 
-新RTS（仮称） does not own provider scrapers. Instead, an external exporter may supply a directory containing `EXPORT_ATTESTATION.json`:
+新RTS（仮称） does not own provider scrapers. An external exporter may supply a directory containing `EXPORT_ATTESTATION.json`:
 
 ```json
 {
@@ -79,29 +79,27 @@ Git alone does not preserve provider-only state such as issue/PR conversations o
 }
 ```
 
-The caller decides which scopes are Tier 0 for the current provider. If a required scope is absent, capture fails closed.
-
-This keeps the continuity contract stable while provider adapters remain replaceable.
+The workload declares which scopes are Tier 0. Missing declared scopes fail closed. This keeps provider adapters replaceable.
 
 ## Fresh recovery drill
 
 `continuity.py drill`:
 
-1. verifies hashes and manifests;
+1. verifies hashes/manifests;
 2. verifies the Git bundle;
-3. clones it into a new mirror repository;
+3. clones it into a fresh mirror repository;
 4. runs `git fsck --full`;
-5. requires the restored refs to equal the captured refs;
+5. requires restored refs to equal captured refs;
 6. verifies optional platform-export content;
 7. **does not execute restored project code**.
 
 `BACKUP_EXISTS != RECOVERY_PROVEN`
 
-## Encryption and recovery identity
+## Encryption and alternate recovery
 
-Encryption remains externalized to the existing encrypted Cloud Custody candidate (GnuPG/OpenPGP). The producer receives public recovery keys; private recovery identities remain outside the producer/provider trust boundary.
+Encryption remains externalized to the Encrypted Cloud Custody occupant (GnuPG/OpenPGP). The producer receives public recovery keys; private identities remain outside the producer/provider trust boundary.
 
-The continuity integration test performs a real two-recipient GPG encryption, destroys the primary storage domain, recovers ciphertext only from the alternate domain, decrypts using only the alternate recovery identity, and runs the fresh Git reconstruction drill.
+The adoption drill generated two real recovery identities, bound producer trust to their exact full fingerprints, encrypted the continuity capsule, destroyed the primary replica domain, recovered ciphertext only from the alternate domain, decrypted using only the alternate private identity, and completed a fresh Git reconstruction. A wrong unrelated recovery identity failed as required.
 
 ## Replica contract
 
@@ -111,7 +109,7 @@ Important limitation:
 
 > Two labels or two paths do not prove physical/provider independence.
 
-Production independence requires external evidence that the domains really differ (provider/account/device/region/control plane as appropriate). The local adapter exists to test failover semantics without inventing a cloud platform.
+Production independence requires external evidence that the domains really differ (provider/account/device/region/control plane as appropriate). The local adapter tests failover semantics without inventing a cloud platform.
 
 ## What is deliberately cut
 
@@ -123,10 +121,24 @@ Production independence requires external evidence that the domains really diffe
 - mandatory one-size-fits-all retention/freshness schedule;
 - automatic preservation of every Tier-1/Tier-2 artifact.
 
-Freshness/retention are policy inputs because acceptable recovery age depends on the workload. A stale backup may be degraded evidence, but emergency recovery should not destroy the last surviving copy merely because a universal timer expired.
+Freshness, RPO, retention, offline/WORM and provider/geographic separation become hard only when the current workload declares them critical.
 
-## `/goal` adoption rule
+## Current evidence
 
-The **contract** may be promoted after inherited Cloud Custody regressions plus Continuity Meteor attacks and the real alternate-domain GPG recovery drill are green.
+Observed adoption evidence on PR #318 before the final record-only update:
 
-Concrete Python/file adapters remain replaceable DARWIN occupants. A better external tool may replace them if it preserves all inherited death causes and the same Tier-0 evidence contract.
+- provider-neutral capture/drill on the actual RTS PR repository: `PASS`;
+- Git bundle: 5,701,092 bytes;
+- captured/restored refs: 103;
+- fresh mirror `git fsck`: `PASS`;
+- 10 Continuity Meteor regressions: `PASS`;
+- real GPG alternate-domain recovery: `PASS`;
+- wrong recovery identity: `BLOCK` as required;
+- inherited Cloud Custody Meteor suite: `PASS`;
+- Unicode Guard and independent Semgrep: `PASS`.
+
+## DARWIN rule
+
+The **contract** is adopted. The Python/file/GnuPG/GCS occupants have no permanent implementation right.
+
+A challenger may replace any occupant if it preserves the hard invariants and all inherited death causes with equal-or-better evidence and lower burden.

--- a/thin-rts/continuity/continuity.py
+++ b/thin-rts/continuity/continuity.py
@@ -1,0 +1,818 @@
+#!/usr/bin/env python3
+"""Provider-neutral continuity/recovery glue for 新RTS（仮称）.
+
+No custom source host, cloud, crypto, key vault, scheduler, or database is implemented here.
+The durable responsibility is narrower: prove that critical Git state can leave the current
+provider, bind optional provider metadata exports, replicate already-protected artifacts
+across declared failure domains, and survive a fresh non-executing reconstruction drill.
+"""
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+from pathlib import Path, PurePosixPath
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+from datetime import datetime, timezone
+
+SCHEMA = "new-rts-provisional-continuity/v0"
+PLATFORM_ATTESTATION_SCHEMA = "new-rts-provisional-platform-export-attestation/v0"
+REPLICA_RECEIPT_SCHEMA = "new-rts-provisional-replica-receipt/v0"
+MANIFEST_NAME = "CONTINUITY_MANIFEST.json"
+PLATFORM_MANIFEST_NAME = "PLATFORM_EXPORT_MANIFEST.json"
+DOMAIN_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,95}$")
+
+
+class ContinuityError(RuntimeError):
+    pass
+
+
+def now_utc() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def canonical_json_bytes(value: object) -> bytes:
+    return (json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")) + "\n").encode("utf-8")
+
+
+def write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(canonical_json_bytes(value))
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def run(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    check: bool = True,
+    env: dict[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    cp = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+        env=env,
+    )
+    if check and cp.returncode != 0:
+        raise ContinuityError(
+            f"command failed ({cp.returncode}): {' '.join(cmd)}\n{cp.stderr.strip()}"
+        )
+    return cp
+
+
+def git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return run(["git", "-C", str(repo), *args], check=check)
+
+
+def assert_git_repo(repo: Path) -> Path:
+    repo = repo.expanduser().resolve()
+    cp = git(repo, "rev-parse", "--is-inside-work-tree", check=False)
+    if cp.returncode != 0 or cp.stdout.strip() != "true":
+        raise ContinuityError(f"not a Git work tree: {repo}")
+    return repo
+
+
+def assert_outside_source(path: Path, source_repo: Path) -> Path:
+    resolved = path.expanduser().resolve()
+    source = source_repo.expanduser().resolve()
+    if resolved == source or source in resolved.parents:
+        raise ContinuityError(
+            f"continuity runtime path must be outside source repository: {resolved}"
+        )
+    return resolved
+
+
+def ensure_empty_output(path: Path) -> None:
+    if path.exists():
+        if not path.is_dir():
+            raise ContinuityError(f"output path is not a directory: {path}")
+        if any(path.iterdir()):
+            raise ContinuityError(f"output directory must be empty: {path}")
+    else:
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def git_refs(repo: Path) -> dict[str, str]:
+    cp = git(repo, "for-each-ref", "--format=%(refname)%00%(objectname)")
+    refs: dict[str, str] = {}
+    for line in cp.stdout.splitlines():
+        if "\x00" not in line:
+            continue
+        ref, oid = line.split("\x00", 1)
+        if ref and oid:
+            refs[ref] = oid
+    if not refs:
+        raise ContinuityError("repository has no refs to preserve")
+    return dict(sorted(refs.items()))
+
+
+def head_identity(repo: Path) -> tuple[str, str]:
+    head_sha = git(repo, "rev-parse", "HEAD").stdout.strip()
+    sym = git(repo, "symbolic-ref", "-q", "HEAD", check=False)
+    head_ref = sym.stdout.strip() if sym.returncode == 0 and sym.stdout.strip() else "DETACHED"
+    return head_ref, head_sha
+
+
+def tracked_attribute_files(repo: Path) -> list[Path]:
+    cp = git(repo, "ls-files")
+    return [repo / raw for raw in cp.stdout.splitlines() if Path(raw).name == ".gitattributes"]
+
+
+def assert_capture_safe(repo: Path) -> None:
+    dirty = git(repo, "status", "--porcelain=v1", "--untracked-files=all").stdout
+    if dirty.strip():
+        raise ContinuityError(
+            "dirty/untracked working tree is not silently excluded; commit or separately archive it first"
+        )
+
+    shallow = git(repo, "rev-parse", "--is-shallow-repository").stdout.strip().lower()
+    if shallow == "true":
+        raise ContinuityError("shallow repository cannot prove full reachable history")
+
+    promisor = git(repo, "config", "--get-regexp", r"^remote\..*\.promisor$", check=False)
+    if promisor.returncode == 0 and promisor.stdout.strip():
+        raise ContinuityError("partial/promisor clone cannot prove locally complete object custody")
+
+    gitmodules = repo / ".gitmodules"
+    if gitmodules.is_file() and gitmodules.read_text("utf-8", errors="replace").strip():
+        raise ContinuityError(
+            "submodules require separate provider-neutral exports; refusing a partial Tier-0 snapshot"
+        )
+
+    for attrs in tracked_attribute_files(repo):
+        text = attrs.read_text("utf-8", errors="replace")
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#") and "filter=lfs" in stripped:
+                raise ContinuityError(
+                    "Git LFS content requires a separate export adapter; refusing pointer-only custody"
+                )
+
+    # The source object database must itself be internally readable before we freeze it.
+    git(repo, "fsck", "--full", "--no-reflogs")
+
+
+def list_bundle_refs(bundle: Path) -> dict[str, str]:
+    cp = run(["git", "bundle", "list-heads", str(bundle)])
+    refs: dict[str, str] = {}
+    for line in cp.stdout.splitlines():
+        parts = line.split(maxsplit=1)
+        if len(parts) != 2:
+            continue
+        oid, ref = parts
+        if ref == "HEAD":
+            continue
+        refs[ref] = oid
+    if not refs:
+        raise ContinuityError("bundle exposes no named refs")
+    return dict(sorted(refs.items()))
+
+
+def verify_bundle_file(bundle: Path) -> dict[str, str]:
+    if not bundle.is_file() or bundle.is_symlink():
+        raise ContinuityError(f"Git bundle missing/unsafe: {bundle}")
+    with tempfile.TemporaryDirectory(prefix="new-rts-bundle-verify-") as td:
+        bare = Path(td) / "verify.git"
+        run(["git", "init", "--bare", str(bare)])
+        run(["git", "-C", str(bare), "bundle", "verify", str(bundle)])
+    return list_bundle_refs(bundle)
+
+
+def safe_relpath(value: str) -> str:
+    rel = PurePosixPath(value)
+    if not value or rel.is_absolute() or ".." in rel.parts or value == ".":
+        raise ContinuityError(f"unsafe relative path: {value!r}")
+    return rel.as_posix()
+
+
+def normalized_files(root: Path) -> list[Path]:
+    root = root.resolve()
+    files: list[Path] = []
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ContinuityError(f"symlink rejected: {path}")
+        if path.is_file():
+            files.append(path)
+    return sorted(files, key=lambda p: p.relative_to(root).as_posix())
+
+
+def normalized_tarinfo(name: str, size: int) -> tarfile.TarInfo:
+    info = tarfile.TarInfo(name=name)
+    info.size = size
+    info.mode = 0o644
+    info.uid = 0
+    info.gid = 0
+    info.uname = ""
+    info.gname = ""
+    info.mtime = 0
+    return info
+
+
+def load_platform_attestation(root: Path, required_scope: set[str]) -> dict:
+    path = root / "EXPORT_ATTESTATION.json"
+    if not path.is_file() or path.is_symlink():
+        raise ContinuityError("platform export requires EXPORT_ATTESTATION.json")
+    try:
+        data = json.loads(path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContinuityError("platform export attestation is invalid JSON") from exc
+    if data.get("schema") != PLATFORM_ATTESTATION_SCHEMA:
+        raise ContinuityError("platform export attestation schema mismatch")
+    if data.get("secret_values_excluded") is not True:
+        raise ContinuityError("platform export must attest that secret values were excluded")
+    if not isinstance(data.get("producer_id"), str) or not data["producer_id"].strip():
+        raise ContinuityError("platform export attestation requires producer_id")
+    if not isinstance(data.get("captured_at"), str) or not data["captured_at"].strip():
+        raise ContinuityError("platform export attestation requires captured_at")
+    scope = data.get("scope")
+    if not isinstance(scope, list) or not scope or not all(isinstance(v, str) and v for v in scope):
+        raise ContinuityError("platform export attestation requires a non-empty scope list")
+    missing = sorted(required_scope - set(scope))
+    if missing:
+        raise ContinuityError(f"platform export missing required scope: {', '.join(missing)}")
+    return data
+
+
+def create_platform_export_archive(
+    root: Path,
+    output: Path,
+    required_scope: set[str],
+) -> dict:
+    root = root.expanduser().resolve()
+    if not root.is_dir():
+        raise ContinuityError(f"platform export directory missing: {root}")
+    attestation = load_platform_attestation(root, required_scope)
+    files = normalized_files(root)
+    if not files:
+        raise ContinuityError("platform export is empty")
+    for path in files:
+        if path.relative_to(root).as_posix() == PLATFORM_MANIFEST_NAME:
+            raise ContinuityError(
+                f"reserved export manifest path already exists: {PLATFORM_MANIFEST_NAME}"
+            )
+
+    entries = [
+        {
+            "path": safe_relpath(path.relative_to(root).as_posix()),
+            "size": path.stat().st_size,
+            "sha256": sha256_file(path),
+        }
+        for path in files
+    ]
+    export_manifest = {
+        "schema": SCHEMA,
+        "kind": "platform-export-manifest",
+        "entries": entries,
+        "attestation": attestation,
+    }
+    manifest_bytes = canonical_json_bytes(export_manifest)
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(prefix="new-rts-platform-", suffix=".tar", delete=False) as tf:
+        tmp_tar = Path(tf.name)
+    try:
+        with tarfile.open(tmp_tar, "w", format=tarfile.PAX_FORMAT) as tar:
+            for path in files:
+                rel = path.relative_to(root).as_posix()
+                data = path.read_bytes()
+                tar.addfile(normalized_tarinfo(rel, len(data)), io.BytesIO(data))
+            tar.addfile(
+                normalized_tarinfo(PLATFORM_MANIFEST_NAME, len(manifest_bytes)),
+                io.BytesIO(manifest_bytes),
+            )
+        with tmp_tar.open("rb") as src, output.open("wb") as raw:
+            with gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as gz:
+                shutil.copyfileobj(src, gz)
+    finally:
+        tmp_tar.unlink(missing_ok=True)
+
+    return {
+        "path": output.name,
+        "sha256": sha256_file(output),
+        "size": output.stat().st_size,
+        "producer_id": attestation["producer_id"],
+        "captured_at": attestation["captured_at"],
+        "scope": sorted(attestation["scope"]),
+    }
+
+
+def safe_extract_archive(archive: Path, output: Path) -> None:
+    if output.exists():
+        if not output.is_dir() or any(output.iterdir()):
+            raise ContinuityError(f"restore destination must be an empty directory: {output}")
+    else:
+        output.mkdir(parents=True, exist_ok=True)
+    root = output.resolve()
+    with tarfile.open(archive, "r:gz") as tar:
+        seen: set[str] = set()
+        for member in tar.getmembers():
+            rel = safe_relpath(member.name)
+            if rel in seen:
+                raise ContinuityError(f"duplicate archive member: {rel}")
+            seen.add(rel)
+            if member.issym() or member.islnk() or member.isdev():
+                raise ContinuityError(f"unsafe archive member type: {rel}")
+            target = (root / Path(*PurePosixPath(rel).parts)).resolve()
+            if target != root and root not in target.parents:
+                raise ContinuityError(f"archive member escapes destination: {rel}")
+        tar.extractall(root, filter="data")
+
+
+def verify_platform_export_archive(archive: Path, output: Path) -> dict:
+    safe_extract_archive(archive, output)
+    manifest_path = output / PLATFORM_MANIFEST_NAME
+    if not manifest_path.is_file() or manifest_path.is_symlink():
+        raise ContinuityError("platform export internal manifest missing/unsafe")
+    try:
+        manifest = json.loads(manifest_path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContinuityError("platform export internal manifest invalid") from exc
+    if manifest.get("schema") != SCHEMA or manifest.get("kind") != "platform-export-manifest":
+        raise ContinuityError("platform export internal manifest contract mismatch")
+    entries = manifest.get("entries")
+    if not isinstance(entries, list) or not entries:
+        raise ContinuityError("platform export internal manifest has no entries")
+    expected: set[str] = set()
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise ContinuityError("platform export manifest entry invalid")
+        rel = safe_relpath(str(entry.get("path", "")))
+        if rel in expected:
+            raise ContinuityError(f"duplicate platform export path: {rel}")
+        expected.add(rel)
+        path = output / Path(*PurePosixPath(rel).parts)
+        if not path.is_file() or path.is_symlink():
+            raise ContinuityError(f"platform export file missing/unsafe: {rel}")
+        if path.stat().st_size != entry.get("size") or sha256_file(path) != entry.get("sha256"):
+            raise ContinuityError(f"platform export digest mismatch: {rel}")
+    actual = {
+        path.relative_to(output).as_posix()
+        for path in normalized_files(output)
+        if path.relative_to(output).as_posix() != PLATFORM_MANIFEST_NAME
+    }
+    if actual != expected:
+        raise ContinuityError("platform export contains missing or unmanifested files")
+    return {
+        "status": "PASS",
+        "entries": len(entries),
+        "attestation": manifest.get("attestation"),
+    }
+
+
+def capture_repo(
+    repo: Path,
+    output: Path,
+    platform_export: Path | None = None,
+    required_platform_scope: set[str] | None = None,
+    require_platform_export: bool = False,
+) -> dict:
+    repo = assert_git_repo(repo)
+    output = assert_outside_source(output, repo)
+    ensure_empty_output(output)
+    assert_capture_safe(repo)
+    required_platform_scope = required_platform_scope or set()
+
+    head_ref, head_sha = head_identity(repo)
+    refs = git_refs(repo)
+    object_format = git(repo, "rev-parse", "--show-object-format").stdout.strip()
+    git_version = run(["git", "--version"]).stdout.strip()
+
+    bundle = output / "repository.bundle"
+    git(repo, "bundle", "create", str(bundle), "--all")
+    bundle_refs = verify_bundle_file(bundle)
+    if bundle_refs != refs:
+        raise ContinuityError("Git bundle ref set does not exactly match source refs")
+
+    artifacts: list[dict] = [
+        {
+            "role": "tier0-git-history",
+            "path": bundle.name,
+            "sha256": sha256_file(bundle),
+            "size": bundle.stat().st_size,
+        }
+    ]
+
+    platform_record = None
+    if platform_export is not None:
+        platform_record = create_platform_export_archive(
+            platform_export,
+            output / "platform-export.tar.gz",
+            required_platform_scope,
+        )
+        artifacts.append(
+            {
+                "role": "provider-export",
+                "path": platform_record["path"],
+                "sha256": platform_record["sha256"],
+                "size": platform_record["size"],
+            }
+        )
+    elif require_platform_export:
+        raise ContinuityError(
+            "declared Tier-0 platform metadata export is required but was not supplied"
+        )
+
+    snapshot_seed = head_sha + artifacts[0]["sha256"] + (
+        platform_record["sha256"] if platform_record else ""
+    )
+    snapshot_id = hashlib.sha256(snapshot_seed.encode("ascii")).hexdigest()[:24]
+    manifest = {
+        "schema": SCHEMA,
+        "system_name": "新RTS（仮称）",
+        "snapshot_id": snapshot_id,
+        "created_at": now_utc(),
+        "source": {
+            "head_ref": head_ref,
+            "head_sha": head_sha,
+            "refs": refs,
+            "ref_count": len(refs),
+            "object_format": object_format,
+            "git_version": git_version,
+        },
+        "artifacts": artifacts,
+        "platform_export": platform_record,
+        "coverage": {
+            "git_history_and_refs": "CAPTURED",
+            "platform_metadata": "CAPTURED" if platform_record else "NOT_SUPPLIED",
+            "secret_values": "INTENTIONALLY_NOT_CAPTURED",
+            "working_tree_uncommitted": "REJECTED_IF_PRESENT",
+            "git_lfs": "REJECTED_UNLESS_SEPARATELY_EXPORTED",
+            "git_submodules": "REJECTED_UNLESS_SEPARATELY_EXPORTED",
+            "partial_or_shallow_clone": "REJECTED",
+        },
+        "status": "COMPLETE_FOR_DECLARED_SCOPE" if platform_record else "CORE_GIT_ONLY",
+        "next_gate": (
+            "encrypt with separated recovery identities, replicate across independent failure "
+            "domains, then perform a fresh non-executing recovery drill"
+        ),
+    }
+    write_json(output / MANIFEST_NAME, manifest)
+    return manifest
+
+
+def load_manifest(capsule: Path) -> dict:
+    path = capsule / MANIFEST_NAME
+    if not path.is_file() or path.is_symlink():
+        raise ContinuityError(f"continuity manifest missing/unsafe: {path}")
+    try:
+        manifest = json.loads(path.read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContinuityError("continuity manifest invalid JSON") from exc
+    if manifest.get("schema") != SCHEMA:
+        raise ContinuityError("continuity manifest schema mismatch")
+    return manifest
+
+
+def verify_capsule(capsule: Path) -> dict:
+    capsule = capsule.expanduser().resolve()
+    manifest = load_manifest(capsule)
+    artifacts = manifest.get("artifacts")
+    if not isinstance(artifacts, list) or not artifacts:
+        raise ContinuityError("continuity manifest has no artifacts")
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            raise ContinuityError("continuity artifact entry invalid")
+        rel = safe_relpath(str(artifact.get("path", "")))
+        path = capsule / rel
+        if not path.is_file() or path.is_symlink():
+            raise ContinuityError(f"continuity artifact missing/unsafe: {rel}")
+        if path.stat().st_size != artifact.get("size") or sha256_file(path) != artifact.get("sha256"):
+            raise ContinuityError(f"continuity artifact digest mismatch: {rel}")
+
+    expected_refs = manifest.get("source", {}).get("refs")
+    if not isinstance(expected_refs, dict) or not expected_refs:
+        raise ContinuityError("source refs missing from continuity manifest")
+    actual_refs = verify_bundle_file(capsule / "repository.bundle")
+    if actual_refs != expected_refs:
+        raise ContinuityError("bundle refs do not match continuity manifest")
+
+    platform_result = None
+    if manifest.get("platform_export"):
+        with tempfile.TemporaryDirectory(prefix="new-rts-platform-verify-") as td:
+            platform_result = verify_platform_export_archive(
+                capsule / "platform-export.tar.gz",
+                Path(td) / "platform",
+            )
+
+    return {
+        "status": "PASS",
+        "snapshot_id": manifest.get("snapshot_id"),
+        "ref_count": len(actual_refs),
+        "platform_export": platform_result,
+        "manifest_sha256": sha256_file(capsule / MANIFEST_NAME),
+    }
+
+
+def drill_capsule(
+    capsule: Path,
+    restore_root: Path,
+    receipt_path: Path | None = None,
+) -> dict:
+    capsule = capsule.expanduser().resolve()
+    restore_root = restore_root.expanduser().resolve()
+    ensure_empty_output(restore_root)
+
+    verify = verify_capsule(capsule)
+    manifest = load_manifest(capsule)
+    restored_git = restore_root / "repository.git"
+    run(["git", "clone", "--mirror", str(capsule / "repository.bundle"), str(restored_git)])
+    run(["git", "-C", str(restored_git), "fsck", "--full"])
+    restored_refs = git_refs(restored_git)
+    expected_refs = manifest["source"]["refs"]
+    if restored_refs != expected_refs:
+        raise ContinuityError("fresh mirror restore refs differ from captured refs")
+
+    head_sha = manifest["source"]["head_sha"]
+    cat = run(
+        ["git", "-C", str(restored_git), "cat-file", "-e", f"{head_sha}^{{commit}}"],
+        check=False,
+    )
+    if cat.returncode != 0:
+        raise ContinuityError("captured HEAD commit is absent from restored repository")
+
+    platform_status = "NOT_SUPPLIED"
+    if manifest.get("platform_export"):
+        platform_out = restore_root / "platform-export"
+        result = verify_platform_export_archive(
+            capsule / "platform-export.tar.gz",
+            platform_out,
+        )
+        platform_status = result["status"]
+
+    receipt = {
+        "schema": SCHEMA,
+        "kind": "fresh-recovery-drill-receipt",
+        "system_name": "新RTS（仮称）",
+        "snapshot_id": manifest["snapshot_id"],
+        "drilled_at": now_utc(),
+        "status": "PASS",
+        "manifest_sha256": verify["manifest_sha256"],
+        "restored_head_sha": head_sha,
+        "restored_ref_count": len(restored_refs),
+        "git_fsck": "PASS",
+        "platform_export": platform_status,
+        "code_execution": "NOT_PERFORMED",
+    }
+    if receipt_path:
+        write_json(receipt_path.expanduser().resolve(), receipt)
+    return receipt
+
+
+def parse_destination(spec: str) -> tuple[str, Path]:
+    if "=" not in spec:
+        raise ContinuityError("replica destination must be DOMAIN_ID=PATH")
+    domain_id, raw_path = spec.split("=", 1)
+    if not DOMAIN_ID_RE.fullmatch(domain_id):
+        raise ContinuityError(f"invalid failure-domain id: {domain_id!r}")
+    if not raw_path:
+        raise ContinuityError("replica destination path is empty")
+    return domain_id, Path(raw_path).expanduser().resolve()
+
+
+def assert_independent_declared_destinations(destinations: list[tuple[str, Path]]) -> None:
+    if len(destinations) < 2:
+        raise ContinuityError("at least two declared failure domains are required")
+    ids = [domain_id for domain_id, _ in destinations]
+    if len(ids) != len(set(ids)):
+        raise ContinuityError("duplicate failure-domain ids are not independent")
+    paths = [path for _, path in destinations]
+    if len(paths) != len(set(paths)):
+        raise ContinuityError("duplicate replica paths are not independent")
+    for index, left in enumerate(paths):
+        for right in paths[index + 1 :]:
+            if left in right.parents or right in left.parents:
+                raise ContinuityError(
+                    "nested replica roots share a local failure domain; use non-overlapping roots"
+                )
+
+
+def atomic_copy_verified(source: Path, destination: Path, expected_sha256: str) -> dict:
+    source = source.expanduser().resolve()
+    if not source.is_file() or source.is_symlink():
+        raise ContinuityError(f"source artifact missing/unsafe: {source}")
+    if sha256_file(source) != expected_sha256:
+        raise ContinuityError("source artifact digest does not match declared digest")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        if destination.is_symlink() or not destination.is_file():
+            raise ContinuityError(f"existing replica path is unsafe: {destination}")
+        if sha256_file(destination) != expected_sha256:
+            raise ContinuityError("existing replica conflicts with expected immutable artifact")
+        return {
+            "path": str(destination),
+            "sha256": expected_sha256,
+            "size": destination.stat().st_size,
+            "status": "ALREADY_PRESENT_VERIFIED",
+        }
+    tmp = destination.with_name(destination.name + f".tmp-{os.getpid()}")
+    try:
+        shutil.copyfile(source, tmp)
+        os.chmod(tmp, 0o600)
+        if sha256_file(tmp) != expected_sha256:
+            raise ContinuityError("replica copy digest mismatch")
+        os.replace(tmp, destination)
+    finally:
+        tmp.unlink(missing_ok=True)
+    return {
+        "path": str(destination),
+        "sha256": expected_sha256,
+        "size": destination.stat().st_size,
+        "status": "COPIED_VERIFIED",
+    }
+
+
+def replicate_protected_artifact(
+    artifact: Path,
+    destinations: list[tuple[str, Path]],
+    receipt_path: Path,
+    artifact_kind: str = "encrypted-continuity-artifact",
+) -> dict:
+    assert_independent_declared_destinations(destinations)
+    artifact = artifact.expanduser().resolve()
+    if not artifact.is_file() or artifact.is_symlink():
+        raise ContinuityError(f"protected artifact missing/unsafe: {artifact}")
+    digest = sha256_file(artifact)
+    replicas = []
+    for domain_id, root in destinations:
+        target = root / digest[:16] / artifact.name
+        result = atomic_copy_verified(artifact, target, digest)
+        replicas.append({"failure_domain": domain_id, **result})
+    receipt = {
+        "schema": REPLICA_RECEIPT_SCHEMA,
+        "system_name": "新RTS（仮称）",
+        "kind": artifact_kind,
+        "created_at": now_utc(),
+        "artifact": {
+            "name": artifact.name,
+            "sha256": digest,
+            "size": artifact.stat().st_size,
+        },
+        "replicas": replicas,
+        "independence_claim": (
+            "declared logical failure domains with non-overlapping local reference paths; "
+            "physical/provider independence requires external evidence"
+        ),
+    }
+    write_json(receipt_path.expanduser().resolve(), receipt)
+    return receipt
+
+
+def recover_replica(
+    receipt_path: Path,
+    failure_domain: str,
+    output: Path,
+) -> dict:
+    try:
+        receipt = json.loads(receipt_path.expanduser().resolve().read_text("utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ContinuityError("replica receipt unreadable/invalid") from exc
+    if receipt.get("schema") != REPLICA_RECEIPT_SCHEMA:
+        raise ContinuityError("replica receipt schema mismatch")
+    artifact = receipt.get("artifact")
+    if not isinstance(artifact, dict):
+        raise ContinuityError("replica receipt artifact record missing")
+    expected_sha = str(artifact.get("sha256", ""))
+    if len(expected_sha) != 64:
+        raise ContinuityError("replica receipt digest invalid")
+    replicas = receipt.get("replicas")
+    if not isinstance(replicas, list):
+        raise ContinuityError("replica receipt list missing")
+    matches = [item for item in replicas if isinstance(item, dict) and item.get("failure_domain") == failure_domain]
+    if len(matches) != 1:
+        raise ContinuityError(f"failure domain not uniquely recorded: {failure_domain}")
+    source = Path(str(matches[0].get("path", ""))).expanduser().resolve()
+    if not source.is_file() or source.is_symlink():
+        raise ContinuityError(f"replica unavailable/unsafe in domain {failure_domain}")
+    if sha256_file(source) != expected_sha:
+        raise ContinuityError(f"replica corruption detected in domain {failure_domain}")
+    output = output.expanduser().resolve()
+    result = atomic_copy_verified(source, output, expected_sha)
+    return {
+        "status": "PASS",
+        "failure_domain": failure_domain,
+        "artifact_sha256": expected_sha,
+        "output": result["path"],
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="新RTS（仮称） continuity/recovery core")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    capture = sub.add_parser("capture")
+    capture.add_argument("--repo", required=True)
+    capture.add_argument("--output", required=True)
+    capture.add_argument("--platform-export")
+    capture.add_argument("--require-platform-export", action="store_true")
+    capture.add_argument("--required-platform-scope", action="append", default=[])
+
+    verify = sub.add_parser("verify")
+    verify.add_argument("--capsule", required=True)
+
+    drill = sub.add_parser("drill")
+    drill.add_argument("--capsule", required=True)
+    drill.add_argument("--restore-root", required=True)
+    drill.add_argument("--receipt")
+
+    replicate = sub.add_parser("replicate")
+    replicate.add_argument("--artifact", required=True)
+    replicate.add_argument("--destination", action="append", required=True, help="DOMAIN_ID=PATH")
+    replicate.add_argument("--receipt", required=True)
+
+    recover = sub.add_parser("recover-replica")
+    recover.add_argument("--receipt", required=True)
+    recover.add_argument("--failure-domain", required=True)
+    recover.add_argument("--output", required=True)
+
+    goal = sub.add_parser("goal")
+    goal.add_argument("--repo", required=True)
+    goal.add_argument("--output", required=True)
+    goal.add_argument("--restore-root", required=True)
+    goal.add_argument("--platform-export")
+    goal.add_argument("--require-platform-export", action="store_true")
+    goal.add_argument("--required-platform-scope", action="append", default=[])
+    goal.add_argument("--receipt")
+
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    try:
+        if args.command == "capture":
+            result = capture_repo(
+                Path(args.repo),
+                Path(args.output),
+                Path(args.platform_export) if args.platform_export else None,
+                set(args.required_platform_scope),
+                args.require_platform_export,
+            )
+        elif args.command == "verify":
+            result = verify_capsule(Path(args.capsule))
+        elif args.command == "drill":
+            result = drill_capsule(
+                Path(args.capsule),
+                Path(args.restore_root),
+                Path(args.receipt) if args.receipt else None,
+            )
+        elif args.command == "replicate":
+            result = replicate_protected_artifact(
+                Path(args.artifact),
+                [parse_destination(spec) for spec in args.destination],
+                Path(args.receipt),
+            )
+        elif args.command == "recover-replica":
+            result = recover_replica(
+                Path(args.receipt),
+                args.failure_domain,
+                Path(args.output),
+            )
+        elif args.command == "goal":
+            capture = capture_repo(
+                Path(args.repo),
+                Path(args.output),
+                Path(args.platform_export) if args.platform_export else None,
+                set(args.required_platform_scope),
+                args.require_platform_export,
+            )
+            drill = drill_capsule(
+                Path(args.output),
+                Path(args.restore_root),
+                Path(args.receipt) if args.receipt else None,
+            )
+            result = {
+                "goal": "CORE_CONTINUITY_DRILL_PASS",
+                "capture": capture,
+                "drill": drill,
+                "next_gate": "encrypt then replicate protected artifact across independent failure domains",
+            }
+        else:
+            raise ContinuityError("unsupported command")
+        print(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True))
+        return 0
+    except ContinuityError as exc:
+        print(json.dumps({"goal": "ERROR", "error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/thin-rts/continuity/test_continuity.py
+++ b/thin-rts/continuity/test_continuity.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+import continuity
+
+
+class ContinuityTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def run(self, *args, cwd: Path | None = None, check: bool = True):  # type: ignore[override]
+        cp = subprocess.run(
+            list(args),
+            cwd=str(cwd) if cwd else None,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+        if check and cp.returncode != 0:
+            raise AssertionError(f"command failed: {args}\n{cp.stdout}\n{cp.stderr}")
+        return cp
+
+    def make_repo(self, name: str = "repo") -> Path:
+        repo = self.root / name
+        self.run("git", "init", str(repo))
+        self.run("git", "-C", str(repo), "config", "user.email", "test@example.invalid")
+        self.run("git", "-C", str(repo), "config", "user.name", "Continuity Test")
+        (repo / "alpha.txt").write_text("alpha\n", encoding="utf-8")
+        self.run("git", "-C", str(repo), "add", "alpha.txt")
+        self.run("git", "-C", str(repo), "commit", "-m", "alpha")
+        self.run("git", "-C", str(repo), "tag", "v0")
+        self.run("git", "-C", str(repo), "branch", "recovery-test")
+        return repo
+
+    def make_platform_export(self, *, secret_values_excluded: bool = True, scope=None) -> Path:
+        root = self.root / "platform"
+        root.mkdir()
+        scope = scope or ["issues", "pull_requests", "repository_rules"]
+        attestation = {
+            "schema": continuity.PLATFORM_ATTESTATION_SCHEMA,
+            "producer_id": "fixture:github-export-v0",
+            "captured_at": "2026-08-13T00:00:00Z",
+            "secret_values_excluded": secret_values_excluded,
+            "scope": scope,
+        }
+        (root / "EXPORT_ATTESTATION.json").write_text(
+            json.dumps(attestation), encoding="utf-8"
+        )
+        (root / "issues.json").write_text("[]\n", encoding="utf-8")
+        (root / "pulls.json").write_text("[]\n", encoding="utf-8")
+        (root / "rules.json").write_text("{}\n", encoding="utf-8")
+        return root
+
+    def capture(self, repo: Path, *, platform: bool = False) -> Path:
+        capsule = self.root / f"capsule-{repo.name}"
+        export = self.make_platform_export() if platform else None
+        continuity.capture_repo(
+            repo,
+            capsule,
+            export,
+            {"issues", "pull_requests", "repository_rules"} if platform else set(),
+            platform,
+        )
+        return capsule
+
+    def test_clean_capture_and_fresh_drill_preserve_refs(self) -> None:
+        repo = self.make_repo()
+        capsule = self.capture(repo, platform=True)
+        verified = continuity.verify_capsule(capsule)
+        self.assertEqual(verified["status"], "PASS")
+        restored = continuity.drill_capsule(capsule, self.root / "restore")
+        self.assertEqual(restored["status"], "PASS")
+        self.assertEqual(restored["platform_export"], "PASS")
+        self.assertEqual(restored["code_execution"], "NOT_PERFORMED")
+
+    def test_dirty_tree_is_rejected(self) -> None:
+        repo = self.make_repo()
+        (repo / "uncommitted.txt").write_text("lost if ignored\n", encoding="utf-8")
+        with self.assertRaisesRegex(continuity.ContinuityError, "dirty/untracked"):
+            continuity.capture_repo(repo, self.root / "capsule")
+
+    def test_shallow_clone_is_rejected(self) -> None:
+        source = self.make_repo("source")
+        (source / "beta.txt").write_text("beta\n", encoding="utf-8")
+        self.run("git", "-C", str(source), "add", "beta.txt")
+        self.run("git", "-C", str(source), "commit", "-m", "beta")
+        shallow = self.root / "shallow"
+        self.run("git", "clone", "--depth", "1", source.as_uri(), str(shallow))
+        with self.assertRaisesRegex(continuity.ContinuityError, "shallow"):
+            continuity.capture_repo(shallow, self.root / "capsule")
+
+    def test_submodule_marker_is_rejected(self) -> None:
+        repo = self.make_repo()
+        (repo / ".gitmodules").write_text(
+            '[submodule "x"]\n\tpath = x\n\turl = https://example.invalid/x.git\n',
+            encoding="utf-8",
+        )
+        self.run("git", "-C", str(repo), "add", ".gitmodules")
+        self.run("git", "-C", str(repo), "commit", "-m", "submodule marker")
+        with self.assertRaisesRegex(continuity.ContinuityError, "submodules"):
+            continuity.capture_repo(repo, self.root / "capsule")
+
+    def test_lfs_pointer_policy_is_rejected(self) -> None:
+        repo = self.make_repo()
+        (repo / ".gitattributes").write_text("*.bin filter=lfs diff=lfs merge=lfs -text\n")
+        self.run("git", "-C", str(repo), "add", ".gitattributes")
+        self.run("git", "-C", str(repo), "commit", "-m", "lfs marker")
+        with self.assertRaisesRegex(continuity.ContinuityError, "Git LFS"):
+            continuity.capture_repo(repo, self.root / "capsule")
+
+    def test_required_platform_export_missing_is_rejected(self) -> None:
+        repo = self.make_repo()
+        with self.assertRaisesRegex(continuity.ContinuityError, "required"):
+            continuity.capture_repo(
+                repo,
+                self.root / "capsule",
+                require_platform_export=True,
+            )
+
+    def test_platform_export_must_attest_no_secret_values(self) -> None:
+        repo = self.make_repo()
+        export = self.make_platform_export(secret_values_excluded=False)
+        with self.assertRaisesRegex(continuity.ContinuityError, "secret values"):
+            continuity.capture_repo(repo, self.root / "capsule", export)
+
+    def test_platform_export_required_scope_is_fail_closed(self) -> None:
+        repo = self.make_repo()
+        export = self.make_platform_export(scope=["issues"])
+        with self.assertRaisesRegex(continuity.ContinuityError, "missing required scope"):
+            continuity.capture_repo(
+                repo,
+                self.root / "capsule",
+                export,
+                {"issues", "pull_requests"},
+                True,
+            )
+
+    def test_bundle_tamper_is_detected(self) -> None:
+        repo = self.make_repo()
+        capsule = self.capture(repo)
+        bundle = capsule / "repository.bundle"
+        data = bytearray(bundle.read_bytes())
+        data[len(data) // 2] ^= 0x01
+        bundle.write_bytes(data)
+        with self.assertRaises(continuity.ContinuityError):
+            continuity.verify_capsule(capsule)
+
+    def test_manifest_ref_tamper_is_detected(self) -> None:
+        repo = self.make_repo()
+        capsule = self.capture(repo)
+        manifest_path = capsule / continuity.MANIFEST_NAME
+        manifest = json.loads(manifest_path.read_text("utf-8"))
+        first_ref = next(iter(manifest["source"]["refs"]))
+        manifest["source"]["refs"][first_ref] = "0" * 40
+        manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+        with self.assertRaisesRegex(continuity.ContinuityError, "refs"):
+            continuity.verify_capsule(capsule)
+
+    def test_platform_export_archive_tamper_is_detected(self) -> None:
+        repo = self.make_repo()
+        capsule = self.capture(repo, platform=True)
+        archive = capsule / "platform-export.tar.gz"
+        archive.write_bytes(archive.read_bytes() + b"tamper")
+        with self.assertRaisesRegex(continuity.ContinuityError, "digest"):
+            continuity.verify_capsule(capsule)
+
+    def test_restore_root_must_be_empty(self) -> None:
+        repo = self.make_repo()
+        capsule = self.capture(repo)
+        restore = self.root / "restore"
+        restore.mkdir()
+        (restore / "stale.txt").write_text("stale\n")
+        with self.assertRaisesRegex(continuity.ContinuityError, "empty"):
+            continuity.drill_capsule(capsule, restore)
+
+    def test_replication_requires_two_domains(self) -> None:
+        artifact = self.root / "opaque.gpg"
+        artifact.write_bytes(b"ciphertext")
+        with self.assertRaisesRegex(continuity.ContinuityError, "at least two"):
+            continuity.replicate_protected_artifact(
+                artifact,
+                [("domain-a", self.root / "a")],
+                self.root / "receipt.json",
+            )
+
+    def test_replication_rejects_duplicate_or_nested_domains(self) -> None:
+        artifact = self.root / "opaque.gpg"
+        artifact.write_bytes(b"ciphertext")
+        with self.assertRaisesRegex(continuity.ContinuityError, "duplicate failure-domain"):
+            continuity.replicate_protected_artifact(
+                artifact,
+                [("same", self.root / "a"), ("same", self.root / "b")],
+                self.root / "receipt.json",
+            )
+        with self.assertRaisesRegex(continuity.ContinuityError, "nested"):
+            continuity.replicate_protected_artifact(
+                artifact,
+                [("a", self.root / "r"), ("b", self.root / "r" / "child")],
+                self.root / "receipt2.json",
+            )
+
+    def test_second_domain_survives_first_domain_loss(self) -> None:
+        artifact = self.root / "opaque.gpg"
+        artifact.write_bytes(b"ciphertext-v1")
+        receipt_path = self.root / "receipt.json"
+        receipt = continuity.replicate_protected_artifact(
+            artifact,
+            [("domain-a", self.root / "a"), ("domain-b", self.root / "b")],
+            receipt_path,
+        )
+        shutil.rmtree(self.root / "a")
+        recovered = self.root / "recovered.gpg"
+        result = continuity.recover_replica(receipt_path, "domain-b", recovered)
+        self.assertEqual(result["status"], "PASS")
+        self.assertEqual(recovered.read_bytes(), b"ciphertext-v1")
+        self.assertEqual(result["artifact_sha256"], receipt["artifact"]["sha256"])
+
+    def test_corrupt_replica_is_detected_without_poisoning_other_domain(self) -> None:
+        artifact = self.root / "opaque.gpg"
+        artifact.write_bytes(b"ciphertext-v1")
+        receipt_path = self.root / "receipt.json"
+        receipt = continuity.replicate_protected_artifact(
+            artifact,
+            [("domain-a", self.root / "a"), ("domain-b", self.root / "b")],
+            receipt_path,
+        )
+        domain_a_path = Path(receipt["replicas"][0]["path"])
+        domain_a_path.write_bytes(b"corrupt")
+        with self.assertRaisesRegex(continuity.ContinuityError, "corruption"):
+            continuity.recover_replica(receipt_path, "domain-a", self.root / "bad.gpg")
+        good = continuity.recover_replica(receipt_path, "domain-b", self.root / "good.gpg")
+        self.assertEqual(good["status"], "PASS")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/thin-rts/continuity/test_continuity.py
+++ b/thin-rts/continuity/test_continuity.py
@@ -18,14 +18,9 @@ class ContinuityTests(unittest.TestCase):
     def tearDown(self) -> None:
         self.tmp.cleanup()
 
-    def run(self, *args, cwd: Path | None = None, check: bool = True):  # type: ignore[override]
+    def run_cmd(self, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
         cp = subprocess.run(
-            list(args),
-            cwd=str(cwd) if cwd else None,
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            check=False,
+            list(args), text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False
         )
         if check and cp.returncode != 0:
             raise AssertionError(f"command failed: {args}\n{cp.stdout}\n{cp.stderr}")
@@ -33,36 +28,33 @@ class ContinuityTests(unittest.TestCase):
 
     def make_repo(self, name: str = "repo") -> Path:
         repo = self.root / name
-        self.run("git", "init", str(repo))
-        self.run("git", "-C", str(repo), "config", "user.email", "test@example.invalid")
-        self.run("git", "-C", str(repo), "config", "user.name", "Continuity Test")
+        self.run_cmd("git", "init", str(repo))
+        self.run_cmd("git", "-C", str(repo), "config", "user.email", "test@example.invalid")
+        self.run_cmd("git", "-C", str(repo), "config", "user.name", "Continuity Test")
         (repo / "alpha.txt").write_text("alpha\n", encoding="utf-8")
-        self.run("git", "-C", str(repo), "add", "alpha.txt")
-        self.run("git", "-C", str(repo), "commit", "-m", "alpha")
-        self.run("git", "-C", str(repo), "tag", "v0")
-        self.run("git", "-C", str(repo), "branch", "recovery-test")
+        self.run_cmd("git", "-C", str(repo), "add", "alpha.txt")
+        self.run_cmd("git", "-C", str(repo), "commit", "-m", "alpha")
+        self.run_cmd("git", "-C", str(repo), "tag", "v0")
+        self.run_cmd("git", "-C", str(repo), "branch", "recovery-test")
         return repo
 
-    def make_platform_export(self, *, secret_values_excluded: bool = True, scope=None) -> Path:
+    def make_platform_export(self, *, secret_ok: bool = True, scope=None) -> Path:
         root = self.root / "platform"
         root.mkdir()
-        scope = scope or ["issues", "pull_requests", "repository_rules"]
-        attestation = {
+        payload = {
             "schema": continuity.PLATFORM_ATTESTATION_SCHEMA,
-            "producer_id": "fixture:github-export-v0",
+            "producer_id": "fixture:provider-export-v0",
             "captured_at": "2026-08-13T00:00:00Z",
-            "secret_values_excluded": secret_values_excluded,
-            "scope": scope,
+            "secret_values_excluded": secret_ok,
+            "scope": scope or ["issues", "pull_requests", "repository_rules"],
         }
-        (root / "EXPORT_ATTESTATION.json").write_text(
-            json.dumps(attestation), encoding="utf-8"
-        )
+        (root / "EXPORT_ATTESTATION.json").write_text(json.dumps(payload), encoding="utf-8")
         (root / "issues.json").write_text("[]\n", encoding="utf-8")
         (root / "pulls.json").write_text("[]\n", encoding="utf-8")
         (root / "rules.json").write_text("{}\n", encoding="utf-8")
         return root
 
-    def capture(self, repo: Path, *, platform: bool = False) -> Path:
+    def capture(self, repo: Path, platform: bool = False) -> Path:
         capsule = self.root / f"capsule-{repo.name}"
         export = self.make_platform_export() if platform else None
         continuity.capture_repo(
@@ -77,105 +69,92 @@ class ContinuityTests(unittest.TestCase):
     def test_clean_capture_and_fresh_drill_preserve_refs(self) -> None:
         repo = self.make_repo()
         capsule = self.capture(repo, platform=True)
-        verified = continuity.verify_capsule(capsule)
-        self.assertEqual(verified["status"], "PASS")
-        restored = continuity.drill_capsule(capsule, self.root / "restore")
-        self.assertEqual(restored["status"], "PASS")
-        self.assertEqual(restored["platform_export"], "PASS")
-        self.assertEqual(restored["code_execution"], "NOT_PERFORMED")
+        self.assertEqual(continuity.verify_capsule(capsule)["status"], "PASS")
+        drill = continuity.drill_capsule(capsule, self.root / "restore")
+        self.assertEqual(drill["status"], "PASS")
+        self.assertEqual(drill["platform_export"], "PASS")
+        self.assertEqual(drill["code_execution"], "NOT_PERFORMED")
 
     def test_dirty_tree_is_rejected(self) -> None:
         repo = self.make_repo()
-        (repo / "uncommitted.txt").write_text("lost if ignored\n", encoding="utf-8")
+        (repo / "uncommitted.txt").write_text("would be lost\n", encoding="utf-8")
         with self.assertRaisesRegex(continuity.ContinuityError, "dirty/untracked"):
             continuity.capture_repo(repo, self.root / "capsule")
 
     def test_shallow_clone_is_rejected(self) -> None:
         source = self.make_repo("source")
         (source / "beta.txt").write_text("beta\n", encoding="utf-8")
-        self.run("git", "-C", str(source), "add", "beta.txt")
-        self.run("git", "-C", str(source), "commit", "-m", "beta")
+        self.run_cmd("git", "-C", str(source), "add", "beta.txt")
+        self.run_cmd("git", "-C", str(source), "commit", "-m", "beta")
         shallow = self.root / "shallow"
-        self.run("git", "clone", "--depth", "1", source.as_uri(), str(shallow))
+        self.run_cmd("git", "clone", "--depth", "1", source.as_uri(), str(shallow))
         with self.assertRaisesRegex(continuity.ContinuityError, "shallow"):
             continuity.capture_repo(shallow, self.root / "capsule")
 
-    def test_submodule_marker_is_rejected(self) -> None:
-        repo = self.make_repo()
-        (repo / ".gitmodules").write_text(
-            '[submodule "x"]\n\tpath = x\n\turl = https://example.invalid/x.git\n',
-            encoding="utf-8",
-        )
-        self.run("git", "-C", str(repo), "add", ".gitmodules")
-        self.run("git", "-C", str(repo), "commit", "-m", "submodule marker")
+    def test_submodule_and_lfs_partial_custody_are_rejected(self) -> None:
+        repo = self.make_repo("submodule")
+        (repo / ".gitmodules").write_text('[submodule "x"]\n\tpath=x\n\turl=https://example.invalid/x\n')
+        self.run_cmd("git", "-C", str(repo), "add", ".gitmodules")
+        self.run_cmd("git", "-C", str(repo), "commit", "-m", "submodule")
         with self.assertRaisesRegex(continuity.ContinuityError, "submodules"):
-            continuity.capture_repo(repo, self.root / "capsule")
+            continuity.capture_repo(repo, self.root / "capsule-submodule")
 
-    def test_lfs_pointer_policy_is_rejected(self) -> None:
-        repo = self.make_repo()
-        (repo / ".gitattributes").write_text("*.bin filter=lfs diff=lfs merge=lfs -text\n")
-        self.run("git", "-C", str(repo), "add", ".gitattributes")
-        self.run("git", "-C", str(repo), "commit", "-m", "lfs marker")
+        repo2 = self.make_repo("lfs")
+        (repo2 / ".gitattributes").write_text("*.bin filter=lfs diff=lfs merge=lfs -text\n")
+        self.run_cmd("git", "-C", str(repo2), "add", ".gitattributes")
+        self.run_cmd("git", "-C", str(repo2), "commit", "-m", "lfs")
         with self.assertRaisesRegex(continuity.ContinuityError, "Git LFS"):
-            continuity.capture_repo(repo, self.root / "capsule")
+            continuity.capture_repo(repo2, self.root / "capsule-lfs")
 
-    def test_required_platform_export_missing_is_rejected(self) -> None:
+    def test_platform_export_is_explicit_fail_closed_scope(self) -> None:
         repo = self.make_repo()
         with self.assertRaisesRegex(continuity.ContinuityError, "required"):
-            continuity.capture_repo(
-                repo,
-                self.root / "capsule",
-                require_platform_export=True,
-            )
+            continuity.capture_repo(repo, self.root / "missing", require_platform_export=True)
 
-    def test_platform_export_must_attest_no_secret_values(self) -> None:
-        repo = self.make_repo()
-        export = self.make_platform_export(secret_values_excluded=False)
+        bad_secret = self.make_platform_export(secret_ok=False)
         with self.assertRaisesRegex(continuity.ContinuityError, "secret values"):
-            continuity.capture_repo(repo, self.root / "capsule", export)
+            continuity.capture_repo(repo, self.root / "bad-secret", bad_secret)
 
-    def test_platform_export_required_scope_is_fail_closed(self) -> None:
+    def test_platform_scope_gap_is_rejected(self) -> None:
         repo = self.make_repo()
         export = self.make_platform_export(scope=["issues"])
         with self.assertRaisesRegex(continuity.ContinuityError, "missing required scope"):
             continuity.capture_repo(
                 repo,
-                self.root / "capsule",
+                self.root / "scope-gap",
                 export,
                 {"issues", "pull_requests"},
                 True,
             )
 
-    def test_bundle_tamper_is_detected(self) -> None:
-        repo = self.make_repo()
+    def test_bundle_manifest_and_platform_tamper_are_detected(self) -> None:
+        repo = self.make_repo("bundle")
         capsule = self.capture(repo)
         bundle = capsule / "repository.bundle"
         data = bytearray(bundle.read_bytes())
-        data[len(data) // 2] ^= 0x01
+        data[len(data) // 2] ^= 1
         bundle.write_bytes(data)
         with self.assertRaises(continuity.ContinuityError):
             continuity.verify_capsule(capsule)
 
-    def test_manifest_ref_tamper_is_detected(self) -> None:
-        repo = self.make_repo()
-        capsule = self.capture(repo)
-        manifest_path = capsule / continuity.MANIFEST_NAME
+        repo2 = self.make_repo("manifest")
+        capsule2 = self.capture(repo2)
+        manifest_path = capsule2 / continuity.MANIFEST_NAME
         manifest = json.loads(manifest_path.read_text("utf-8"))
         first_ref = next(iter(manifest["source"]["refs"]))
         manifest["source"]["refs"][first_ref] = "0" * 40
         manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
         with self.assertRaisesRegex(continuity.ContinuityError, "refs"):
-            continuity.verify_capsule(capsule)
+            continuity.verify_capsule(capsule2)
 
-    def test_platform_export_archive_tamper_is_detected(self) -> None:
-        repo = self.make_repo()
-        capsule = self.capture(repo, platform=True)
-        archive = capsule / "platform-export.tar.gz"
+        repo3 = self.make_repo("platform-tamper")
+        capsule3 = self.capture(repo3, platform=True)
+        archive = capsule3 / "platform-export.tar.gz"
         archive.write_bytes(archive.read_bytes() + b"tamper")
         with self.assertRaisesRegex(continuity.ContinuityError, "digest"):
-            continuity.verify_capsule(capsule)
+            continuity.verify_capsule(capsule3)
 
-    def test_restore_root_must_be_empty(self) -> None:
+    def test_stale_restore_directory_is_rejected(self) -> None:
         repo = self.make_repo()
         capsule = self.capture(repo)
         restore = self.root / "restore"
@@ -184,63 +163,47 @@ class ContinuityTests(unittest.TestCase):
         with self.assertRaisesRegex(continuity.ContinuityError, "empty"):
             continuity.drill_capsule(capsule, restore)
 
-    def test_replication_requires_two_domains(self) -> None:
+    def test_replica_domains_must_be_distinct_and_non_overlapping(self) -> None:
         artifact = self.root / "opaque.gpg"
         artifact.write_bytes(b"ciphertext")
         with self.assertRaisesRegex(continuity.ContinuityError, "at least two"):
             continuity.replicate_protected_artifact(
-                artifact,
-                [("domain-a", self.root / "a")],
-                self.root / "receipt.json",
+                artifact, [("a", self.root / "a")], self.root / "r1.json"
             )
-
-    def test_replication_rejects_duplicate_or_nested_domains(self) -> None:
-        artifact = self.root / "opaque.gpg"
-        artifact.write_bytes(b"ciphertext")
         with self.assertRaisesRegex(continuity.ContinuityError, "duplicate failure-domain"):
             continuity.replicate_protected_artifact(
                 artifact,
                 [("same", self.root / "a"), ("same", self.root / "b")],
-                self.root / "receipt.json",
+                self.root / "r2.json",
             )
         with self.assertRaisesRegex(continuity.ContinuityError, "nested"):
             continuity.replicate_protected_artifact(
                 artifact,
-                [("a", self.root / "r"), ("b", self.root / "r" / "child")],
-                self.root / "receipt2.json",
+                [("a", self.root / "root"), ("b", self.root / "root" / "child")],
+                self.root / "r3.json",
             )
 
-    def test_second_domain_survives_first_domain_loss(self) -> None:
+    def test_alternate_domain_survives_loss_and_corruption(self) -> None:
         artifact = self.root / "opaque.gpg"
         artifact.write_bytes(b"ciphertext-v1")
-        receipt_path = self.root / "receipt.json"
+        receipt_path = self.root / "replicas.json"
         receipt = continuity.replicate_protected_artifact(
             artifact,
             [("domain-a", self.root / "a"), ("domain-b", self.root / "b")],
             receipt_path,
         )
-        shutil.rmtree(self.root / "a")
-        recovered = self.root / "recovered.gpg"
-        result = continuity.recover_replica(receipt_path, "domain-b", recovered)
-        self.assertEqual(result["status"], "PASS")
-        self.assertEqual(recovered.read_bytes(), b"ciphertext-v1")
-        self.assertEqual(result["artifact_sha256"], receipt["artifact"]["sha256"])
 
-    def test_corrupt_replica_is_detected_without_poisoning_other_domain(self) -> None:
-        artifact = self.root / "opaque.gpg"
-        artifact.write_bytes(b"ciphertext-v1")
-        receipt_path = self.root / "receipt.json"
-        receipt = continuity.replicate_protected_artifact(
-            artifact,
-            [("domain-a", self.root / "a"), ("domain-b", self.root / "b")],
-            receipt_path,
-        )
-        domain_a_path = Path(receipt["replicas"][0]["path"])
-        domain_a_path.write_bytes(b"corrupt")
+        # Corrupt A: recovery must stop on A, not silently accept it.
+        Path(receipt["replicas"][0]["path"]).write_bytes(b"corrupt")
         with self.assertRaisesRegex(continuity.ContinuityError, "corruption"):
             continuity.recover_replica(receipt_path, "domain-a", self.root / "bad.gpg")
+
+        # B still recovers. Then model total loss of A.
         good = continuity.recover_replica(receipt_path, "domain-b", self.root / "good.gpg")
         self.assertEqual(good["status"], "PASS")
+        shutil.rmtree(self.root / "a")
+        good2 = continuity.recover_replica(receipt_path, "domain-b", self.root / "good2.gpg")
+        self.assertEqual(good2["status"], "PASS")
 
 
 if __name__ == "__main__":

--- a/thin-rts/continuity/test_continuity_custody_integration.py
+++ b/thin-rts/continuity/test_continuity_custody_integration.py
@@ -97,9 +97,9 @@ class ContinuityCustodyIntegrationTests(unittest.TestCase):
         ).stdout
         return home, fpr, public
 
-    def import_public(self, producer: Path, public: bytes) -> None:
+    def import_trusted_public(self, producer: Path, fingerprint: str, public: bytes) -> None:
         env = self.gpg_env(producer)
-        cp = subprocess.run(
+        imported = subprocess.run(
             ["gpg", "--batch", "--import"],
             input=public,
             stdout=subprocess.PIPE,
@@ -107,8 +107,22 @@ class ContinuityCustodyIntegrationTests(unittest.TestCase):
             check=False,
             env=env,
         )
-        if cp.returncode != 0:
-            raise AssertionError(cp.stderr.decode("utf-8", errors="replace"))
+        if imported.returncode != 0:
+            raise AssertionError(imported.stderr.decode("utf-8", errors="replace"))
+
+        # The custody contract binds recipients by full primary fingerprint. GPG still
+        # requires a local certification-trust decision before unattended encryption.
+        # Record that decision against the exact fingerprint; never trust by UID search.
+        trusted = subprocess.run(
+            ["gpg", "--batch", "--import-ownertrust"],
+            input=f"{fingerprint}:6:\n".encode("ascii"),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=env,
+        )
+        if trusted.returncode != 0:
+            raise AssertionError(trusted.stderr.decode("utf-8", errors="replace"))
 
     def test_real_gpg_two_recipient_encryption_survives_primary_domain_loss(self) -> None:
         if shutil.which("gpg") is None:
@@ -122,8 +136,8 @@ class ContinuityCustodyIntegrationTests(unittest.TestCase):
         home_a, fpr_a, pub_a = self.generate_recovery_identity("a")
         home_b, fpr_b, pub_b = self.generate_recovery_identity("b")
         producer = self.root / "gnupg-producer"
-        self.import_public(producer, pub_a)
-        self.import_public(producer, pub_b)
+        self.import_trusted_public(producer, fpr_a, pub_a)
+        self.import_trusted_public(producer, fpr_b, pub_b)
 
         os.environ["GNUPGHOME"] = str(producer)
         candidate = custody.build_local_candidate(
@@ -185,8 +199,8 @@ class ContinuityCustodyIntegrationTests(unittest.TestCase):
         _, fpr_b, pub_b = self.generate_recovery_identity("b")
         wrong_home, _, _ = self.generate_recovery_identity("wrong")
         producer = self.root / "gnupg-producer"
-        self.import_public(producer, pub_a)
-        self.import_public(producer, pub_b)
+        self.import_trusted_public(producer, fpr_a, pub_a)
+        self.import_trusted_public(producer, fpr_b, pub_b)
         os.environ["GNUPGHOME"] = str(producer)
         candidate = custody.build_local_candidate(
             capsule,

--- a/thin-rts/continuity/test_continuity_custody_integration.py
+++ b/thin-rts/continuity/test_continuity_custody_integration.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+HERE = Path(__file__).resolve().parent
+CLOUD = HERE.parent / "cloud-custody"
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(CLOUD))
+
+import continuity
+import custody
+
+
+class ContinuityCustodyIntegrationTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.original_gnupg = os.environ.get("GNUPGHOME")
+
+    def tearDown(self) -> None:
+        if self.original_gnupg is None:
+            os.environ.pop("GNUPGHOME", None)
+        else:
+            os.environ["GNUPGHOME"] = self.original_gnupg
+        self.tmp.cleanup()
+
+    def run_cmd(self, *args: str, env=None, check=True) -> subprocess.CompletedProcess[str]:
+        cp = subprocess.run(
+            list(args),
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=env,
+        )
+        if check and cp.returncode != 0:
+            raise AssertionError(f"command failed: {args}\n{cp.stdout}\n{cp.stderr}")
+        return cp
+
+    def make_repo(self) -> Path:
+        repo = self.root / "repo"
+        self.run_cmd("git", "init", str(repo))
+        self.run_cmd("git", "-C", str(repo), "config", "user.email", "test@example.invalid")
+        self.run_cmd("git", "-C", str(repo), "config", "user.name", "Recovery Integration")
+        (repo / "critical.txt").write_text("critical-state\n", encoding="utf-8")
+        self.run_cmd("git", "-C", str(repo), "add", "critical.txt")
+        self.run_cmd("git", "-C", str(repo), "commit", "-m", "critical state")
+        self.run_cmd("git", "-C", str(repo), "tag", "continuity-test")
+        return repo
+
+    def gpg_env(self, home: Path) -> dict[str, str]:
+        home.mkdir(parents=True, exist_ok=True)
+        os.chmod(home, 0o700)
+        env = os.environ.copy()
+        env["GNUPGHOME"] = str(home)
+        return env
+
+    def generate_recovery_identity(self, name: str) -> tuple[Path, str, bytes]:
+        home = self.root / f"gnupg-{name}"
+        env = self.gpg_env(home)
+        uid = f"Recovery {name} <{name}@example.invalid>"
+        self.run_cmd(
+            "gpg", "--batch", "--passphrase", "", "--quick-gen-key",
+            uid, "rsa2048", "cert", "1d", env=env,
+        )
+        listing = self.run_cmd(
+            "gpg", "--batch", "--with-colons", "--fingerprint", "--list-keys", uid,
+            env=env,
+        ).stdout
+        fpr = None
+        saw_pub = False
+        for line in listing.splitlines():
+            parts = line.split(":")
+            if parts[0] == "pub":
+                saw_pub = True
+            elif saw_pub and parts[0] == "fpr" and len(parts) > 9 and parts[9]:
+                fpr = parts[9]
+                break
+        self.assertIsNotNone(fpr)
+        assert fpr is not None
+        self.run_cmd(
+            "gpg", "--batch", "--passphrase", "", "--quick-add-key",
+            fpr, "rsa2048", "encr", "1d", env=env,
+        )
+        public = subprocess.run(
+            ["gpg", "--batch", "--armor", "--export", fpr],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+            env=env,
+        ).stdout
+        return home, fpr, public
+
+    def import_public(self, producer: Path, public: bytes) -> None:
+        env = self.gpg_env(producer)
+        cp = subprocess.run(
+            ["gpg", "--batch", "--import"],
+            input=public,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            env=env,
+        )
+        if cp.returncode != 0:
+            raise AssertionError(cp.stderr.decode("utf-8", errors="replace"))
+
+    def test_real_gpg_two_recipient_encryption_survives_primary_domain_loss(self) -> None:
+        if shutil.which("gpg") is None:
+            self.fail("gpg is required external continuity dependency for this integration")
+
+        repo = self.make_repo()
+        capsule = self.root / "capsule"
+        continuity.capture_repo(repo, capsule)
+        self.assertEqual(continuity.verify_capsule(capsule)["status"], "PASS")
+
+        home_a, fpr_a, pub_a = self.generate_recovery_identity("a")
+        home_b, fpr_b, pub_b = self.generate_recovery_identity("b")
+        producer = self.root / "gnupg-producer"
+        self.import_public(producer, pub_a)
+        self.import_public(producer, pub_b)
+
+        os.environ["GNUPGHOME"] = str(producer)
+        candidate = custody.build_local_candidate(
+            capsule,
+            self.root / "custody-work",
+            [fpr_a, fpr_b],
+            "continuity-test-epoch",
+        )
+        ciphertext = Path(candidate["ciphertext"]["path"])
+        self.assertTrue(ciphertext.is_file())
+
+        replica_receipt = self.root / "replicas.json"
+        continuity.replicate_protected_artifact(
+            ciphertext,
+            [
+                ("primary-domain", self.root / "primary-domain"),
+                ("alternate-domain", self.root / "alternate-domain"),
+            ],
+            replica_receipt,
+        )
+
+        # Meteor: primary storage disappears completely.
+        shutil.rmtree(self.root / "primary-domain")
+        recovered_ciphertext = self.root / "recovered.gpg"
+        recovered = continuity.recover_replica(
+            replica_receipt,
+            "alternate-domain",
+            recovered_ciphertext,
+        )
+        self.assertEqual(recovered["status"], "PASS")
+
+        # Fresh recovery trust boundary: only recovery identity B is available.
+        os.environ["GNUPGHOME"] = str(home_b)
+        recovered_archive = self.root / "recovered.tar.gz"
+        custody.decrypt_gpg(recovered_ciphertext, recovered_archive)
+        self.assertEqual(
+            custody.sha256_file(recovered_archive),
+            candidate["plaintext"]["sha256"],
+        )
+
+        restored_capsule = self.root / "restored-capsule"
+        custody.safe_extract_tar_gz(recovered_archive, restored_capsule)
+        verified_tree = custody.verify_extracted_tree(restored_capsule)
+        self.assertEqual(verified_tree["status"], "PASS")
+
+        final_restore = self.root / "final-restore"
+        drill = continuity.drill_capsule(restored_capsule, final_restore)
+        self.assertEqual(drill["status"], "PASS")
+        self.assertEqual(drill["code_execution"], "NOT_PERFORMED")
+
+    def test_wrong_recovery_identity_cannot_decrypt(self) -> None:
+        if shutil.which("gpg") is None:
+            self.fail("gpg is required external continuity dependency for this integration")
+
+        repo = self.make_repo()
+        capsule = self.root / "capsule"
+        continuity.capture_repo(repo, capsule)
+        _, fpr_a, pub_a = self.generate_recovery_identity("a")
+        _, fpr_b, pub_b = self.generate_recovery_identity("b")
+        wrong_home, _, _ = self.generate_recovery_identity("wrong")
+        producer = self.root / "gnupg-producer"
+        self.import_public(producer, pub_a)
+        self.import_public(producer, pub_b)
+        os.environ["GNUPGHOME"] = str(producer)
+        candidate = custody.build_local_candidate(
+            capsule,
+            self.root / "custody-work",
+            [fpr_a, fpr_b],
+            "continuity-test-epoch",
+        )
+        os.environ["GNUPGHOME"] = str(wrong_home)
+        with self.assertRaises(custody.CustodyError):
+            custody.decrypt_gpg(
+                Path(candidate["ciphertext"]["path"]),
+                self.root / "should-not-decrypt.tar.gz",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
`/goal` final adoption package for **新RTS（仮称） Continuity / Recovery v0**, composed from the existing encrypted Cloud Custody prototype and then attacked through METEOR.

## Surviving hard invariants
- Safety: tampered/incomplete recovery material must fail closed and restored project code is not executed during verification.
- Reproducibility: Tier-0 Git history/refs must reconstruct exactly.
- Recoverability: backup existence is not PASS; fresh reconstruction is required.
- Exitability: critical state must have provider-neutral form, not only provider-native custody.
- Failure-domain resilience: one failed/corrupt recovery path must not poison the other.

## What was deliberately cut
- custom cloud/source host/object store;
- custom cryptography/key vault;
- mandatory one-size-fits-all cadence/RPO/retention;
- mandatory preservation of Tier-1/Tier-2 state;
- pretending that two logical labels prove physical/provider independence.

## METEOR Round 1 deaths retained
- validator/build activity dirtied the source before live capture; repair was to capture the untouched repo first, not weaken dirty-tree rejection;
- GPG exact-fingerprint recipients lacked unattended local certification trust after public-key import; repair binds producer owner-trust to the exact selected full fingerprints while private recovery identities remain outside the producer;
- validator helper accidentally collided with `unittest.TestCase.run`; repaired and retained as validator-process regression.

## Final evidence
Final head: `b734854eeeffab6526edb6b4a3f8b3d3f069079f`.

- Continuity Recovery Candidate Tests run #12: SUCCESS
  - actual provider-neutral capture on untouched PR repo: SUCCESS
  - focused Continuity METEOR regressions: SUCCESS
  - real GPG alternate-domain recovery drill: SUCCESS
- Cloud Custody Candidate Tests run #33: SUCCESS
- Unicode Guard run #1088: SUCCESS
  - Unicode/quarantine/egress job: SUCCESS
  - independent pinned Semgrep challenger + positive attack-fixture self-test: SUCCESS

Observed material recovery evidence from Round 2:
- actual RTS Git bundle: 5,701,092 bytes;
- bundle SHA-256: `8efd6e01be3656034f9ee99a69344f1040f6f47201122b7ea91d373fa6dfad14`;
- captured/restored refs: 103;
- fresh mirror `git fsck`: PASS;
- restored project code execution: NOT_PERFORMED;
- wrong unrelated recovery identity: rejected as required.

## Strength classification
- Tier-0 Git reproducibility: `STRONG_UNDER_CURRENT_EVIDENCE`
- incomplete/tampered backup rejection: `STRONG_UNDER_CURRENT_EVIDENCE`
- encrypted alternate-domain failover semantics: `STRONG_UNDER_CURRENT_EVIDENCE`
- provider-neutral Git exitability: `STRONG_UNDER_CURRENT_EVIDENCE`
- provider-only metadata export: `CONTRACT_PROVEN / LIVE_ADAPTER_DEPLOYMENT_DEPENDENT`
- real physical/provider/geographic independence: `OPERATIONAL_EVIDENCE_REQUIRED`
- cadence/RPO/retention/offline-WORM: `SITUATIONAL_POLICY`

Final `/goal` verdict: **ADOPT** the contract, Tier policy, fresh-recovery proof rule, alternate-recovery semantics and all observed death causes into 新RTS（仮称）. Concrete Python/GnuPG/GCS/filesystem/provider-export adapters remain replaceable DARWIN occupants.