### PR TITLE
Add Publication Bridge v0 for X/note handoff

### DIFF
--- a/publication_bridge/README.md
+++ b/publication_bridge/README.md
@@ -1,0 +1,112 @@
+# Publication Bridge v0
+
+Status: `HUMAN-GATED HANDOFF / NO AUTO PUBLISHING`
+
+Publication Bridge receives an already-reviewed Post Adapter bundle and prepares safe handoff actions for external platforms.
+
+```text
+POST ADAPTER
+-> DRAFT / REVIEW
+-> APPROVED_FOR_COPY
+-> PUBLICATION BRIDGE
+   -> X: official Web Intent composer
+   -> note: copy title / copy body / open official editor
+-> USER performs the final platform action
+```
+
+## Why this exists
+
+Platform-side draft APIs are not a stable common denominator.
+
+- X's official create-post API publishes immediately, so v0 deliberately does not call it.
+- X Web Intent opens a pre-filled composer and keeps the final Post action with the user.
+- note's official public route `https://note.com/new` opens the editor, while v0 does not depend on a private posting endpoint.
+
+The durable source of truth is therefore the reviewed bundle and handoff record, not a platform's private draft implementation.
+
+## Run
+
+First create a Post Adapter bundle and explicitly approve it for copy:
+
+```bash
+python -m post_adapter source.json \
+  --out-dir /tmp/post-bundle \
+  --review-state APPROVED_FOR_COPY
+```
+
+Then prepare the handoff UI:
+
+```bash
+python -m publication_bridge /tmp/post-bundle \
+  --out-dir /tmp/publication-handoff
+```
+
+Open:
+
+```text
+/tmp/publication-handoff/index.html
+```
+
+Generated files:
+
+```text
+publication-handoff/
+├── handoff.json
+└── index.html
+```
+
+## X adapter
+
+For each X block, v0 creates an official Web Intent URL using:
+
+```text
+https://x.com/intent/tweet?text=...
+```
+
+The user sees the actual composer and decides whether to post. Publication Bridge stores no X credentials and does not call `POST /2/tweets`.
+
+## note adapter
+
+The handoff page provides:
+
+- title preview + copy;
+- body preview + copy;
+- `note.com/new` editor launch.
+
+It does not store a note cookie, scrape a logged-in session, or call a private note endpoint.
+
+## Fail-closed gates
+
+Handoff generation is rejected when:
+
+- `human_review_state` is not `APPROVED_FOR_COPY` / `APPROVED_FOR_HANDOFF`;
+- verification warnings remain;
+- the source manifest does not explicitly state `external_publication_performed: false`;
+- no supported X/note drafts are present.
+
+## Handoff state
+
+```text
+DRAFT
+-> REVIEW_REQUIRED
+-> APPROVED_FOR_COPY
+-> APPROVED_FOR_HANDOFF
+-> USER OPENS PLATFORM
+-> USER PUBLISHES OR SAVES PLATFORM DRAFT
+```
+
+v0 never writes `PUBLISHED` itself because it has no publication authority and no external-post verification connector.
+
+## Explicitly forbidden in v0
+
+- automatic X posting;
+- note private/undocumented posting API use;
+- browser cookie/session exfiltration;
+- OAuth/token vault;
+- background scheduling;
+- auto-retries that could duplicate posts;
+- silently weakening Post Adapter evidence gates.
+
+## Extension rule
+
+A future official platform API can be added as a separate adapter. It must not change the reviewed-source contract and must preserve a human approval boundary before any irreversible publication action.

--- a/publication_bridge/__init__.py
+++ b/publication_bridge/__init__.py
@@ -1,0 +1,25 @@
+"""Human-gated publication handoff adapters for Post Adapter outputs."""
+
+from .core import (
+    NOTE_EDITOR_URL,
+    X_INTENT_BASE,
+    PublicationBridgeError,
+    build_handoff,
+    note_actions,
+    parse_note,
+    parse_x_blocks,
+    render_handoff_html,
+    x_actions,
+)
+
+__all__ = [
+    "NOTE_EDITOR_URL",
+    "X_INTENT_BASE",
+    "PublicationBridgeError",
+    "build_handoff",
+    "note_actions",
+    "parse_note",
+    "parse_x_blocks",
+    "render_handoff_html",
+    "x_actions",
+]

--- a/publication_bridge/__main__.py
+++ b/publication_bridge/__main__.py
@@ -1,0 +1,3 @@
+from .cli import main
+
+raise SystemExit(main())

--- a/publication_bridge/cli.py
+++ b/publication_bridge/cli.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+from .core import PublicationBridgeError, build_handoff, load_bundle, render_handoff_html
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Prepare reviewed drafts for human handoff to X and note without auto-publishing.")
+    parser.add_argument("bundle_dir", type=Path, help="Post Adapter bundle directory")
+    parser.add_argument("--out-dir", type=Path, required=True, help="Output directory")
+    args = parser.parse_args(argv)
+
+    try:
+        manifest, drafts = load_bundle(args.bundle_dir)
+        handoff = build_handoff(manifest, drafts)
+        args.out_dir.mkdir(parents=True, exist_ok=True)
+        (args.out_dir / "handoff.json").write_text(json.dumps(handoff, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        (args.out_dir / "index.html").write_text(render_handoff_html(handoff), encoding="utf-8")
+    except (OSError, json.JSONDecodeError, PublicationBridgeError) as exc:
+        print(f"publication-bridge: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps({"state": handoff["state"], "actions": len(handoff["actions"]), "automatic_publication": False, "out_dir": str(args.out_dir)}, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/publication_bridge/core.py
+++ b/publication_bridge/core.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import html
+import json
+from pathlib import Path
+import re
+from urllib.parse import urlencode
+
+
+class PublicationBridgeError(ValueError):
+    pass
+
+
+X_INTENT_BASE = "https://x.com/intent/tweet"
+NOTE_EDITOR_URL = "https://note.com/new"
+ALLOWED_SOURCE_STATES = {"APPROVED_FOR_COPY", "APPROVED_FOR_HANDOFF"}
+
+
+@dataclass(frozen=True)
+class HandoffAction:
+    channel: str
+    action: str
+    label: str
+    url: str | None = None
+    text: str | None = None
+    requires_user_action: bool = True
+
+
+def _require_approved(manifest: dict) -> None:
+    state = manifest.get("human_review_state")
+    if state not in ALLOWED_SOURCE_STATES:
+        raise PublicationBridgeError(f"source is not approved for handoff: {state!r}")
+    if manifest.get("external_publication_performed") is not False:
+        raise PublicationBridgeError("source manifest publication boundary is invalid")
+    if manifest.get("verification_warnings"):
+        raise PublicationBridgeError("cannot hand off a bundle with verification warnings")
+
+
+def parse_x_blocks(text: str) -> list[str]:
+    marker = re.compile(r"^\[X POST \d+/\d+\]\s*$", re.MULTILINE)
+    if not marker.search(text):
+        clean = text.strip()
+        return [clean] if clean else []
+    return [part.strip() for part in marker.split(text) if part.strip()]
+
+
+def x_actions(text: str) -> list[HandoffAction]:
+    blocks = parse_x_blocks(text)
+    if not blocks:
+        raise PublicationBridgeError("x draft contains no post bodies")
+    actions: list[HandoffAction] = []
+    for index, block in enumerate(blocks, start=1):
+        actions.append(
+            HandoffAction(
+                channel="x",
+                action="OPEN_COMPOSER",
+                label=f"Xで確認 {index}/{len(blocks)}",
+                url=X_INTENT_BASE + "?" + urlencode({"text": block}),
+                text=block,
+            )
+        )
+    return actions
+
+
+def parse_note(text: str) -> tuple[str, str]:
+    lines = text.strip().splitlines()
+    if not lines:
+        raise PublicationBridgeError("note draft is empty")
+    title = lines[0].lstrip("#").strip() if lines[0].startswith("#") else ""
+    body = "\n".join(lines[1:] if title else lines).strip()
+    if not title:
+        raise PublicationBridgeError("note draft must start with a markdown H1 title")
+    if not body:
+        raise PublicationBridgeError("note draft body is empty")
+    return title, body
+
+
+def note_actions(text: str) -> list[HandoffAction]:
+    title, body = parse_note(text)
+    return [
+        HandoffAction("note", "COPY_TITLE", "タイトルをコピー", text=title),
+        HandoffAction("note", "COPY_BODY", "本文をコピー", text=body),
+        HandoffAction("note", "OPEN_EDITOR", "noteを開く", url=NOTE_EDITOR_URL),
+    ]
+
+
+def build_handoff(manifest: dict, drafts: dict[str, str]) -> dict:
+    _require_approved(manifest)
+    actions: list[HandoffAction] = []
+    if drafts.get("x"):
+        actions.extend(x_actions(drafts["x"]))
+    if drafts.get("note"):
+        actions.extend(note_actions(drafts["note"]))
+    if not actions:
+        raise PublicationBridgeError("no supported handoff drafts supplied")
+    return {
+        "schema_version": "0.1",
+        "source_bundle_id": manifest.get("bundle_id"),
+        "state": "APPROVED_FOR_HANDOFF",
+        "publication_authority": "USER_ONLY",
+        "automatic_publication": False,
+        "credential_storage": False,
+        "private_api_usage": False,
+        "actions": [asdict(action) for action in actions],
+    }
+
+
+def render_handoff_html(handoff: dict) -> str:
+    cards: list[str] = []
+    for action in handoff["actions"]:
+        label = html.escape(action["label"])
+        channel = html.escape(action["channel"].upper())
+        text = action.get("text") or ""
+        preview = html.escape(text)
+        if action["action"].startswith("COPY_"):
+            payload = html.escape(json.dumps(text, ensure_ascii=False), quote=True)
+            control = f'<button data-copy="{payload}" onclick="copyText(this)">{label}</button>'
+        elif action.get("url"):
+            control = f'<a class="button" target="_blank" rel="noopener noreferrer" href="{html.escape(action["url"], quote=True)}">{label}</a>'
+        else:
+            control = ""
+        cards.append(f'<section><h2>{channel}</h2><pre>{preview}</pre>{control}</section>')
+    return """<!doctype html><html lang="ja"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>Publication Bridge</title><style>body{font-family:system-ui,sans-serif;max-width:860px;margin:auto;padding:20px;background:#f6f7f9;color:#111}section{background:#fff;padding:18px;border-radius:16px;margin:16px 0;box-shadow:0 4px 18px #0001}pre{white-space:pre-wrap;word-break:break-word;background:#f3f4f6;padding:12px;border-radius:10px}button,.button{display:inline-block;border:0;background:#111;color:#fff;padding:11px 15px;border-radius:10px;text-decoration:none;font-weight:700}small{color:#666}</style></head><body><h1>Publication Bridge</h1><p><small>自動公開なし。内容を確認してから各サービス側で最終操作してください。</small></p>""" + "".join(cards) + """<script>async function copyText(el){await navigator.clipboard.writeText(JSON.parse(el.dataset.copy));}</script></body></html>"""
+
+
+def load_bundle(bundle_dir: Path) -> tuple[dict, dict[str, str]]:
+    manifest = json.loads((bundle_dir / "manifest.json").read_text(encoding="utf-8"))
+    drafts: dict[str, str] = {}
+    for channel in ("x", "note"):
+        path = bundle_dir / f"{channel}.md"
+        if path.exists():
+            drafts[channel] = path.read_text(encoding="utf-8")
+    return manifest, drafts

--- a/tests/test_publication_bridge.py
+++ b/tests/test_publication_bridge.py
@@ -1,0 +1,67 @@
+import unittest
+from urllib.parse import parse_qs, urlparse
+
+from publication_bridge import (
+    NOTE_EDITOR_URL,
+    X_INTENT_BASE,
+    PublicationBridgeError,
+    build_handoff,
+    note_actions,
+    parse_x_blocks,
+    x_actions,
+)
+
+
+def approved_manifest():
+    return {
+        "bundle_id": "PA-TEST",
+        "human_review_state": "APPROVED_FOR_COPY",
+        "verification_warnings": [],
+        "external_publication_performed": False,
+    }
+
+
+class PublicationBridgeTests(unittest.TestCase):
+    def test_x_thread_becomes_review_intents_without_posting(self):
+        draft = "[X POST 1/2]\nfirst\n\n[X POST 2/2]\nsecond"
+        actions = x_actions(draft)
+        self.assertEqual(len(actions), 2)
+        self.assertTrue(all(a.action == "OPEN_COMPOSER" for a in actions))
+        self.assertTrue(all(a.requires_user_action for a in actions))
+        self.assertTrue(all(a.url.startswith(X_INTENT_BASE) for a in actions))
+        self.assertEqual(parse_qs(urlparse(actions[0].url).query)["text"], ["first"])
+        self.assertEqual(parse_qs(urlparse(actions[1].url).query)["text"], ["second"])
+
+    def test_note_is_copy_and_open_only(self):
+        actions = note_actions("# Title\n\nBody")
+        self.assertEqual([a.action for a in actions], ["COPY_TITLE", "COPY_BODY", "OPEN_EDITOR"])
+        self.assertEqual(actions[-1].url, NOTE_EDITOR_URL)
+        self.assertTrue(all(a.requires_user_action for a in actions))
+
+    def test_handoff_records_no_automation_credentials_or_private_api(self):
+        handoff = build_handoff(approved_manifest(), {"x": "hello", "note": "# T\n\nB"})
+        self.assertEqual(handoff["state"], "APPROVED_FOR_HANDOFF")
+        self.assertEqual(handoff["publication_authority"], "USER_ONLY")
+        self.assertFalse(handoff["automatic_publication"])
+        self.assertFalse(handoff["credential_storage"])
+        self.assertFalse(handoff["private_api_usage"])
+
+    def test_unapproved_source_fails_closed(self):
+        manifest = approved_manifest()
+        manifest["human_review_state"] = "DRAFT"
+        with self.assertRaises(PublicationBridgeError):
+            build_handoff(manifest, {"x": "hello"})
+
+    def test_warnings_fail_closed(self):
+        manifest = approved_manifest()
+        manifest["verification_warnings"] = ["unsupported claim"]
+        with self.assertRaises(PublicationBridgeError):
+            build_handoff(manifest, {"x": "hello"})
+
+    def test_x_parser_preserves_text(self):
+        draft = "[X POST 1/2]\na\n\nline\n\n[X POST 2/2]\nb"
+        self.assertEqual(parse_x_blocks(draft), ["a\n\nline", "b"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## /goal

Build the smallest safe connector layer between Post Adapter and external publishing surfaces.

### Architecture

`Post Adapter -> APPROVED_FOR_COPY -> Publication Bridge -> user-controlled platform handoff`

### X adapter

- official `https://x.com/intent/tweet` Web Intent only
- preserves each X thread block exactly
- pre-fills the composer
- user performs final Post action
- no OAuth, API key, token storage, or `POST /2/tweets`

### note adapter

- preview title/body
- copy title
- copy body
- open official `https://note.com/new` editor
- no cookie/session capture
- no undocumented/private note API

### Safety gates

Handoff fails closed unless:

- source state is `APPROVED_FOR_COPY` or `APPROVED_FOR_HANDOFF`
- verification warnings are empty
- source manifest records `external_publication_performed: false`

Generated handoff records explicitly state:

- `publication_authority: USER_ONLY`
- `automatic_publication: false`
- `credential_storage: false`
- `private_api_usage: false`

### Usability

`python -m publication_bridge <post-bundle> --out-dir <handoff-dir>` generates:

- `handoff.json`
- `index.html`

The HTML is mobile-friendly and provides X composer buttons plus note copy/open actions.

### Validation

Exact core behavior reproduced in isolated execution: **6/6 PASS**.

Tests cover X thread preservation, official intent URLs, note copy/open-only behavior, no automation/credentials/private API flags, fail-closed unapproved sources, fail-closed verification warnings.

No external post is performed by this PR.