### PR TITLE
feat: add discovery refresh and post-deploy debug gates

### DIFF
--- a/experiments/GENERIC_DEBUG_HARNESS_20260814/GOAL_RESULT.md
+++ b/experiments/GENERIC_DEBUG_HARNESS_20260814/GOAL_RESULT.md
@@ -1,0 +1,29 @@
+# /goal — Generic Debug Harness v0
+
+Date: **2026-08-14**
+
+Status: `MONOLITHIC_DEBUG_PLATFORM_KILLED / THIN_EVIDENCE_HARNESS_SURVIVES`
+
+## Verdict
+
+Do **not** build a browser-testing, telemetry, error-monitoring, profiling, AI-patching or self-healing platform inside RTS. Those execution/collection responsibilities remain external and replaceable.
+
+A thin adapter-neutral evidence harness survives because ULTIMATE LOOP still needs one shared fail-closed contract after deployment:
+
+`DEPLOYMENT IDENTITY -> PROBES -> FAILURE EVIDENCE -> EXTERNAL ANALYSIS/PATCH -> RE-IDENTITY -> FAILED-PROBE REPLAY -> REGRESSION -> FIX_VALIDATED`
+
+The existing Deployment Identity boundary is reused. Old PR #299 is not revived wholesale; only its surviving invariants are inherited.
+
+Hard rules:
+
+- `CODE EXISTENCE != RUNTIME EVIDENCE`
+- `RUNTIME-TO-CODE MAPPING != ROOT CAUSE`
+- `PATCH APPLIED != FIX VALIDATED`
+- blocked/missing runtime evidence fails closed;
+- a patch must establish post-patch deployment identity;
+- every previously failed required probe must replay PASS with evidence;
+- regression must PASS with evidence.
+
+The first occupant is `debug_harness.py`: a small pure evaluator with no network, process execution, browser, telemetry store, database, credentials, patching, deployment or promotion authority.
+
+`BUILD THIN EVIDENCE HARNESS / KILL GENERIC DEBUG PLATFORM`.

--- a/experiments/GENERIC_DEBUG_HARNESS_20260814/debug_harness.py
+++ b/experiments/GENERIC_DEBUG_HARNESS_20260814/debug_harness.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+class DebugEvidenceError(ValueError):
+    pass
+
+
+def evaluate(case: dict[str, Any]) -> dict[str, Any]:
+    identity = case.get("deployment_identity") or {}
+    if identity.get("status") != "ESTABLISHED" or not identity.get("evidence_ref"):
+        return {"state": "BLOCKED_DEPLOYMENT_IDENTITY", "fix_validated": False}
+
+    probes = case.get("probes")
+    if not isinstance(probes, list) or not probes:
+        raise DebugEvidenceError("non-empty probes required")
+
+    failed: list[str] = []
+    for probe in probes:
+        if not isinstance(probe, dict):
+            raise DebugEvidenceError("probe must be an object")
+        if probe.get("status") not in {"PASS", "FAIL", "BLOCKED"}:
+            raise DebugEvidenceError("invalid probe status")
+        if not probe.get("probe_id") or not probe.get("evidence_refs"):
+            raise DebugEvidenceError("probe identity and evidence required")
+        if probe["status"] == "BLOCKED":
+            return {"state": "BLOCKED_PROBE_EXECUTION", "failed_probe_ids": failed, "fix_validated": False}
+        if probe["status"] == "FAIL":
+            failed.append(probe["probe_id"])
+
+    if not failed:
+        return {"state": "NO_FAILURE_OBSERVED", "failed_probe_ids": [], "fix_validated": False}
+
+    patch = case.get("patch") or {}
+    if patch.get("applied") is not True:
+        return {"state": "FAILURE_EVIDENCE_READY", "failed_probe_ids": failed, "fix_validated": False}
+
+    post = patch.get("post_deployment_identity") or {}
+    blockers: list[str] = []
+    if post.get("status") != "ESTABLISHED" or not post.get("evidence_ref"):
+        blockers.append("POST_PATCH_IDENTITY_NOT_ESTABLISHED")
+
+    replay = {row.get("probe_id"): row for row in patch.get("replay_results", []) if isinstance(row, dict)}
+    for probe_id in failed:
+        row = replay.get(probe_id)
+        if not row or row.get("status") != "PASS" or not row.get("evidence_refs"):
+            blockers.append(f"FAILED_PROBE_REPLAY_NOT_PROVEN:{probe_id}")
+
+    if patch.get("regression_status") != "PASS" or not patch.get("regression_evidence_refs"):
+        blockers.append("REGRESSION_NOT_PROVEN")
+
+    return {
+        "state": "FIX_VALIDATED" if not blockers else "PATCH_NOT_VALIDATED",
+        "failed_probe_ids": sorted(failed),
+        "blocking_states": sorted(blockers),
+        "fix_validated": not blockers,
+        "invariants": [
+            "CODE_EXISTENCE != RUNTIME_EVIDENCE",
+            "MAPPING != ROOT_CAUSE",
+            "PATCH_APPLIED != FIX_VALIDATED",
+        ],
+    }

--- a/experiments/GENERIC_DEBUG_HARNESS_20260814/debug_harness.py
+++ b/experiments/GENERIC_DEBUG_HARNESS_20260814/debug_harness.py
@@ -7,9 +7,20 @@ class DebugEvidenceError(ValueError):
     pass
 
 
+def _established(identity: Any) -> bool:
+    return (
+        isinstance(identity, dict)
+        and identity.get("status") == "ESTABLISHED"
+        and isinstance(identity.get("evidence_ref"), str)
+        and bool(identity["evidence_ref"])
+        and isinstance(identity.get("fingerprint"), str)
+        and bool(identity["fingerprint"])
+    )
+
+
 def evaluate(case: dict[str, Any]) -> dict[str, Any]:
     identity = case.get("deployment_identity") or {}
-    if identity.get("status") != "ESTABLISHED" or not identity.get("evidence_ref"):
+    if not _established(identity):
         return {"state": "BLOCKED_DEPLOYMENT_IDENTITY", "fix_validated": False}
 
     probes = case.get("probes")
@@ -24,8 +35,15 @@ def evaluate(case: dict[str, Any]) -> dict[str, Any]:
             raise DebugEvidenceError("invalid probe status")
         if not probe.get("probe_id") or not probe.get("evidence_refs"):
             raise DebugEvidenceError("probe identity and evidence required")
+        if probe.get("deployment_fingerprint") != identity["fingerprint"]:
+            return {
+                "state": "BLOCKED_PROBE_IDENTITY_MISMATCH",
+                "failed_probe_ids": sorted(failed),
+                "blocking_states": [f"PROBE_IDENTITY_MISMATCH:{probe['probe_id']}"],
+                "fix_validated": False,
+            }
         if probe["status"] == "BLOCKED":
-            return {"state": "BLOCKED_PROBE_EXECUTION", "failed_probe_ids": failed, "fix_validated": False}
+            return {"state": "BLOCKED_PROBE_EXECUTION", "failed_probe_ids": sorted(failed), "fix_validated": False}
         if probe["status"] == "FAIL":
             failed.append(probe["probe_id"])
 
@@ -34,21 +52,37 @@ def evaluate(case: dict[str, Any]) -> dict[str, Any]:
 
     patch = case.get("patch") or {}
     if patch.get("applied") is not True:
-        return {"state": "FAILURE_EVIDENCE_READY", "failed_probe_ids": failed, "fix_validated": False}
+        return {"state": "FAILURE_EVIDENCE_READY", "failed_probe_ids": sorted(failed), "fix_validated": False}
 
     post = patch.get("post_deployment_identity") or {}
     blockers: list[str] = []
-    if post.get("status") != "ESTABLISHED" or not post.get("evidence_ref"):
+    if not _established(post):
         blockers.append("POST_PATCH_IDENTITY_NOT_ESTABLISHED")
 
-    replay = {row.get("probe_id"): row for row in patch.get("replay_results", []) if isinstance(row, dict)}
+    replay_results = patch.get("replay_results", [])
+    if not isinstance(replay_results, list):
+        raise DebugEvidenceError("replay_results must be a list")
+    replay: dict[str, dict[str, Any]] = {}
+    for row in replay_results:
+        if not isinstance(row, dict):
+            raise DebugEvidenceError("replay row must be an object")
+        probe_id = row.get("probe_id")
+        if not probe_id or probe_id in replay:
+            raise DebugEvidenceError("replay probe_id missing or duplicate")
+        replay[probe_id] = row
+
+    post_fingerprint = post.get("fingerprint")
     for probe_id in failed:
         row = replay.get(probe_id)
         if not row or row.get("status") != "PASS" or not row.get("evidence_refs"):
             blockers.append(f"FAILED_PROBE_REPLAY_NOT_PROVEN:{probe_id}")
+        elif row.get("deployment_fingerprint") != post_fingerprint:
+            blockers.append(f"FAILED_PROBE_REPLAY_IDENTITY_MISMATCH:{probe_id}")
 
     if patch.get("regression_status") != "PASS" or not patch.get("regression_evidence_refs"):
         blockers.append("REGRESSION_NOT_PROVEN")
+    elif patch.get("regression_deployment_fingerprint") != post_fingerprint:
+        blockers.append("REGRESSION_IDENTITY_MISMATCH")
 
     return {
         "state": "FIX_VALIDATED" if not blockers else "PATCH_NOT_VALIDATED",
@@ -59,5 +93,6 @@ def evaluate(case: dict[str, Any]) -> dict[str, Any]:
             "CODE_EXISTENCE != RUNTIME_EVIDENCE",
             "MAPPING != ROOT_CAUSE",
             "PATCH_APPLIED != FIX_VALIDATED",
+            "RUNTIME_EVIDENCE_MUST_BIND_TO_DEPLOYMENT_FINGERPRINT",
         ],
     }

--- a/experiments/GENERIC_DEBUG_HARNESS_20260814/test_debug_harness.py
+++ b/experiments/GENERIC_DEBUG_HARNESS_20260814/test_debug_harness.py
@@ -1,14 +1,48 @@
 import unittest
-from debug_harness import evaluate
+
+from debug_harness import DebugEvidenceError, evaluate
+
+
+def base_case():
+    return {
+        "deployment_identity": {"status": "ESTABLISHED", "evidence_ref": "d1", "fingerprint": "fp1"},
+        "probes": [{"probe_id": "r", "status": "FAIL", "evidence_refs": ["p1"], "deployment_fingerprint": "fp1"}],
+        "patch": {
+            "applied": True,
+            "post_deployment_identity": {"status": "ESTABLISHED", "evidence_ref": "d2", "fingerprint": "fp2"},
+            "replay_results": [{"probe_id": "r", "status": "PASS", "evidence_refs": ["p2"], "deployment_fingerprint": "fp2"}],
+            "regression_status": "PASS",
+            "regression_evidence_refs": ["g1"],
+            "regression_deployment_fingerprint": "fp2",
+        },
+    }
+
 
 class TestDebugHarness(unittest.TestCase):
-    def test_chain(self):
-        c={"deployment_identity":{"status":"ESTABLISHED","evidence_ref":"d1"},"probes":[{"probe_id":"r","status":"FAIL","evidence_refs":["p1"]}],"patch":{"applied":True,"post_deployment_identity":{"status":"ESTABLISHED","evidence_ref":"d2"},"replay_results":[{"probe_id":"r","status":"PASS","evidence_refs":["p2"]}],"regression_status":"PASS","regression_evidence_refs":["g1"]}}
-        self.assertEqual(evaluate(c)["state"],"FIX_VALIDATED")
-        c["patch"]["replay_results"]=[]
-        self.assertEqual(evaluate(c)["state"],"PATCH_NOT_VALIDATED")
-    def test_identity(self):
-        c={"deployment_identity":{"status":"UNKNOWN"},"probes":[{"probe_id":"x","status":"PASS","evidence_refs":["p"]}]}
-        self.assertEqual(evaluate(c)["state"],"BLOCKED_DEPLOYMENT_IDENTITY")
+    def test_valid_chain(self):
+        self.assertEqual(evaluate(base_case())["state"], "FIX_VALIDATED")
 
-if __name__=="__main__": unittest.main()
+    def test_stale_replay_identity_blocks(self):
+        case = base_case()
+        case["patch"]["replay_results"][0]["deployment_fingerprint"] = "fp1"
+        self.assertIn("FAILED_PROBE_REPLAY_IDENTITY_MISMATCH:r", evaluate(case)["blocking_states"])
+
+    def test_stale_regression_identity_blocks(self):
+        case = base_case()
+        case["patch"]["regression_deployment_fingerprint"] = "fp1"
+        self.assertIn("REGRESSION_IDENTITY_MISMATCH", evaluate(case)["blocking_states"])
+
+    def test_null_replay_is_malformed(self):
+        case = base_case()
+        case["patch"]["replay_results"] = None
+        with self.assertRaises(DebugEvidenceError):
+            evaluate(case)
+
+    def test_initial_probe_must_bind_identity(self):
+        case = base_case()
+        case["probes"][0]["deployment_fingerprint"] = "wrong"
+        self.assertEqual(evaluate(case)["state"], "BLOCKED_PROBE_IDENTITY_MISMATCH")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/GENERIC_DEBUG_HARNESS_20260814/test_debug_harness.py
+++ b/experiments/GENERIC_DEBUG_HARNESS_20260814/test_debug_harness.py
@@ -1,0 +1,14 @@
+import unittest
+from debug_harness import evaluate
+
+class TestDebugHarness(unittest.TestCase):
+    def test_chain(self):
+        c={"deployment_identity":{"status":"ESTABLISHED","evidence_ref":"d1"},"probes":[{"probe_id":"r","status":"FAIL","evidence_refs":["p1"]}],"patch":{"applied":True,"post_deployment_identity":{"status":"ESTABLISHED","evidence_ref":"d2"},"replay_results":[{"probe_id":"r","status":"PASS","evidence_refs":["p2"]}],"regression_status":"PASS","regression_evidence_refs":["g1"]}}
+        self.assertEqual(evaluate(c)["state"],"FIX_VALIDATED")
+        c["patch"]["replay_results"]=[]
+        self.assertEqual(evaluate(c)["state"],"PATCH_NOT_VALIDATED")
+    def test_identity(self):
+        c={"deployment_identity":{"status":"UNKNOWN"},"probes":[{"probe_id":"x","status":"PASS","evidence_refs":["p"]}]}
+        self.assertEqual(evaluate(c)["state"],"BLOCKED_DEPLOYMENT_IDENTITY")
+
+if __name__=="__main__": unittest.main()

--- a/thin-rts/ultimate-loop/DISCOVERY_REFRESH_GATE_2026-08-14.md
+++ b/thin-rts/ultimate-loop/DISCOVERY_REFRESH_GATE_2026-08-14.md
@@ -1,0 +1,71 @@
+# ULTIMATE LOOP — Discovery Refresh Gate
+
+Date: **2026-08-14**
+
+Status: `CANONICAL_EXTENSION_CANDIDATE`
+
+## Purpose
+
+Before ULTIMATE LOOP authorizes either a new program or a deliberately constructed external challenger, it must refresh the surrounding implementation landscape under current evidence.
+
+The goal is not to claim that the entire internet has been exhausted. The goal is to prevent a build or superiority claim from being based on a stale or selectively searched landscape.
+
+## Gate
+
+```text
+NEW PROGRAM / EXTERNAL CHALLENGER INTENT
+-> FROZEN SUBJECT + WORKLOAD
+-> CURRENT DISCOVERY SWEEP
+-> EXISTING HOLDERS / ADJACENT ARCHITECTURES / DEPENDENCIES / FAILURE MODES
+-> COVERAGE + GAP RECORD
+-> SEARCH_SATURATED_UNDER_CURRENT_EVIDENCE
+-> RAISON D'ÊTRE / NEW-BUILD GATE / METEOR
+```
+
+Hard rule:
+
+`NO CURRENT LANDSCAPE SWEEP -> NO SUPERIORITY CLAIM`
+
+## Required output
+
+A discovery result must preserve at least:
+
+- frozen subject/workload identity;
+- source classes searched and their current status;
+- query/search evidence references;
+- discovered candidate identities and source references;
+- relationship types such as incumbent, competitor, component, dependency, architecture reference, failure reference or substitute;
+- materiality disposition or explicit UNKNOWN;
+- blocked/unsearched gaps;
+- frontier rounds and bounded stop state;
+- handoff to METEOR without promotion authority.
+
+## Saturation boundary
+
+`SEARCH_SATURATED_UNDER_CURRENT_EVIDENCE != COMPLETE_WEB_KNOWLEDGE`
+
+Saturation is a bounded evidence state. A materially new candidate, architecture term, source class, dependency, provider capability or failure mode reopens the frontier.
+
+A required source class that is blocked or unsearched prevents a clean saturation claim unless the workload explicitly records why that source class is not required.
+
+## Acquisition boundary
+
+ULTIMATE LOOP does **not** require one owned crawler.
+
+Actual acquisition may be performed by replaceable external search, feeds, GitHub/package APIs, browser crawlers, official documentation search, research indexes, human research or AI-assisted research.
+
+The owned responsibility, when needed, is only the small coverage/provenance/saturation contract that makes heterogeneous acquisition reconstructable.
+
+## Relation to Architecture Superiority Gate
+
+The architecture-superiority new-build path requires a current discovery result before a new architecture can claim that available incumbents are materially deficient.
+
+Discovery does not prove superiority. It establishes the comparison field.
+
+`DISCOVERY != METEOR WIN`
+
+`METEOR WIN != PROMOTION AUTHORITY`
+
+## Emergency exception
+
+A bounded emergency/recovery action may proceed without a full sweep when waiting would materially worsen restoration or safety. The missing sweep is then explicit debt and the emergency choice cannot become the long-term promoted occupant merely from emergency use.

--- a/thin-rts/ultimate-loop/POST_DEPLOY_DEBUG_GATE_2026-08-14.md
+++ b/thin-rts/ultimate-loop/POST_DEPLOY_DEBUG_GATE_2026-08-14.md
@@ -1,0 +1,71 @@
+# ULTIMATE LOOP — Post-Deploy Debug / Reality Gate
+
+Date: **2026-08-14**
+
+Status: `CANONICAL_EXTENSION_CANDIDATE`
+
+## Purpose
+
+A published or deployed program has not earned STABLE merely because build/tests passed or deployment completed.
+
+Hard rule:
+
+`DEPLOYED != OBSERVED_CORRECT`
+
+The promoted implementation must be checked against runtime reality on the actual deployed identity and must retain a reproducible failure/retest path.
+
+## Gate
+
+```text
+DEPLOY / PUBLISH
+-> DEPLOYMENT IDENTITY
+-> BOUNDED RUNTIME PROBES
+-> EXPECTED vs OBSERVED
+-> EVIDENCE BINDING
+-> FAILURE CORRELATION
+-> ROOT-CAUSE HYPOTHESIS GATE
+-> PATCH / CHANGE BY AUTHORIZED EXTERNAL IMPLEMENTER
+-> DEPLOYMENT RE-IDENTITY
+-> EXACT FAILED-PROBE REPLAY
+-> REGRESSION
+-> FIX_VALIDATED / RETURN TO ANALYSIS
+```
+
+## Hard invariants
+
+- `CODE EXISTENCE != RUNTIME EVIDENCE`
+- `RUNTIME-TO-CODE MAPPING != ROOT CAUSE`
+- root-cause promotion requires support, reproduction, falsification and no unresolved counterevidence;
+- `PATCH APPLIED != FIX VALIDATED`;
+- post-patch Deployment Identity must be re-established;
+- every originally failed required probe must be replayed against the new identity;
+- regression PASS requires evidence, not a label only;
+- blocked probes remain blocked/unknown and cannot be silently counted as PASS.
+
+## Externalization boundary
+
+ULTIMATE LOOP does not need to own browser automation, telemetry, tracing, crash collection, log storage, HTTP clients, profilers or AI patch generation.
+
+Those remain replaceable adapters such as browser test tools, HTTP/CLI probes, logs/traces/metrics systems, error trackers, profilers and human/AI analysis.
+
+The only potentially owned responsibility is a thin adapter-neutral evidence contract that binds:
+
+- deployed identity;
+- probe identity and expected/observed result;
+- evidence references;
+- root-cause disposition;
+- patch identity;
+- post-patch re-identity;
+- exact failure replay;
+- regression evidence;
+- final validation state.
+
+## Authority boundary
+
+The debug gate may classify evidence and refuse unsupported closure. It does not create authority to deploy, patch, restart, rollback, publish, access secrets or mutate external systems.
+
+## Relation to STABLE
+
+Workload policy decides which probes are required before STABLE. A purely offline/library artifact may have no live deployment probe, while a web/service/UI workload may require runtime probes after each material deployment.
+
+A material runtime failure reopens BUILD/analysis or the appropriate repair frame. Repeated deployment failure may also trigger METEOR/DARWIN against the current implementation architecture.


### PR DESCRIPTION
## /goal scope

This PR attacks two proposed additions after the successor-core freeze:

1. a crawler before new-program / external-challenger work;
2. a generic debug engine after publication/deployment.

## Verdicts

### Discovery

- owned general web crawler/platform: **KILLED**;
- current-landscape discovery refresh gate: **SURVIVES**.

Canonical boundary:

`NO CURRENT LANDSCAPE SWEEP -> NO SUPERIORITY CLAIM`

Acquisition remains external/replaceable. The small owned responsibility is only coverage, provenance, gaps and bounded saturation before Raison d'être / Architecture Superiority / METEOR decisions.

### Debugging

- owned browser/telemetry/error-monitoring/self-healing platform: **KILLED**;
- adapter-neutral post-deploy debug evidence gate: **SURVIVES**.

Canonical chain:

`DEPLOYMENT IDENTITY -> PROBES -> FAILURE EVIDENCE -> EXTERNAL ANALYSIS/PATCH -> RE-IDENTITY -> FAILED-PROBE REPLAY -> REGRESSION -> FIX_VALIDATED`

The old PR #299 is not revived wholesale. Deployment Identity and surviving fail-closed invariants are reused; the first experiment is deliberately tiny and has no network/process/browser/telemetry/deploy/patch authority.

## Files

- `thin-rts/ultimate-loop/DISCOVERY_REFRESH_GATE_2026-08-14.md`
- `thin-rts/ultimate-loop/POST_DEPLOY_DEBUG_GATE_2026-08-14.md`
- `experiments/GENERIC_DEBUG_HARNESS_20260814/GOAL_RESULT.md`
- `experiments/GENERIC_DEBUG_HARNESS_20260814/debug_harness.py`
- `experiments/GENERIC_DEBUG_HARNESS_20260814/test_debug_harness.py`

## Freeze boundary

This is not unrestricted RTS core expansion. It adds two method gates plus one bounded optional experiment. No GitHub Actions workflow, daemon, scheduler, DB, crawler runtime, browser runtime, telemetry platform, credential, external mutation or autonomous promotion is introduced.