### PR TITLE
Sync BridgePatch launch state after payment-link hotfix

### DIFF
--- a/bridgepatch/LAUNCH_CHECKLIST.md
+++ b/bridgepatch/LAUNCH_CHECKLIST.md
@@ -1,41 +1,71 @@
 # BridgePatch Launch Checklist
 
-Status: `PRELAUNCH / DO NOT PUBLISH OR ANNOUNCE UNTIL HUMAN APPROVAL`
+Status: `PUBLIC_SALE_ACTIVE / PAYMENT_LINK_V2 / PAGES_BUILD_PASSED`
 
-## Already completed in this branch
+## Current production state
 
-- [x] Public contact email fixed to `yamauchi.rts.office@gmail.com`
-- [x] Free consultation CTA bound to the public contact email
-- [x] Existing live Stripe Payment Link identified and reused
-- [x] Stripe product renamed to `BridgePatch 暫定ツール実装設計書`
-- [x] Stripe amount remains JPY 10,000 / one-time / quantity 1
-- [x] Stripe individual name collection enabled and required
-- [x] Stripe business name collection enabled and optional
-- [x] Stripe pre-submit text states product boundary, provision timing, and refund/cancellation boundary
-- [x] Stripe post-payment message points to the public contact email
-- [x] GitHub Pages deployment identity confirmed: `main` repository root -> `https://nobutakayamauchi.github.io/RTS/`
-- [x] Planned BridgePatch public path fixed to `/RTS/bridgepatch/`
-- [x] Terms / privacy / commercial disclosure staged
-- [x] Address and telephone disclosure-on-request wording staged
-- [x] Prepayment follow-up email procedure staged without committing private seller data
+- [x] Founder explicitly stated `PUBLIC_SALE_APPROVED` on 2026-08-15 JST.
+- [x] BridgePatch sales surface merged to `main`.
+- [x] Public URL fixed to `https://nobutakayamauchi.github.io/RTS/bridgepatch/`.
+- [x] Public contact email fixed to `yamauchi.rts.office@gmail.com`.
+- [x] Free consultation CTA uses the public contact email.
+- [x] Terms / privacy / commercial disclosure are present in `bridgepatch/`.
+- [x] Non-public seller address and reachable phone are available outside the public repository for disclosure/prepayment notices.
 
-## Must remain true before public sale
+## Stripe production link v2
 
-- [ ] `bridgepatch/` is merged to `main`
-- [ ] GitHub Pages build succeeds on the merged commit
-- [ ] `https://nobutakayamauchi.github.io/RTS/bridgepatch/` returns the expected BridgePatch page
-- [ ] Free consultation button opens `yamauchi.rts.office@gmail.com`
-- [ ] JPY 10,000 button opens exactly `https://buy.stripe.com/3cI7sN7TG4vb9ie8jV3Nm02`
-- [ ] Checkout visibly shows JPY 10,000 and quantity 1
-- [ ] Checkout visibly shows the service boundary / delivery timing / cancellation-refund text
-- [ ] `tokusho.html`, `terms.html`, `privacy.html` are reachable from the sales page
-- [ ] No `REPLACE_ME`, placeholder email, placeholder URL, test customer, or private seller address/phone appears in public files
-- [ ] Private seller address and telephone are available outside the public repository for disclosure requests and any required prepayment notice
-- [ ] Human reviews the final live pages and explicitly states `PUBLIC_SALE_APPROVED`
+The initially reused legacy Price/Payment Link was rejected during live smoke because its line-item description remained `新規案件 初動フローチャート策定` even after the Product itself had been renamed.
 
-## Do not do before `PUBLIC_SALE_APPROVED`
+That link is no longer production authority.
 
-- Do not announce the product as publicly on sale.
-- Do not send the Payment Link to a real prospect as the finalized public offer.
-- Do not treat a Pages build as legal or commercial approval.
-- Do not place private seller address or phone number in the public repository merely to satisfy an internal placeholder.
+Current canonical payment objects:
+
+```text
+Product: prod_UAWEhRHXtUTaWb
+Product name: BridgePatch 暫定ツール実装設計書
+Price: price_1U4ewGPYxtfxmKGliOKXtIP1
+Payment Link: plink_1U4ewTPYxtfxmKGlnNEYk9Bs
+URL: https://buy.stripe.com/5kQ3cxb5SaTz0LI8jV3Nm0f
+Amount: JPY 10,000
+Quantity: 1
+Adjustable quantity: false
+Tax behavior: inclusive
+Live mode: true
+```
+
+- [x] New dedicated Price created after Product rename.
+- [x] New dedicated Payment Link created from the new Price.
+- [x] Stripe line-item smoke shows `BridgePatch 暫定ツール実装設計書`.
+- [x] Stripe line-item total is JPY 10,000.
+- [x] Individual name is required.
+- [x] Business name is optional.
+- [x] Pre-submit text states product boundary, delivery timing, and cancellation/refund boundary.
+- [x] Post-payment message points to `yamauchi.rts.office@gmail.com`.
+- [x] `bridgepatch/config.js` on `main` points to the v2 URL.
+- [x] GitHub Pages build succeeded for the hotfix commit `fb66986ac60347134ace9f0597871f22ca27e748` with no Pages build error.
+
+## Retired legacy link
+
+```text
+Payment Link: plink_1TCBEnPYxtfxmKGlmuK4Cwqe
+URL: https://buy.stripe.com/3cI7sN7TG4vb9ie8jV3Nm02
+State: INACTIVE
+Reason: retained stale line-item description from the pre-BridgePatch product
+```
+
+Do not reactivate or reintroduce this URL into production configuration.
+
+## Remaining operational checks
+
+These are operations, not launch blockers:
+
+- [ ] When the first real purchase arrives, send the required intake/follow-up email promptly.
+- [ ] If address/phone disclosure is requested, provide the non-public verified values before the customer must decide whether to purchase.
+- [ ] If a prepayment notice is legally required for a specific transaction, send the prepared notice with the required seller/contact/provision information.
+- [ ] Reopen `/goal` if Stripe restrictions, law/policy changes, broken delivery, unsupported claims, or a material product/price/refund change occurs.
+
+## Current verdict
+
+`BRIDGEPATCH_PUBLIC_SALE_ACTIVE`
+
+The payment-link mismatch found during launch smoke is fixed. The v2 Price/Payment Link is the only canonical public checkout path.

--- a/docs/business-portfolio/SALES_BLOCKER_MATRIX_2026-08-15.md
+++ b/docs/business-portfolio/SALES_BLOCKER_MATRIX_2026-08-15.md
@@ -1,18 +1,8 @@
 # Sales Blocker Matrix — 2026-08-15
 
-Status: `AXIS_LIVE / BRIDGEPATCH_PRELAUNCH_HUMAN_GATE`
+Status: `BRIDGEPATCH_LIVE / AXIS_LIVE / POST_ADAPTER_NEXT`
 
-This matrix supersedes the earlier handoff-based assumptions with current repository, Stripe, GitHub Pages, and official-rule evidence.
-
-Allowed blocker classes:
-
-- `DONE`
-- `NOT_BLOCKING`
-- `HUMAN_INPUT_REQUIRED`
-- `EXTERNAL_ACCOUNT_ACTION_REQUIRED`
-- `LEGAL_REVIEW_REQUIRED`
-- `TECHNICAL_FIX_REQUIRED`
-- `VERIFICATION_REQUIRED`
+This matrix supersedes earlier handoff-based and prelaunch assumptions with the current repository, Stripe, GitHub Pages, and release evidence.
 
 # A. BridgePatch
 
@@ -20,47 +10,49 @@ Allowed blocker classes:
 |---|---|---|---|---|
 | BP-01 | Product boundary and offer ladder | `DONE` | Free fit check, JPY 10,000 portable implementation spec, JPY 50,000 simple tool remain the frozen offer | No redesign |
 | BP-02 | Seller/operator identity | `DONE` | `山内 延天（屋号：RS AI）` / operator `山内 延天` | Preserve |
-| BP-03 | Public contact email | `DONE` | Fixed by Founder to `yamauchi.rts.office@gmail.com` and staged in all BridgePatch surfaces | Preserve |
-| BP-04 | Free consultation route | `DONE` | Staged as a mailto route to the public contact email; no new form is required for v0 | Live smoke after deployment |
-| BP-05 | JPY 10,000 Stripe Payment Link | `DONE` | Existing live link `plink_1TCBEnPYxtfxmKGlmuK4Cwqe` reused; URL `https://buy.stripe.com/3cI7sN7TG4vb9ie8jV3Nm02`; product renamed to `BridgePatch 暫定ツール実装設計書`; JPY 10,000; quantity 1; individual name required; business name optional | Live smoke after deployment |
-| BP-06 | Paid-intake redirect | `NOT_BLOCKING` | Checkout completion message sends the customer to email follow-up; no intake app is needed | Preserve thin flow |
-| BP-07 | Address/phone disclosure method | `DONE` | Current official rule review supports omission from the public ad when disclosure-on-request is stated and information can be supplied without delay before purchase decision; wording staged | Re-review only if law/operation changes |
-| BP-08 | Actual non-public seller address/phone availability | `DONE` | Current Stripe account contains a verified non-public seller address and reachable phone number; values are deliberately not committed to the public repository | Retrieve privately when a disclosure/prepayment notice requires them |
-| BP-09 | Hosting target / public URL | `DONE` | Existing RTS GitHub Pages deploys from `main` repository root; planned public path is `https://nobutakayamauchi.github.io/RTS/bridgepatch/` | Deploy only after human gate |
-| BP-10 | Production config / public documents | `DONE` | `bridgepatch/` now contains config, LP, terms, privacy, commercial disclosure, prepayment notice procedure, and launch checklist with live identifiers and no private seller address/phone | Preserve |
-| BP-11 | Stripe purchase-boundary text | `DONE` | Checkout pre-submit text states no tool build, provision timing, and refund/cancellation boundary; post-payment message points to the public contact email | Preserve |
-| BP-12 | Cross-page / Pages live smoke | `VERIFICATION_REQUIRED` | Cannot prove the final GitHub Pages route before `bridgepatch/` reaches `main` | Merge/deploy, then run live smoke |
-| BP-13 | Stripe Terms-of-Service consent checkbox | `NOT_BLOCKING` | The public terms page is not live before deployment; the checkout already displays the critical service/delivery/refund boundary. Do not break checkout merely to force a pre-deployment checkbox | Reconsider after the live terms URL exists |
-| BP-14 | Final public-sale human approval | `HUMAN_INPUT_REQUIRED` | Merging PR #334 will put the staged BridgePatch page on the public GitHub Pages site. The current branch explicitly preserves a human public-sale gate | Obtain one explicit current approval before merge/public deployment |
+| BP-03 | Public contact email | `DONE` | `yamauchi.rts.office@gmail.com` is the canonical public contact | Preserve |
+| BP-04 | Free consultation route | `DONE` | Production config uses the canonical mailto route | Preserve |
+| BP-05 | Dedicated JPY 10,000 Price | `DONE` | `price_1U4ewGPYxtfxmKGliOKXtIP1`, JPY 10,000, one-time, tax behavior inclusive | Preserve |
+| BP-06 | Dedicated Payment Link | `DONE` | `plink_1U4ewTPYxtfxmKGlnNEYk9Bs` / `https://buy.stripe.com/5kQ3cxb5SaTz0LI8jV3Nm0f`, live and active | Preserve |
+| BP-07 | Payment line-item identity | `DONE` | Stripe line-item smoke returns `BridgePatch 暫定ツール実装設計書`, quantity 1, adjustable quantity false, total JPY 10,000 | Preserve |
+| BP-08 | Retire incorrect reused legacy link | `DONE` | Legacy `plink_1TCBEnPYxtfxmKGlmuK4Cwqe` set inactive after the stale line-item description was discovered | Do not reactivate |
+| BP-09 | Address/phone disclosure method | `DONE` | Disclosure-on-request path staged; verified non-public seller address and reachable phone exist outside public repository | Re-review only if law/operation changes |
+| BP-10 | Hosting / production URL | `DONE` | GitHub Pages uses `main` root; production route `https://nobutakayamauchi.github.io/RTS/bridgepatch/` | Preserve |
+| BP-11 | Production config / public documents | `DONE` | LP, terms, privacy, commercial disclosure, prepayment procedure and config are on `main` | Preserve |
+| BP-12 | Checkout boundary text | `DONE` | Checkout states product boundary, delivery timing and cancellation/refund boundary; completion message points to public email | Preserve |
+| BP-13 | Founder public-sale approval | `DONE` | Explicit `PUBLIC_SALE_APPROVED` received 2026-08-15 JST and recorded on PR #334 | Reapprove only on a material trigger |
+| BP-14 | Initial Pages deployment | `DONE` | PR #334 merged; Pages build succeeded for commit `7bbbaf4180393e5dfdc4b3bc2e33a2ebedfc769b` | Superseded by payment-link hotfix |
+| BP-15 | Payment-link v2 hotfix deployment | `DONE` | PR #335 merged; Pages build succeeded with no error for commit `fb66986ac60347134ace9f0597871f22ca27e748`; `main` config points to v2 URL | Preserve |
 
-## BridgePatch /goal conclusion
-
-All non-human prelaunch blockers that can currently be resolved without public deployment are resolved.
-
-Current irreducible sequence:
+## BridgePatch current operating state
 
 ```text
-explicit current human public-sale/deployment approval
--> merge PR #334
--> GitHub Pages build
--> live BridgePatch smoke
--> if smoke passes, public sale active
+PUBLIC_SALE_APPROVED: YES
+PUBLIC_SALE_ACTIVE: YES
+PAGES_BUILD: PASS
+CANONICAL_PAYMENT_LINK: plink_1U4ewTPYxtfxmKGlnNEYk9Bs
+CANONICAL_PAYMENT_URL: https://buy.stripe.com/5kQ3cxb5SaTz0LI8jV3Nm0f
+CANONICAL_PRICE: price_1U4ewGPYxtfxmKGliOKXtIP1
+LEGACY_PAYMENT_LINK: INACTIVE
+ACTIVE_PAID_ENGAGEMENTS: not inferred from launch state
 ```
+
+No additional BridgePatch product-development work is authorized merely because no customer has purchased yet.
 
 # B. RTS AXIS
 
-The prior handoff used for the first matrix was stale. The current `nobutakayamauchi/RTS-minicompany` main record establishes a later state.
+The earlier handoff used during the first blocker pass was stale. Current `nobutakayamauchi/RTS-minicompany` main establishes the later release state.
 
 | ID | Requirement | Status | Current evidence | Next action |
 |---|---|---|---|---|
 | AX-01 | Product / JPY 49,500 / scope | `DONE` | Approved active service profile | Preserve |
-| AX-02 | Public seller identity and legal/customer surfaces | `DONE` | Gates A-H and final cross-surface comparison passed before Founder approval | Preserve |
-| AX-03 | Explicit `PUBLIC_SALE_APPROVED` | `DONE` | Founder approval recorded 2026-07-23 12:33 JST; Gate I passed | Preserve until a reapproval trigger occurs |
-| AX-04 | Repository release | `DONE` | PR #91 merged; release completed | No action |
-| AX-05 | note sales page | `DONE` | Published note article identifier `n86c36f6a406c`; controlled public launch active | Keep live unless a pause trigger occurs |
+| AX-02 | Public seller identity and customer surfaces | `DONE` | Gates A-H and final cross-surface comparison passed | Preserve |
+| AX-03 | Explicit `PUBLIC_SALE_APPROVED` | `DONE` | Founder approval recorded 2026-07-23 12:33 JST; Gate I passed | Preserve until reapproval trigger |
+| AX-04 | Repository release | `DONE` | PR #91 merged | No action |
+| AX-05 | note sales page | `DONE` | Published article `n86c36f6a406c`; controlled public launch active | Keep live unless pause trigger occurs |
 | AX-06 | Inquiry route | `DONE` | Inbound inquiry route open and ready for fit checks | Handle inbound as it arrives |
 | AX-07 | Gmail / written-consent / customer-specific Stripe invoice flow | `DONE` | Customer flow and safe pre-send invoice preview approved | Use only for a specific customer after written consent |
-| AX-08 | Live invoice / paid work | `NOT_BLOCKING` | No live invoice is authorized without a specific consenting customer; this is an operational customer gate, not a product-launch blocker | Wait for qualifying customer / explicit customer-specific authority |
+| AX-08 | Live invoice / paid work | `NOT_BLOCKING` | Customer-specific consent and payment gates remain operational boundaries, not product-launch blockers | Wait for qualifying customer |
 | AX-09 | Initial capacity | `DONE` | Controlled launch cap is one simultaneous paid engagement | Do not exceed cap without separate review |
 
 ## RTS AXIS current operating state
@@ -74,15 +66,31 @@ INBOUND_INQUIRY_ROUTE_OPEN: YES
 READY_FOR_INBOUND_FIT_CHECKS: YES
 ACTIVE_PAID_ENGAGEMENTS: 0
 SIMULTANEOUS_PAID_ENGAGEMENT_CAP: 1
-OUTBOUND_CUSTOMER_OUTREACH: NOT GENERALLY AUTHORIZED BY THE AXIS RELEASE RECORD
 LIVE_CUSTOMER_INVOICE: CUSTOMER-SPECIFIC CONSENT GATE REQUIRED
 ```
 
-No new AXIS product-development work is authorized merely because no customer is currently active.
+# C. Development order after blocker closure
 
-# C. Development order after refresh
+The sales-blocker phase requested by `/goal` is closed.
 
-- RTS AXIS: already live; do not rebuild it.
-- BridgePatch: prepared to the public-deployment human gate.
-- Post Adapter v0: already implemented on PR #334; continue dogfood after the BridgePatch launch gate is resolved.
-- Real World Roguelike: remains `LARGE_VENTURE_PRIORITY = 1`, `FROZEN`, `NOT_SELECTED`.
+Next software target:
+
+`POST ADAPTER v0 DOGFOOD`
+
+Use the real BridgePatch launch/hotfix as the first production-shaped source record and verify that:
+
+1. completed vs planned vs deployed claims remain distinct;
+2. Stripe/GitHub evidence bindings survive transformation;
+3. X / note / GitHub / Instagram outputs differ meaningfully by channel;
+4. unsupported claims fail closed;
+5. no external publication occurs without a separate human action.
+
+Real World Roguelike remains:
+
+```text
+CLASS: LARGE_VENTURE
+LARGE_VENTURE_PRIORITY: 1
+STATE: FROZEN
+SELECTION: NOT_SELECTED
+CURRENT_CYCLE_IMPLEMENTATION: FORBIDDEN
+```


### PR DESCRIPTION
## /goal state sync

Synchronizes control documents with the live BridgePatch state after the dedicated Price/Payment Link correction.

- marks BridgePatch public sale active
- records canonical v2 Price and Payment Link
- records legacy reused Payment Link as inactive
- records successful Pages build for hotfix commit `fb66986ac60347134ace9f0597871f22ca27e748`
- closes the BridgePatch sales-blocker phase
- authorizes Post Adapter v0 dogfood as the next software target

No payment, customer outreach, invoice, or external social post is performed by this PR.