### PR TITLE
Prepare BridgePatch live launch handoff and minimal funnel observation

### DIFF
--- a/bridgepatch/LAUNCH_OBSERVATION.md
+++ b/bridgepatch/LAUNCH_OBSERVATION.md
@@ -1,0 +1,69 @@
+# BridgePatch Launch Observation
+
+Status: `ACTIVE / MINIMAL FUNNEL / NO NEW LARGE DEVELOPMENT`
+
+## Purpose
+
+Observe whether the live BridgePatch offer reaches a real prospect and where friction appears before building more infrastructure.
+
+## Minimal funnel
+
+Track only these five events:
+
+1. `SEEN` — external post was actually published and can be viewed.
+2. `VISIT` — a prospect reaches the BridgePatch sales page or clearly references it.
+3. `INQUIRY` — a real prospect sends a BridgePatch inquiry.
+4. `FIT_CHECK` — the four-question free fit check is answered far enough to classify FIT / NEED_MORE_INFO / OUT_OF_SCOPE.
+5. `PAID_SPEC` — the JPY 10,000 BridgePatch implementation design specification is purchased.
+
+Do not build an analytics application just to count these events.
+
+## Record shape
+
+For each meaningful event, retain only what is needed:
+
+```text
+date/time
+channel/source: X / note / GitHub / direct / unknown
+event: SEEN / VISIT / INQUIRY / FIT_CHECK / PAID_SPEC
+reference: URL, message/thread reference, or Stripe payment reference when available
+next action
+notes: short, factual, no unnecessary personal data
+```
+
+If a metric cannot be directly observed, record `UNKNOWN`; do not infer a number.
+
+## Priority rule
+
+A qualified inbound prospect overrides unrelated feature work.
+
+```text
+QUALIFIED INBOUND > NEW FEATURE WORK
+```
+
+Once an inquiry arrives:
+
+```text
+INQUIRY
+-> use Gmail BridgePatch intake template
+-> ask the four fit-check questions
+-> FIT / NEED_MORE_INFO / OUT_OF_SCOPE
+-> if FIT and useful: offer JPY 10,000 design specification
+-> after payment: follow INQUIRY_FLOW.md and prepayment/start-notice rules
+```
+
+Do not start Real World Roguelike or another large product while a qualified BridgePatch inbound needs action.
+
+## What not to optimize yet
+
+Until real traffic or inquiry evidence exists, do not add:
+
+- custom analytics backend;
+- CRM application;
+- automated DM/outreach;
+- automatic social publishing;
+- attribution model beyond the five events;
+- new BridgePatch product tiers;
+- unrelated large development.
+
+First learn from actual publication, inquiry, fit-check, payment and delivery friction.

--- a/post_adapter/campaigns/bridgepatch-sales-20260815/MANIFEST.md
+++ b/post_adapter/campaigns/bridgepatch-sales-20260815/MANIFEST.md
@@ -1,12 +1,12 @@
 # BridgePatch Sales Campaign Manifest — 2026-08-15
 
-Status: `READY_FOR_MANUAL_X_NOTE_PUBLICATION / GITHUB_ROUTE_STAGED`
+Status: `HUMAN_GATE_PASSED / PRIVATE_HANDOFF_GENERATED / READY_FOR_USER_PLATFORM_ACTION`
 
 Source:
 
 `post_adapter/campaigns/bridgepatch-sales-20260815/source.json`
 
-Current Post Adapter policy reproduction:
+Current Post Adapter / Publication Bridge state:
 
 ```text
 CHANNEL_POLICY: x
@@ -15,31 +15,51 @@ FACT_PRIORITY: enabled
 OVERFLOW_STRATEGY: thread
 verified facts: 5
 verification warnings: 0
-X post blocks: 2
-max observed X body: 254 codepoints
-claim truncation/paraphrase by shaping layer: none
-external publication performed by Post Adapter: false
+/human: PASSED
+/human evidence preservation: PASSED
+X post blocks after /human: 2
+X body sizes after /human: 163 / 193 unicode codepoints
+Publication Bridge state: APPROVED_FOR_HANDOFF
+publication authority: USER_ONLY
+automatic publication: false
+credential storage: false
+private API usage: false
+external publication performed by tooling: false
 ```
 
-Generated/staged channel drafts:
+Final external-facing drafts:
 
-- `x.md`
-- `note.md`
-- `github.md`
+- `x.md` — `/human` reviewed
+- `note.md` — `/human` reviewed
+- `github.md` — retained technical/discovery copy
+
+The exact X/note drafts are SHA-256 bound by the `/human` handoff record. Any edit after `/human` requires the gate to be run again before Publication Bridge may hand the content to a platform.
+
+The actual composer/editor handoff UI is intentionally **not committed to this public repository**. A public-repo handoff page would expose the unpublished draft before the user performs the final platform action. The handoff is generated privately for the current launch session instead.
 
 Discovery targets:
 
 - Sales page: `https://nobutakayamauchi.github.io/RTS/bridgepatch/`
-- GitHub Pages home: direct BridgePatch card staged in this goal
-- Repository README: current-service BridgePatch route staged in this goal
+- GitHub Pages home: BridgePatch discovery card live
+- Repository README: BridgePatch current-service route live
 - Gmail: `yamauchi.rts.office@gmail.com`
+
+Post-publication observation uses:
+
+`bridgepatch/LAUNCH_OBSERVATION.md`
+
+Minimal funnel:
+
+```text
+SEEN -> VISIT -> INQUIRY -> FIT_CHECK -> PAID_SPEC
+```
 
 Operating boundary:
 
+- final X/note publish action remains human/user controlled;
 - no automatic X post;
 - no automatic note post;
 - no mass DM/outreach;
 - no new large-product development;
-- no unsupported customer/revenue claims.
-
-The first qualified inbound inquiry takes priority over unrelated feature work.
+- no unsupported customer/revenue claims;
+- `QUALIFIED INBOUND > NEW FEATURE WORK`.


### PR DESCRIPTION
## /goal

Complete the BridgePatch real-world launch preparation without starting any new large development.

### Publication handoff state

- current X/note campaign copy is already `/human` reviewed
- evidence-preservation gate passed
- Publication Bridge state is `APPROVED_FOR_HANDOFF`
- final platform action remains `USER_ONLY`
- no automatic publication, credentials, or private APIs
- private composer/editor handoff UI is generated outside the public repository so unpublished drafts are not exposed early

### Observation

Adds `bridgepatch/LAUNCH_OBSERVATION.md` with the minimum five-event funnel:

`SEEN -> VISIT -> INQUIRY -> FIT_CHECK -> PAID_SPEC`

Unknown measurements must remain `UNKNOWN`; no invented attribution.

### Priority

`QUALIFIED INBOUND > NEW FEATURE WORK`

A real inquiry routes through the existing Gmail BridgePatch intake flow and four-question fit check before the JPY 10,000 design-spec offer.

### Boundary

- no new large development
- no CRM/analytics app
- no auto social posting
- no mass outreach
- no unsupported customer/revenue claims
