### PR TITLE
Add evidence-bound X Article Engine v0

### DIFF
--- a/tests/test_x_article_engine.py
+++ b/tests/test_x_article_engine.py
@@ -1,0 +1,140 @@
+import pytest
+
+from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
+
+
+
+def bridgepatch_brief(article_type="HOW_TO"):
+    return {
+        "offer": "BridgePatch: one bounded manual workflow step is assessed first, then optionally specified and implemented.",
+        "target": "A small business owner repeating manual transfer, aggregation, checking, or drafting work every week.",
+        "pain": "AI seems useful, but they do not know how to describe the work safely or what to automate first.",
+        "primary_info": [
+            {
+                "claim": "During Vlog-tool development, supporting test, debug, operation-recording, and repair mechanisms kept expanding around the original tool; I called this tendency シムシティ化.",
+                "source_ref": "human_attestation:bridgepatch-origin",
+                "attested": True,
+            }
+        ],
+        "article_type": article_type,
+        "topic_mode": "BUSINESS",
+        "cta": "Use the free BridgePatch fit check.",
+        "evidence": [
+            {
+                "claim": "The BridgePatch provisional implementation design document costs 10,000円 including tax and does not include tool implementation.",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "A simple one-action tool is standard 50,000円 including tax, with scope, total price, and timing agreed before start.",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "The design document is normally delivered within 5営業日 after required information is available.",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "TIMING",
+            },
+        ],
+    }
+
+
+
+def test_build_packet_preserves_human_and_evidence_boundaries():
+    packet = build_generation_packet(bridgepatch_brief())
+
+    assert packet["article_type"] == "HOW_TO"
+    assert packet["opening_mode"] == "RELATABLE"
+    assert packet["human_gate"]["required"] is True
+    assert packet["external_publication_performed"] is False
+    assert len(packet["verified_primary_info"]) == 1
+    assert len(packet["verified_evidence"]) == 3
+
+
+
+def test_story_requires_human_attested_primary_information():
+    source = bridgepatch_brief("STORY")
+    source["primary_info"][0]["attested"] = False
+
+    with pytest.raises(XArticleEngineError, match="STORY requires"):
+        build_generation_packet(source)
+
+
+
+def test_case_result_requires_verified_result_evidence():
+    with pytest.raises(XArticleEngineError, match="CASE_RESULT requires"):
+        build_generation_packet(bridgepatch_brief("CASE_RESULT"))
+
+
+
+def test_case_result_accepts_bound_result_evidence():
+    source = bridgepatch_brief("CASE_RESULT")
+    source["evidence"].append(
+        {
+            "claim": "A verified customer case reduced the target step from 20分 to 5分.",
+            "source_ref": "customer-case-001",
+            "status": "VERIFIED",
+            "kind": "CASE_RESULT",
+        }
+    )
+
+    packet = build_generation_packet(source)
+    assert packet["article_type"] == "CASE_RESULT"
+    assert packet["opening_mode"] == "PROOF_FIRST"
+
+
+
+def test_unverified_evidence_is_excluded_and_forces_review():
+    source = bridgepatch_brief()
+    source["evidence"].append(
+        {
+            "claim": "Customers save 90% of their time.",
+            "source_ref": "unsupported",
+            "status": "UNVERIFIED",
+            "kind": "RESULT",
+        }
+    )
+
+    packet = build_generation_packet(source)
+    assert packet["review_state"] == "REVIEW_REQUIRED"
+    assert all("90%" not in item["claim"] for item in packet["verified_evidence"])
+
+
+
+def test_audit_blocks_invented_numeric_claims():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = (
+        "毎週2時間かかる作業を見直します。"
+        "設計書は10,000円、実装は50,000円が標準で、通常5営業日です。"
+    )
+
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "BLOCKED"
+    assert any(
+        item["code"] == "UNBOUND_NUMERIC_CLAIM" and item["detail"] == "2時間"
+        for item in audit["findings"]
+    )
+
+
+
+def test_audit_allows_bound_numeric_claims_but_still_requires_human_review():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = "設計書は10,000円、実装は50,000円が標準で、通常5営業日です。"
+
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert audit["findings"] == []
+    assert audit["human_review_required"] is True
+
+
+
+def test_audit_blocks_strengthened_commercial_promise():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = "開始後は追加料金が発生しません。"
+
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "BLOCKED"
+    assert any(item["code"] == "UNBOUND_STRONG_CLAIM" for item in audit["findings"])

--- a/x_article_engine/README.md
+++ b/x_article_engine/README.md
@@ -1,0 +1,120 @@
+# X Article Engine v0
+
+X Article Engine v0 turns a bounded commercial/article brief into a model-agnostic generation packet, then audits the resulting draft before mandatory `/human` review.
+
+It does **not** publish to X and it does **not** call an LLM by itself.
+
+## Why this exists
+
+Dogfooding long-form X article generation showed a useful split:
+
+- narrative structure, objection handling, pacing, and CTA shaping can be delegated heavily;
+- facts, numbers, first-person history, customer outcomes, commercial promises, and risk boundaries cannot be left to unconstrained narrative completion.
+
+The v0 architecture is therefore:
+
+```text
+Article brief
+  -> Narrative plan
+  -> Evidence-bound generation packet
+  -> model draft
+  -> audit_draft
+  -> /human
+  -> Publication Bridge / manual X Articles handoff
+```
+
+## Inputs
+
+Required:
+
+- `offer`: what is being offered;
+- `target`: one concrete buyer/reader;
+- `pain`: one pre-purchase problem for this article;
+- `primary_info`: first-person material explicitly attested by the human;
+- `article_type`: `HOW_TO`, `STORY`, or `CASE_RESULT`;
+- `cta`: exactly one desired next action;
+- `evidence`: source-bound factual claims.
+
+Optional:
+
+- `topic_mode`: `PROCEDURAL`, `HABIT`, `RELATIONSHIP`, or `BUSINESS` (default `BUSINESS`);
+- `opening_mode`: `RELATABLE`, `PROOF_FIRST`, or `CONTRARIAN`.
+
+## Core doctrine
+
+Top-level reader journey:
+
+```text
+EMOTION -> LOGIC -> EASY_NEXT_ACTION
+```
+
+Article construction:
+
+```text
+reader state
+-> evidence when available
+-> anticipated objection
+-> cause
+-> solution
+-> likely stumbling point
+-> one action today
+-> one CTA
+```
+
+Depth is layered rather than split into separate beginner/advanced articles:
+
+```text
+L1: conclusion
+L2: why
+L3: conditions / exceptions / application
+```
+
+A strong human-attested episode may be used inside a HOW_TO article, and explanation may appear inside a STORY article. The selected article type is the dominant structure, not a rigid cage.
+
+## Evidence rules
+
+The engine deliberately does **not** require a quota such as “at least five numbers.” If the evidence contains two useful numbers, use two. If it contains none, the article may have none.
+
+Blocked behavior includes:
+
+- inventing plausible durations, percentages, customer counts, or results;
+- inventing first-person chronology, jobs, failures, emotions, or biography;
+- turning “scope/total/timing are agreed before start” into a stronger promise such as “no extra charges can ever occur”;
+- presenting a newly invented label as established technical terminology;
+- using `PROOF_FIRST` or `CASE_RESULT` without the evidence needed to support them.
+
+Derived arithmetic is acceptable only when every operand is verified and the derivation is explicit.
+
+`audit_draft()` v0 detects unbound Arabic-number claims with high-risk units (money, time, percentages, counts) and several strong commercial/guarantee phrases. It is intentionally conservative and incomplete: semantic truth still requires `/human`.
+
+## `/human` is mandatory
+
+`/human` is not an AI-smell remover. It is the boundary where the owner verifies identity-bearing material and adds real point of view.
+
+Before handoff, check:
+
+- Would I actually say this?
+- Are all first-person details true and mine?
+- Are numbers, prices, timing, results, and scope evidence-bound?
+- Did the draft invent emotions, biography, customer outcomes, or certainty?
+- Is there only one CTA?
+- Were factual/risk boundaries preserved while making the writing sound human?
+
+## Usage / credit policy
+
+**Not part of v0.**
+
+Generation quotas, credits, replenishment cadence, and product tiers are business/deployment policy, not article-quality logic. They should be set only after observing:
+
+- actual model cost per article;
+- support/coaching capacity;
+- real customer generation frequency;
+- revision frequency and `/human` workload;
+- abuse/fair-use behavior;
+- desired product tiers.
+
+Do not copy a third-party `5,000 credits` or monthly article allowance into the product simply because the reference implementation uses it.
+
+## Publication boundary
+
+This module never performs external publication. X Articles should continue through mandatory `/human` and a user-controlled handoff. Private X APIs, cookies, or session automation are out of scope.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,0 +1,13 @@
+from .core import (
+    XArticleEngineError,
+    audit_draft,
+    build_generation_packet,
+    normalize_brief,
+)
+
+__all__ = [
+    "XArticleEngineError",
+    "audit_draft",
+    "build_generation_packet",
+    "normalize_brief",
+]

--- a/x_article_engine/core.py
+++ b/x_article_engine/core.py
@@ -1,0 +1,335 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import re
+from typing import Iterable
+
+
+class XArticleEngineError(ValueError):
+    """Raised when an article brief is unsafe or incomplete for generation."""
+
+
+ARTICLE_TYPES = {"HOW_TO", "STORY", "CASE_RESULT"}
+OPENING_MODES = {"RELATABLE", "PROOF_FIRST", "CONTRARIAN"}
+TOPIC_MODES = {"PROCEDURAL", "HABIT", "RELATIONSHIP", "BUSINESS"}
+
+REQUIRED_FIELDS = (
+    "offer",
+    "target",
+    "pain",
+    "primary_info",
+    "article_type",
+    "cta",
+    "evidence",
+)
+
+# This is deliberately small. It catches the failure mode observed during
+# dogfooding: plausible-looking numbers being invented to make an article feel
+# more concrete. Bare structural counts ("3つ", "1工程") are not treated as
+# factual numeric claims by this v0 audit.
+NUMERIC_CLAIM_RE = re.compile(
+    r"(?<!\d)(?:\d{1,3}(?:,\d{3})+|\d+(?:\.\d+)?)"
+    r"(?:円|%|％|時間|分|秒|営業日|日間|日|週間|週|ヶ月|か月|カ月|月間|年|件|社|人|回)"
+)
+
+COMMERCIAL_STRENGTHENING_PHRASES = (
+    "追加料金が発生しません",
+    "追加料金は発生しません",
+    "絶対",
+    "100%",
+    "１００％",
+)
+
+
+
+def _text(value: object, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise XArticleEngineError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+
+def _normalize_evidence(items: object) -> tuple[list[dict], list[str]]:
+    if not isinstance(items, list) or not items:
+        raise XArticleEngineError("evidence must be a non-empty list")
+
+    verified: list[dict] = []
+    warnings: list[str] = []
+    for index, raw in enumerate(items, start=1):
+        if not isinstance(raw, dict):
+            raise XArticleEngineError("evidence entries must be objects")
+        claim = _text(raw.get("claim"), "evidence[].claim")
+        source_ref = _text(raw.get("source_ref"), "evidence[].source_ref")
+        status = _text(raw.get("status", "UNVERIFIED"), "evidence[].status").upper()
+        kind = _text(raw.get("kind", "FACT"), "evidence[].kind").upper()
+
+        if status == "VERIFIED":
+            verified.append(
+                {
+                    "claim": claim,
+                    "source_ref": source_ref,
+                    "status": "VERIFIED",
+                    "kind": kind,
+                }
+            )
+        else:
+            warnings.append(f"evidence {index} excluded because it is not VERIFIED: {claim}")
+
+    if not verified:
+        raise XArticleEngineError("no verified evidence remains")
+    return verified, warnings
+
+
+
+def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
+    if not isinstance(items, list):
+        raise XArticleEngineError("primary_info must be a list")
+
+    accepted: list[dict] = []
+    warnings: list[str] = []
+    for index, raw in enumerate(items, start=1):
+        if not isinstance(raw, dict):
+            raise XArticleEngineError("primary_info entries must be objects")
+        claim = _text(raw.get("claim"), "primary_info[].claim")
+        source_ref = _text(raw.get("source_ref", "human_attestation"), "primary_info[].source_ref")
+        attested = raw.get("attested", False)
+        if not isinstance(attested, bool):
+            raise XArticleEngineError("primary_info[].attested must be boolean")
+        if attested:
+            accepted.append(
+                {
+                    "claim": claim,
+                    "source_ref": source_ref,
+                    "attested": True,
+                }
+            )
+        else:
+            warnings.append(f"primary_info {index} excluded because it is not human-attested: {claim}")
+    return accepted, warnings
+
+
+
+def normalize_brief(source: dict) -> dict:
+    """Normalize one X Article brief and bind every usable factual input.
+
+    ``primary_info`` is reserved for first-person experience, belief, failure,
+    chronology, and other identity-bearing material. It is usable only when the
+    human explicitly attests it. ``evidence`` is for externally checkable facts,
+    prices, timing, scope, results, and other claims.
+    """
+    if not isinstance(source, dict):
+        raise XArticleEngineError("source must be an object")
+
+    missing = [field for field in REQUIRED_FIELDS if field not in source]
+    if missing:
+        raise XArticleEngineError(f"missing required fields: {', '.join(missing)}")
+
+    normalized = deepcopy(source)
+    for field in ("offer", "target", "pain", "cta"):
+        normalized[field] = _text(normalized[field], field)
+
+    article_type = _text(normalized["article_type"], "article_type").upper()
+    if article_type not in ARTICLE_TYPES:
+        raise XArticleEngineError("article_type must be HOW_TO, STORY, or CASE_RESULT")
+    normalized["article_type"] = article_type
+
+    topic_mode = _text(normalized.get("topic_mode", "BUSINESS"), "topic_mode").upper()
+    if topic_mode not in TOPIC_MODES:
+        raise XArticleEngineError(
+            "topic_mode must be PROCEDURAL, HABIT, RELATIONSHIP, or BUSINESS"
+        )
+    normalized["topic_mode"] = topic_mode
+
+    verified, evidence_warnings = _normalize_evidence(normalized["evidence"])
+    primary_info, primary_warnings = _normalize_primary_info(normalized["primary_info"])
+    normalized["verified_evidence"] = verified
+    normalized["verified_primary_info"] = primary_info
+    normalized["warnings"] = [*evidence_warnings, *primary_warnings]
+
+    if article_type == "STORY" and not primary_info:
+        raise XArticleEngineError("STORY requires at least one human-attested primary_info item")
+
+    if article_type == "CASE_RESULT":
+        has_result = any(item["kind"] in {"RESULT", "CASE_RESULT"} for item in verified)
+        if not has_result:
+            raise XArticleEngineError("CASE_RESULT requires verified result evidence")
+
+    opening_mode = normalized.get("opening_mode")
+    if opening_mode is None:
+        opening_mode = "PROOF_FIRST" if any(
+            item["kind"] in {"RESULT", "CASE_RESULT"} for item in verified
+        ) else "RELATABLE"
+    opening_mode = _text(opening_mode, "opening_mode").upper()
+    if opening_mode not in OPENING_MODES:
+        raise XArticleEngineError(
+            "opening_mode must be RELATABLE, PROOF_FIRST, or CONTRARIAN"
+        )
+    if opening_mode == "PROOF_FIRST" and not verified:
+        raise XArticleEngineError("PROOF_FIRST requires verified evidence")
+    normalized["opening_mode"] = opening_mode
+
+    normalized["review_state"] = "REVIEW_REQUIRED" if normalized["warnings"] else "DRAFT"
+    return normalized
+
+
+
+def build_generation_packet(source: dict) -> dict:
+    """Compile a safe, model-agnostic generation packet.
+
+    This function does not call an LLM and does not publish. It defines what a
+    downstream writer is allowed to use and how the article should be shaped.
+    """
+    brief = normalize_brief(source)
+
+    if brief["topic_mode"] == "PROCEDURAL":
+        shape = "Use steps only where the reader is literally performing a procedure."
+    elif brief["topic_mode"] == "HABIT":
+        shape = "Prefer explanatory reading; do not turn ordinary life into a mechanical manual."
+    elif brief["topic_mode"] == "RELATIONSHIP":
+        shape = "Protect reader dignity; explain causes before tactics and never shame the reader."
+    else:
+        shape = "Use concrete business logic, scope, trade-offs, and reproducible reasoning."
+
+    if brief["article_type"] == "HOW_TO":
+        body_pattern = [
+            "conclusion_or_overview",
+            "method",
+            "why_it_works",
+            "stumbling_points",
+            "conditions_and_limits",
+        ]
+    elif brief["article_type"] == "STORY":
+        body_pattern = [
+            "interesting_destination_or_failure",
+            "previous_state",
+            "turning_point",
+            "what_changed",
+            "lesson",
+            "reader_connection",
+        ]
+    else:
+        body_pattern = [
+            "before",
+            "after",
+            "what_changed",
+            "why_it_worked",
+            "reproduction_conditions",
+        ]
+
+    return {
+        "schema_version": "0.1",
+        "offer": brief["offer"],
+        "target": brief["target"],
+        "pain": brief["pain"],
+        "article_type": brief["article_type"],
+        "topic_mode": brief["topic_mode"],
+        "opening_mode": brief["opening_mode"],
+        "cta": brief["cta"],
+        "verified_evidence": brief["verified_evidence"],
+        "verified_primary_info": brief["verified_primary_info"],
+        "narrative": {
+            "top_level_order": ["EMOTION", "LOGIC", "EASY_NEXT_ACTION"],
+            "body_pattern": body_pattern,
+            "depth_layers": ["L1_CONCLUSION", "L2_REASON", "L3_CONDITIONS_EXCEPTIONS"],
+            "sequence": [
+                "reader_state",
+                "evidence_if_available",
+                "anticipated_objection",
+                "cause",
+                "solution",
+                "stumbling_point",
+                "one_action_today",
+                "single_cta",
+            ],
+            "topic_shape": shape,
+        },
+        "generation_constraints": [
+            "Use only verified_evidence for externally checkable facts, prices, timing, scope, and results.",
+            "Use first-person history, failure, emotion, belief, or chronology only from verified_primary_info.",
+            "Never invent a number to satisfy a density or title rule; a numberless title is valid.",
+            "Derived arithmetic is allowed only when every operand is verified and the derivation is explicit.",
+            "Do not strengthen commercial or contractual wording beyond the verified claim.",
+            "Do not present an invented label as established terminology.",
+            "Explain specialist terms inline in plain language.",
+            "Give useful substance instead of withholding the core method.",
+            "Give exactly one practical next action and one CTA.",
+            "Do not blame or rank the reader.",
+            "Natural hybridization is allowed when strong human-attested primary information helps the article, but the selected article_type remains the dominant structure.",
+            "The draft is not publishable until /human review passes.",
+        ],
+        "human_gate": {
+            "required": True,
+            "checks": [
+                "Would I actually say this?",
+                "Are all first-person details true and mine?",
+                "Are all numbers, prices, timing, results, and scope evidence-bound?",
+                "Did the draft invent emotion, biography, customer outcomes, or certainty?",
+                "Does the CTA still match the offer and only ask for one next action?",
+                "Did the rewrite preserve factual and risk boundaries?",
+            ],
+        },
+        "warnings": brief["warnings"],
+        "review_state": brief["review_state"],
+        "external_publication_performed": False,
+    }
+
+
+
+def _bound_text(packet: dict) -> str:
+    chunks: list[str] = [packet["offer"], packet["target"], packet["pain"], packet["cta"]]
+    chunks.extend(item["claim"] for item in packet["verified_evidence"])
+    chunks.extend(item["claim"] for item in packet["verified_primary_info"])
+    return "\n".join(chunks)
+
+
+
+def _numeric_claims(text: str) -> set[str]:
+    return set(NUMERIC_CLAIM_RE.findall(text))
+
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run a conservative pre-/human audit over a generated draft.
+
+    v0 deliberately focuses on high-value failure classes rather than pretending
+    to prove every sentence automatically. Human review remains mandatory.
+    """
+    draft = _text(draft, "draft")
+    if not isinstance(packet, dict):
+        raise XArticleEngineError("packet must be an object")
+
+    allowed_numeric = _numeric_claims(_bound_text(packet))
+    observed_numeric = _numeric_claims(draft)
+    unbound_numeric = sorted(observed_numeric - allowed_numeric)
+
+    verified_text = _bound_text(packet)
+    strengthened = [
+        phrase
+        for phrase in COMMERCIAL_STRENGTHENING_PHRASES
+        if phrase in draft and phrase not in verified_text
+    ]
+
+    findings: list[dict] = []
+    for claim in unbound_numeric:
+        findings.append(
+            {
+                "code": "UNBOUND_NUMERIC_CLAIM",
+                "severity": "BLOCK",
+                "detail": claim,
+            }
+        )
+    for phrase in strengthened:
+        findings.append(
+            {
+                "code": "UNBOUND_STRONG_CLAIM",
+                "severity": "BLOCK",
+                "detail": phrase,
+            }
+        )
+
+    return {
+        "status": "BLOCKED" if any(item["severity"] == "BLOCK" for item in findings) else "HUMAN_REVIEW_REQUIRED",
+        "findings": findings,
+        "human_review_required": True,
+        "external_publication_performed": False,
+    }


### PR DESCRIPTION
## Summary
- add model-agnostic X Article generation packet compiler
- separate narrative shaping from evidence and first-person attestation
- require verified result evidence for CASE_RESULT and human-attested material for STORY
- add draft audit for unbound numeric claims and strengthened commercial promises
- make `/human` mandatory before publication handoff
- explicitly leave credit/quota/replenishment policy out of v0

## Why
Dogfooding the reference X-article generator showed strong narrative structure but repeatable failure modes around invented durations, numbers, biography, and strengthened commercial claims. This v0 keeps the useful narrative patterns while failing closed on high-value evidence boundaries.

## Tests
Adds `tests/test_x_article_engine.py` covering evidence binding, story/case prerequisites, invented numeric claims, commercial-strengthening claims, and mandatory human review.

External publication remains USER_ONLY.