### PR TITLE
Fix BridgePatch dedicated Payment Link

### DIFF
--- a/bridgepatch/config.js
+++ b/bridgepatch/config.js
@@ -2,11 +2,11 @@ window.BRIDGEPATCH_CONFIG = Object.freeze({
   brand: "BridgePatch / RS AI",
   serviceName: "AI業務レスキュー",
   freeConsultationUrl: "mailto:yamauchi.rts.office@gmail.com?subject=BridgePatch%20%E7%84%A1%E6%96%99%E9%81%A9%E5%90%88%E3%83%81%E3%82%A7%E3%83%83%E3%82%AF",
-  stripeSpecUrl: "https://buy.stripe.com/3cI7sN7TG4vb9ie8jV3Nm02",
+  stripeSpecUrl: "https://buy.stripe.com/5kQ3cxb5SaTz0LI8jV3Nm0f",
   contactEmail: "yamauchi.rts.office@gmail.com",
   sellerName: "山内 延天（屋号：RS AI）",
   operatorName: "山内 延天",
   disclosureRequestText: "所在地・電話番号は、請求があった場合、申込みの意思決定に先立って十分な時間的余裕をもって、電子メールにより遅滞なく開示します。開示請求は yamauchi.rts.office@gmail.com へご連絡ください。",
   publicBaseUrl: "https://nobutakayamauchi.github.io/RTS/bridgepatch/",
-  version: "2026-08-15-prelaunch"
+  version: "2026-08-15-payment-link-v2"
 });


### PR DESCRIPTION
## /goal hotfix

Replace the legacy-reused BridgePatch Payment Link with a newly created dedicated Price and Payment Link.

Verified before this PR:

- new Price: `price_1U4ewGPYxtfxmKGliOKXtIP1`
- JPY 10,000 one-time
- tax behavior: inclusive
- new Payment Link: `plink_1U4ewTPYxtfxmKGlnNEYk9Bs`
- new public URL: `https://buy.stripe.com/5kQ3cxb5SaTz0LI8jV3Nm0f`
- line item description: `BridgePatch 暫定ツール実装設計書`
- adjustable quantity: false
- live mode: true

This changes only `bridgepatch/config.js` to point the production CTA at the corrected link and bumps the config version.

Founder already granted `PUBLIC_SALE_APPROVED` for the active BridgePatch launch and explicitly authorized this correction sequence.