### PR TITLE
docs: Development Sequence Loop v0.1

### DIFF
--- a/thin-rts/ULTIMATE_LOOP_METHOD.md
+++ b/thin-rts/ULTIMATE_LOOP_METHOD.md
@@ -1,16 +1,24 @@
-# ULTIMATE LOOP — Survival-First Development Method
+# Development Sequence Loop — Ultimate Loop
 
 Timestamp: **2026-08-11 20:29 JST**
 
 Canonical extensions integrated: **2026-08-14 JST**
 
-Status: `CANONICAL / ACTIVE`
+Provisional operational completion: **2026-08-14 JST**
 
-Formal name: **ULTIMATE LOOP**
+Status: `PROVISIONAL_OPERATIONAL / CANONICAL / ACTIVE / SELF_EVOLVING`
 
-ULTIMATE LOOP is a development method for deciding what responsibility deserves to exist, which implementation deserves to occupy it, when that occupant should be replaced, and how the human-important outcome remains reconstructable when implementations, providers, tools, or the original creator disappear.
+Formal name: **Development Sequence Loop**
+
+Common name: **Ultimate Loop**
+
+Current release: **v0.1**
+
+The Development Sequence Loop (commonly **Ultimate Loop**) is a development method for deciding what responsibility deserves to exist, which implementation deserves to occupy it, when that occupant should be replaced, and how the human-important outcome remains reconstructable when implementations, providers, tools, or the original creator disappear.
 
 It is not one framework, runtime, product, provider, or model.
+
+`PROVISIONAL_OPERATIONAL` means the sequence is complete enough to run end-to-end on real work under current evidence. It does **not** mean the method itself is permanently finished. Ultimate Loop is also placed inside its own Movable Frame and may be challenged, recomposed, partially replaced, or superseded by a demonstrably better development sequence.
 
 ## Canonical motto
 
@@ -40,8 +48,9 @@ WISH / PROBLEM / EVENT
 → DEPLOYMENT_VALIDATED / FIX_VALIDATED
 → STABLE CORE / MOVABLE FRAME
 → WATCH
+→ WEEKLY CHALLENGER SWEEP + EVENT TRIGGERS
 → MATERIAL FAILURE / BETTER CHALLENGER / ERA CHANGE
-→ LOOP 3: DARWIN ARENA
+→ LOOP 3: DARWIN ARENA / KNOCKOUT MATCH
 → SURVIVE / RECOMPOSE / PARTIAL REPLACE / FULL REPLACE / DIE
 → PHOENIX LINEAGE PRESERVES MEMORY + REGENERATION CAPABILITY
 → repeat
@@ -57,7 +66,7 @@ Hard rule:
 
 `NO CURRENT LANDSCAPE SWEEP → NO SUPERIORITY CLAIM`
 
-Discovery may use replaceable external search engines, feeds, APIs, GitHub/package registries, browser crawlers, official documentation search, human research, or AI-assisted research. ULTIMATE LOOP does not require one owned crawler.
+Discovery may use replaceable external search engines, feeds, APIs, GitHub/package registries, browser crawlers, official documentation search, human research, or AI-assisted research. Ultimate Loop does not require one owned crawler.
 
 The owned responsibility, when needed, is only a small coverage/provenance/freshness/frontier contract.
 
@@ -146,7 +155,7 @@ Hard invariants:
 
 A clean first deployment that satisfies all required probes may become `DEPLOYMENT_VALIDATED`. A repaired deployment becomes `FIX_VALIDATED` only after verifier-controlled re-identity, exact failed-probe replay, and regression evidence.
 
-## Loop 3 — DARWIN ARENA
+## Loop 3 — DARWIN ARENA / Knockout Match
 
 Question:
 
@@ -164,6 +173,33 @@ Possible results:
 
 No implementation gains a permanent right to exist.
 
+## Weekly self-evolution / Knockout cadence
+
+Ultimate Loop itself is subject to Ultimate Loop.
+
+A **weekly challenger sweep** is the minimum scheduled self-evolution cadence. Once every seven days, refresh the external landscape around the current development sequence and its material occupants.
+
+```text
+WEEKLY TICK
+→ DISCOVERY REFRESH
+→ MATERIAL EXTERNAL CHALLENGER?
+   ├─ NO  → KEEP CURRENT / NO MATCH REQUIRED
+   └─ YES → FREEZE SAME WORKLOAD + KNOWN DEATHS
+            → DA / COUNTER-DA
+            → METEOR / DARWIN KNOCKOUT MATCH
+            → KEEP / STANDBY / PARTIAL REPLACE / FULL REPLACE / REJECT
+```
+
+The weekly tick **does not force a rewrite or a match**. A knockout match occurs only when a material external challenger, materially superior architecture, new failure class, or other credible challenge exists.
+
+A material event does not have to wait for the weekly tick. Critical security evidence, provider failure, major degradation, breaking API/platform change, or another urgent material trigger may open the appropriate Emergency, Discovery, METEOR, or DARWIN path immediately.
+
+The current sequence therefore has two simultaneous truths:
+
+`SEQUENCE v0.1 = PROVISIONALLY COMPLETE ENOUGH TO OPERATE`
+
+`ULTIMATE LOOP = NEVER PERMANENTLY IMMUNE FROM CHALLENGE`
+
 ## WATCH rule
 
 STABLE means stable-by-default, not ignored forever.
@@ -174,13 +210,13 @@ Doing nothing may be the correct outcome.
 
 ## Emergency / recovery rule
 
-Outage, shutdown, compromise, account loss, network loss, corruption, storage loss, or provider disappearance may enter a bounded recovery frame whose objective is minimum viable restoration, not improvement.
+Outage, shutdown, compromise, account loss, network loss, corruption, storage loss, provider disappearance, or material instability may enter the bounded Emergency Recovery / Failover Gate whose objective is minimum viable restoration, not improvement.
 
-Emergency restoration may temporarily proceed without a full discovery sweep when delay would materially worsen safety or recovery. The missing sweep becomes explicit debt, and emergency use alone cannot authorize long-term promotion.
+Emergency restoration may temporarily proceed without a full discovery sweep when delay would materially worsen safety or recovery. The missing sweep becomes explicit Recovery Debt, and emergency use alone cannot authorize long-term promotion or automatic failback.
 
 ## Creator-independent continuity
 
-ULTIMATE LOOP is bounded by **PHOENIX LINEAGE**.
+Ultimate Loop is bounded by **PHOENIX LINEAGE**.
 
 The protected subject is not code, a provider, or the creator. It is the human-important outcome and enough material evidence, state, meaning, decisions, failure history, authority boundaries, and recovery path to reconstruct that outcome using the best currently available means.
 
@@ -211,6 +247,6 @@ Every survivor inherits useful memory of the dead:
 
 ## Method invariant
 
-**Search the current reality before claiming superiority. Kill the need. Kill the implementation. Keep killing the incumbent when reality changes. Verify the deployed reality with verifier-controlled trust before calling it stable. Preserve the human-important outcome and the memory required to regenerate it.**
+**Search the current reality before claiming superiority. Kill the need. Kill the implementation. Keep challenging the incumbent when reality changes. Verify the deployed reality with verifier-controlled trust before calling it stable. Recover capability before permanent promotion in emergencies. Preserve the human-important outcome and the memory required to regenerate it.**
 
-That full method is **ULTIMATE LOOP**.
+That full method is formally the **Development Sequence Loop**, commonly called **Ultimate Loop**.

--- a/thin-rts/ultimate-loop/EMERGENCY_RECOVERY_GATE_2026-08-14.md
+++ b/thin-rts/ultimate-loop/EMERGENCY_RECOVERY_GATE_2026-08-14.md
@@ -2,7 +2,7 @@
 
 Date: **2026-08-14 JST**
 
-Status: `MERGE_CANDIDATE / NOT_CANONICAL_UNTIL_MERGED`
+Status: `CANONICAL / ACTIVE / MERGED_PR_331`
 
 ## Purpose
 
@@ -97,7 +97,7 @@ Keep external and replaceable:
 ## METEOR disposition
 
 - Existing + `MANUAL_BOUNDED`: `KEEP_CONDITIONALLY` when operator/runbook/RTO satisfy the workload.
-- Structural extraction: `METEOR_SURVIVOR / MERGE_READY_CANDIDATE`.
+- Structural extraction: `PROMOTED / CANONICAL ACTIVE` after destructive METEOR and PR #331 merge.
 - Standalone new engine: `REJECT` because parity does not justify duplicated lifecycle authority and policy drift.
 
 See `EMERGENCY_METEOR_RESULT_2026-08-14.md` for destructive evidence and retained death causes.

--- a/thin-rts/ultimate-loop/README.md
+++ b/thin-rts/ultimate-loop/README.md
@@ -1,33 +1,77 @@
-# Ultimate Loop Lifecycle v0
+# Development Sequence Loop — Ultimate Loop v0.1
 
-Status: `FRAME_CORE_COMPLETE_UNDER_CURRENT_EVIDENCE / ADOPT_CANDIDATE / NOT PROMOTION AUTHORITY`
+Status: `PROVISIONAL_OPERATIONAL / CANONICAL_INDEX / ACTIVE / SELF_EVOLVING`
 
-This directory contains the smallest machine-checkable lifecycle glue that survived the current WITNESS reuse-first analysis, repository destructive METEOR, and creator-absent PHOENIX probe.
+Formal name: **Development Sequence Loop**
 
-It does **not** implement a crawler, scheduler, database, daemon, model runtime, deployment engine, backup platform, or autonomous promotion system.
+Common name: **Ultimate Loop**
 
-Existing holders remain external or inherited:
+This directory contains the bounded lifecycle/evidence components that support the Development Sequence Loop. The sequence is complete enough for provisional end-to-end operation under current evidence; it is not permanently frozen against better challengers.
 
-- WITNESS / DA / Counter-DA / Raison d'être Destroy Loop for necessity and specification pressure;
-- METEOR CRUCIBLE for same-workload destructive comparison;
-- MOVABLE FRAME / DARWIN ARENA for post-promotion challenger comparison;
-- PHOENIX LINEAGE and Succession Packets for creator-independent regeneration;
-- Continuity / Cloud Custody for protected material recovery;
-- Git/GitHub for durable lineage and review history;
-- external search/crawlers/official feeds for discovery;
-- native schedulers/notifications for timing;
-- human/project authority for promotion, disclosure, spending, deployment and other material actions.
+The canonical method is `../ULTIMATE_LOOP_METHOD.md`.
 
-The surviving binder owns only typed lifecycle binding and fail-closed validation across four responsibilities that were not reliably machine-checkable as free-form records alone:
+## Active sequence
 
-1. stable lifecycle state and re-entry routing;
-2. candidate disposition (`CANDIDATE / SHADOW / STANDBY / PARTIAL / PRIMARY / REJECTED`);
-3. watch-trigger evidence to `OBSERVE / METEOR / EMERGENCY / INNER_LOOP_REOPEN`;
-4. replacement/recovery gates that keep performance gain separate from resilience, authority, recovery and PHOENIX evidence.
+```text
+DISCOVERY REFRESH
+→ RAISON D'ÊTRE DESTROY
+→ KEEP / EXTRACT / COMPOSE / MANUAL_BOUNDED / BOUNDED NEW BUILD
+→ DA / COUNTER-DA
+→ METEOR CRUCIBLE
+→ PROMOTED SURVIVOR
+→ DEPLOY / PUBLISH
+→ DEPLOYMENT IDENTITY
+→ POST-DEPLOY DEBUG / REALITY GATE
+→ STABLE / WATCH
+→ DARWIN KNOCKOUT MATCH WHEN A MATERIAL CHALLENGER EXISTS
+→ EMERGENCY RECOVERY WHEN FAILURE/UNSAFE CONDITIONS REQUIRE IT
+→ PHOENIX LINEAGE
+→ repeat
+```
 
-Canonical principles:
+## Active canonical responsibilities
+
+- `DISCOVERY_REFRESH_GATE_2026-08-14.md` — current landscape evidence before superiority claims;
+- `NEW_BUILD_SUPERIORITY_GATE_2026-08-14.md` — bounded new-build permission for irreducible gaps or proven architecture deficits;
+- `POST_DEPLOY_DEBUG_GATE_2026-08-14.md` — deployed-reality verification and regression binding;
+- `EMERGENCY_RECOVERY_GATE_2026-08-14.md` — bounded emergency recovery semantics;
+- `lifecycle.py` — lifecycle/failover authority binding;
+- `emergency.py` — thin Emergency Recovery evidence/state binder;
+- associated regression suites — retained death-memory for known failure classes.
+
+## Weekly self-evolution cadence
+
+At least once every seven days, refresh the external landscape around the Development Sequence Loop and its material occupants.
+
+`WEEKLY SWEEP != FORCED REWRITE`
+
+If no material external challenger exists, the correct result is `KEEP CURRENT / NO MATCH REQUIRED`.
+
+If a material challenger exists, freeze the same workload and inherited death cases, then run DA / Counter-DA and a METEOR/DARWIN knockout match. Critical security events, provider failure, major degradation, or breaking platform/API changes may open the appropriate loop immediately without waiting for the weekly tick.
+
+Ultimate Loop itself is therefore an occupant of a Movable Frame: it can survive, evolve, be recomposed, or eventually yield to a demonstrably superior development sequence.
+
+## Externalization boundary
+
+This project intentionally does **not** become a crawler platform, scheduler, database, daemon, model runtime, monitoring platform, traffic switch, deployment engine, backup product, or autonomous promotion system.
+
+Search/crawling, monitoring, provider APIs, DNS/load balancers/service meshes, schedulers, deployment/failover execution, and other commodity mechanisms remain replaceable external occupants. Ultimate Loop owns the minimum decision/evidence/authority contracts needed to compare and safely use them.
+
+## Historical evidence vs current authority
+
+Dated DA, Counter-DA, METEOR, necessity-review, completion-gate, experiment, and failure records are retained as **historical evidence and regression memory**. Their old candidate/pre-merge status labels describe the state at the time of that experiment and do not override the current canonical method or this index.
+
+History is preserved; stale experiment labels are not operational authority.
+
+## Core invariants
+
+`NO CURRENT LANDSCAPE SWEEP != SUPERIORITY CLAIM`
 
 `BETTER CANDIDATE != AUTHORIZED REPLACEMENT`
+
+`DEPLOYED != OBSERVED_CORRECT`
+
+`EMERGENCY_USE != PROMOTION`
 
 `BACKUP EXISTS != RECOVERABLE`
 
@@ -37,14 +81,4 @@ Canonical principles:
 
 `IMPLEMENTED != PERMANENT`
 
-The current occupant is intentionally pure Python standard library and JSON input/output. It has no side effects outside reading an input file and printing a report.
-
-## Evidence trail
-
-- `DA_COUNTER_DA_REUSE_EXTRACTION_2026-08-13.md` — reuse/extraction/new-build gate;
-- `METEOR_RESULT_2026-08-13.md` — prototype destruction, real repository death, repair and 30/30 repository survival;
-- `CORE_COMPLETION_GATE_2026-08-13.md` — final frame completion re-gate;
-- `../phoenix/ultimate-loop-lifecycle-succession-v0.json` — Succession Packet;
-- `../phoenix/ULTIMATE_LOOP_LIFECYCLE_PHOENIX_RESULT_2026-08-13.md` — creator-absent regeneration result.
-
-This frame may be reopened by new material evidence or displaced by a later DARWIN challenger. Frame completion is not authority to merge, deploy, spend, disclose or declare unrelated successor-RTS responsibilities complete.
+`PROVISIONAL COMPLETE != PERMANENTLY FINISHED`


### PR DESCRIPTION
Documentation cleanup and naming update for the current provisional operational development sequence. Updates the canonical method, weekly challenger cadence, self-evolution rule, canonical index, and Emergency Recovery status after PR #331.