### PR TITLE
Define Ultimate Loop supersession rule

### DIFF
--- a/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
+++ b/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
@@ -28,11 +28,15 @@ A successor is not proven superior by novelty, naming, claimed intelligence, ben
 
 The successor does **not** need to copy ULTIMATE LOOP's names, internal loops, agents, tools, implementation, or structure. A radically different method is eligible. Structural similarity is not a survival criterion.
 
+The protected outcome and its material obligations may themselves be challenged or retired through explicit evidence and applicable authority, but a successor may not silently weaken or redefine them merely to appear superior.
+
 `DIFFERENT != INFERIOR`
 
 `NEW != SUPERIOR`
 
 `CLAIMED SUPERIORITY != PROVEN SUPERIORITY`
+
+`GOAL SHIFT != METHOD SUPERIORITY`
 
 ## Anti-self-preservation rule
 
@@ -49,6 +53,14 @@ Proof of a superior protocol ends ULTIMATE LOOP's claim to permanent or exclusiv
 However:
 
 `SUPERIORITY PROVEN != OPERATIONAL HANDOVER AUTHORIZED`
+
+The transition is explicitly two-stage:
+
+`SUPERIOR PROTOCOL PROVEN -> SUPERSEDED_PENDING_HANDOVER`
+
+`AUTHORITY + CONTINUITY PASS -> RETIRED / SUCCESSOR_CANONICAL`
+
+While `SUPERSEDED_PENDING_HANDOVER`, ULTIMATE LOOP may remain the bounded operational caretaker only to prevent a responsibility gap. It no longer has a permanent entitlement to remain canonical.
 
 Operational retirement and succession must remain fail-closed until the applicable authority and continuity obligations are satisfied. A successor may not erase the predecessor before the protected outcome, canonical evidence, known failure memory, authority boundaries and reconstruction path are safely inherited or intentionally dispositioned.
 

--- a/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
+++ b/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
@@ -1,13 +1,69 @@
 # ULTIMATE LOOP — Supersession Rule
 
-Status: `CANONICAL ADDENDUM`
+Status: `CANONICAL ADDENDUM / DA-HARDENED`
 
 ## Canonical termination rule
 
-**ULTIMATE LOOPの終了は、ULTIMATE LOOP自身を超える、さらに上位のループまたは新たなプロトコルが実証された瞬間をもって成立し、その時点でULTIMATE LOOPは役割を終え、後継へ継承される。**
+**ULTIMATE LOOPの終了条件は、ULTIMATE LOOP自身を超える、さらに上位のループまたは新たなプロトコルが実証された瞬間をもって成立する。ULTIMATE LOOP自身にも永久の生存権はなく、その役割はより優れた後継へ継承される。**
 
 Operational form:
 
 `ULTIMATE LOOP != IMMORTAL`
 
 `SUPERIOR PROTOCOL PROVEN -> ULTIMATE LOOP YIELDS`
+
+## What counts as PROVEN
+
+A successor is not proven superior by novelty, naming, claimed intelligence, benchmark score, popularity, provider authority, or self-declaration alone.
+
+`PROVEN` requires evidence that the challenger method can preserve or improve the protected human-important outcome across the material obligations inherited from ULTIMATE LOOP, including where applicable:
+
+- known failure / autopsy memory;
+- evidence and reproducibility requirements;
+- authority boundaries;
+- recovery and reconstruction capability;
+- provider / implementation replaceability;
+- real-world destructive cases and materially relevant workloads;
+- whole-life cost, operator burden, safety and resilience.
+
+The successor does **not** need to copy ULTIMATE LOOP's names, internal loops, agents, tools, implementation, or structure. A radically different method is eligible. Structural similarity is not a survival criterion.
+
+`DIFFERENT != INFERIOR`
+
+`NEW != SUPERIOR`
+
+`CLAIMED SUPERIORITY != PROVEN SUPERIORITY`
+
+## Anti-self-preservation rule
+
+ULTIMATE LOOP may not exempt itself from comparison or require a challenger to use ULTIMATE LOOP merely to be considered valid.
+
+Evidence for supersession may be produced by independent humans, tools, systems, protocols, experiments, or future mechanisms that do not exist today.
+
+The comparison target is the protected outcome and inherited material obligations, not loyalty to the current method.
+
+## Termination and handover semantics
+
+Proof of a superior protocol ends ULTIMATE LOOP's claim to permanent or exclusive canonical supremacy.
+
+However:
+
+`SUPERIORITY PROVEN != OPERATIONAL HANDOVER AUTHORIZED`
+
+Operational retirement and succession must remain fail-closed until the applicable authority and continuity obligations are satisfied. A successor may not erase the predecessor before the protected outcome, canonical evidence, known failure memory, authority boundaries and reconstruction path are safely inherited or intentionally dispositioned.
+
+This prevents a transition gap where the old method stops before the new method can safely carry the protected responsibility.
+
+## Lineage after supersession
+
+Supersession retires ULTIMATE LOOP as the canonical incumbent; it does not require destruction of its historical record.
+
+Its useful lineage, evidence, failures and reconstruction material remain available to the successor and to future challengers.
+
+If later evidence invalidates the successor, ULTIMATE LOOP may be reconsidered as a historical challenger like any other method. Neither incumbent nor successor receives permanent entitlement.
+
+`METHOD MAY YIELD`
+
+`LINEAGE MUST SURVIVE`
+
+`PROTECTED OUTCOME OUTRANKS METHOD IDENTITY`

--- a/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
+++ b/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
@@ -26,6 +26,12 @@ A successor is not proven superior by novelty, naming, claimed intelligence, ben
 - real-world destructive cases and materially relevant workloads;
 - whole-life cost, operator burden, safety and resilience.
 
+A successor must demonstrate at least one **material improvement** in the declared mission or materially broader capability. Merely matching ULTIMATE LOOP does not establish supersession.
+
+The comparison must retain inherited hard obligations, known death causes and frozen/material workloads where they remain applicable. A challenger may add stronger tests, but it may not obtain superiority by quietly removing the cases that previously killed weaker designs.
+
+Any material regression or tradeoff must be explicit, evidenced and accepted under the applicable authority; an unacknowledged regression cannot be hidden inside an aggregate score.
+
 The successor does **not** need to copy ULTIMATE LOOP's names, internal loops, agents, tools, implementation, or structure. A radically different method is eligible. Structural similarity is not a survival criterion.
 
 The protected outcome and its material obligations may themselves be challenged or retired through explicit evidence and applicable authority, but a successor may not silently weaken or redefine them merely to appear superior.
@@ -33,6 +39,8 @@ The protected outcome and its material obligations may themselves be challenged 
 `DIFFERENT != INFERIOR`
 
 `NEW != SUPERIOR`
+
+`EQUAL != SUPERIOR`
 
 `CLAIMED SUPERIORITY != PROVEN SUPERIORITY`
 

--- a/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
+++ b/thin-rts/ULTIMATE_LOOP_SUPERSESSION_RULE.md
@@ -1,0 +1,13 @@
+# ULTIMATE LOOP — Supersession Rule
+
+Status: `CANONICAL ADDENDUM`
+
+## Canonical termination rule
+
+**ULTIMATE LOOPの終了は、ULTIMATE LOOP自身を超える、さらに上位のループまたは新たなプロトコルが実証された瞬間をもって成立し、その時点でULTIMATE LOOPは役割を終え、後継へ継承される。**
+
+Operational form:
+
+`ULTIMATE LOOP != IMMORTAL`
+
+`SUPERIOR PROTOCOL PROVEN -> ULTIMATE LOOP YIELDS`


### PR DESCRIPTION
Adds a canonical supersession rule stating that ULTIMATE LOOP itself has no permanent right to exist. If a higher-order protocol is demonstrated to surpass it, ULTIMATE LOOP yields and the successor inherits the role.