### PR TITLE
METEOR harden X Article Engine v0.2

### DIFF
--- a/tests/test_x_article_engine.py
+++ b/tests/test_x_article_engine.py
@@ -3,37 +3,44 @@ import pytest
 from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
 
 
-
 def bridgepatch_brief(article_type="HOW_TO"):
     return {
-        "offer": "BridgePatch: one bounded manual workflow step is assessed first, then optionally specified and implemented.",
-        "target": "A small business owner repeating manual transfer, aggregation, checking, or drafting work every week.",
-        "pain": "AI seems useful, but they do not know how to describe the work safely or what to automate first.",
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
         "primary_info": [
             {
-                "claim": "During Vlog-tool development, supporting test, debug, operation-recording, and repair mechanisms kept expanding around the original tool; I called this tendency シムシティ化.",
+                "claim": "Vlogツール開発では、本体の周囲にテスト、デバッグ、操作記録、修復の仕組みが増えていった。私はこの傾向をシムシティ化と呼んでいた。",
                 "source_ref": "human_attestation:bridgepatch-origin",
                 "attested": True,
+                "kind": "EXPERIENCE",
             }
         ],
         "article_type": article_type,
         "topic_mode": "BUSINESS",
-        "cta": "Use the free BridgePatch fit check.",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "source_refs": [
+            {
+                "id": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "PUBLIC_PAGE",
+            }
+        ],
         "evidence": [
             {
-                "claim": "The BridgePatch provisional implementation design document costs 10,000円 including tax and does not include tool implementation.",
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
                 "source_ref": "bridgepatch-sales-page",
                 "status": "VERIFIED",
                 "kind": "COMMERCIAL",
             },
             {
-                "claim": "A simple one-action tool is standard 50,000円 including tax, with scope, total price, and timing agreed before start.",
+                "claim": "1アクション簡易ツールは50,000円（税込）が標準で、対象範囲・総額・納期は開始前に確定する。",
                 "source_ref": "bridgepatch-sales-page",
                 "status": "VERIFIED",
                 "kind": "COMMERCIAL",
             },
             {
-                "claim": "The design document is normally delivered within 5営業日 after required information is available.",
+                "claim": "必要情報が揃ってから通常5営業日以内を目安に設計書を納品する。",
                 "source_ref": "bridgepatch-sales-page",
                 "status": "VERIFIED",
                 "kind": "TIMING",
@@ -42,26 +49,32 @@ def bridgepatch_brief(article_type="HOW_TO"):
     }
 
 
-
 def test_build_packet_preserves_human_and_evidence_boundaries():
     packet = build_generation_packet(bridgepatch_brief())
-
+    assert packet["schema_version"] == "0.2"
     assert packet["article_type"] == "HOW_TO"
     assert packet["opening_mode"] == "RELATABLE"
     assert packet["human_gate"]["required"] is True
+    assert packet["publication_state"] == "BLOCKED_PENDING_HUMAN"
+    assert packet["publication_authority"] == "USER_ONLY"
     assert packet["external_publication_performed"] is False
     assert len(packet["verified_primary_info"]) == 1
     assert len(packet["verified_evidence"]) == 3
-
+    assert len(packet["verified_source_refs"]) == 1
 
 
 def test_story_requires_human_attested_primary_information():
     source = bridgepatch_brief("STORY")
     source["primary_info"][0]["attested"] = False
-
     with pytest.raises(XArticleEngineError, match="STORY requires"):
         build_generation_packet(source)
 
+
+def test_primary_info_cannot_masquerade_as_result_evidence():
+    source = bridgepatch_brief()
+    source["primary_info"][0]["kind"] = "CASE_RESULT"
+    with pytest.raises(XArticleEngineError, match="primary_info"):
+        build_generation_packet(source)
 
 
 def test_case_result_requires_verified_result_evidence():
@@ -69,48 +82,60 @@ def test_case_result_requires_verified_result_evidence():
         build_generation_packet(bridgepatch_brief("CASE_RESULT"))
 
 
-
 def test_case_result_accepts_bound_result_evidence():
     source = bridgepatch_brief("CASE_RESULT")
+    source["source_refs"].append(
+        {"id": "customer-case-001", "status": "VERIFIED", "kind": "CASE"}
+    )
     source["evidence"].append(
         {
-            "claim": "A verified customer case reduced the target step from 20分 to 5分.",
+            "claim": "確認済みの顧客事例では対象工程が20分から5分になった。",
             "source_ref": "customer-case-001",
             "status": "VERIFIED",
             "kind": "CASE_RESULT",
         }
     )
-
     packet = build_generation_packet(source)
     assert packet["article_type"] == "CASE_RESULT"
     assert packet["opening_mode"] == "PROOF_FIRST"
 
 
-
-def test_unverified_evidence_is_excluded_and_forces_review():
+def test_undeclared_verified_source_is_not_trusted():
     source = bridgepatch_brief()
     source["evidence"].append(
         {
-            "claim": "Customers save 90% of their time.",
-            "source_ref": "unsupported",
-            "status": "UNVERIFIED",
+            "claim": "顧客の作業時間が90%減った。",
+            "source_ref": "made-up-source",
+            "status": "VERIFIED",
             "kind": "RESULT",
         }
     )
-
     packet = build_generation_packet(source)
     assert packet["review_state"] == "REVIEW_REQUIRED"
     assert all("90%" not in item["claim"] for item in packet["verified_evidence"])
 
 
+def test_unverified_declared_source_is_not_trusted():
+    source = bridgepatch_brief()
+    source["source_refs"].append(
+        {"id": "rumor", "status": "UNVERIFIED", "kind": "NOTE"}
+    )
+    source["evidence"].append(
+        {
+            "claim": "顧客の作業時間が90%減った。",
+            "source_ref": "rumor",
+            "status": "VERIFIED",
+            "kind": "RESULT",
+        }
+    )
+    packet = build_generation_packet(source)
+    assert packet["review_state"] == "REVIEW_REQUIRED"
+    assert all("90%" not in item["claim"] for item in packet["verified_evidence"])
+
 
 def test_audit_blocks_invented_numeric_claims():
     packet = build_generation_packet(bridgepatch_brief())
-    draft = (
-        "毎週2時間かかる作業を見直します。"
-        "設計書は10,000円、実装は50,000円が標準で、通常5営業日です。"
-    )
-
+    draft = "毎週2時間かかる作業。設計書は10,000円、実装は50,000円が標準で、通常5営業日。"
     audit = audit_draft(draft, packet)
     assert audit["status"] == "BLOCKED"
     assert any(
@@ -119,22 +144,25 @@ def test_audit_blocks_invented_numeric_claims():
     )
 
 
+def test_audit_normalizes_full_width_digits_before_checking():
+    packet = build_generation_packet(bridgepatch_brief())
+    audit = audit_draft("毎週２時間かかります。", packet)
+    assert audit["status"] == "BLOCKED"
+    assert any(item["detail"] == "2時間" for item in audit["findings"])
+
 
 def test_audit_allows_bound_numeric_claims_but_still_requires_human_review():
     packet = build_generation_packet(bridgepatch_brief())
     draft = "設計書は10,000円、実装は50,000円が標準で、通常5営業日です。"
-
     audit = audit_draft(draft, packet)
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
     assert audit["findings"] == []
     assert audit["human_review_required"] is True
-
+    assert audit["publication_state"] == "BLOCKED_PENDING_HUMAN"
 
 
 def test_audit_blocks_strengthened_commercial_promise():
     packet = build_generation_packet(bridgepatch_brief())
-    draft = "開始後は追加料金が発生しません。"
-
-    audit = audit_draft(draft, packet)
+    audit = audit_draft("開始後は追加料金が発生しません。", packet)
     assert audit["status"] == "BLOCKED"
     assert any(item["code"] == "UNBOUND_STRONG_CLAIM" for item in audit["findings"])

--- a/tests/test_x_article_engine.py
+++ b/tests/test_x_article_engine.py
@@ -3,6 +3,16 @@ import pytest
 from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
 
 
+def bridgepatch_sources():
+    return [
+        {
+            "id": "bridgepatch-sales-page",
+            "status": "VERIFIED",
+            "kind": "PUBLIC_PAGE",
+        }
+    ]
+
+
 def bridgepatch_brief(article_type="HOW_TO"):
     return {
         "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
@@ -19,13 +29,6 @@ def bridgepatch_brief(article_type="HOW_TO"):
         "article_type": article_type,
         "topic_mode": "BUSINESS",
         "cta": "BridgePatchの無料適合確認を使う。",
-        "source_refs": [
-            {
-                "id": "bridgepatch-sales-page",
-                "status": "VERIFIED",
-                "kind": "PUBLIC_PAGE",
-            }
-        ],
         "evidence": [
             {
                 "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
@@ -49,8 +52,15 @@ def bridgepatch_brief(article_type="HOW_TO"):
     }
 
 
+def build(source=None, sources=None):
+    return build_generation_packet(
+        source or bridgepatch_brief(),
+        trusted_source_refs=sources or bridgepatch_sources(),
+    )
+
+
 def test_build_packet_preserves_human_and_evidence_boundaries():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     assert packet["schema_version"] == "0.2"
     assert packet["article_type"] == "HOW_TO"
     assert packet["opening_mode"] == "RELATABLE"
@@ -67,26 +77,26 @@ def test_story_requires_human_attested_primary_information():
     source = bridgepatch_brief("STORY")
     source["primary_info"][0]["attested"] = False
     with pytest.raises(XArticleEngineError, match="STORY requires"):
-        build_generation_packet(source)
+        build(source)
 
 
 def test_primary_info_cannot_masquerade_as_result_evidence():
     source = bridgepatch_brief()
     source["primary_info"][0]["kind"] = "CASE_RESULT"
     with pytest.raises(XArticleEngineError, match="primary_info"):
-        build_generation_packet(source)
+        build(source)
 
 
 def test_case_result_requires_verified_result_evidence():
     with pytest.raises(XArticleEngineError, match="CASE_RESULT requires"):
-        build_generation_packet(bridgepatch_brief("CASE_RESULT"))
+        build(bridgepatch_brief("CASE_RESULT"))
 
 
 def test_case_result_accepts_bound_result_evidence():
     source = bridgepatch_brief("CASE_RESULT")
-    source["source_refs"].append(
+    sources = bridgepatch_sources() + [
         {"id": "customer-case-001", "status": "VERIFIED", "kind": "CASE"}
-    )
+    ]
     source["evidence"].append(
         {
             "claim": "確認済みの顧客事例では対象工程が20分から5分になった。",
@@ -95,13 +105,16 @@ def test_case_result_accepts_bound_result_evidence():
             "kind": "CASE_RESULT",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source, sources)
     assert packet["article_type"] == "CASE_RESULT"
     assert packet["opening_mode"] == "PROOF_FIRST"
 
 
-def test_undeclared_verified_source_is_not_trusted():
+def test_user_brief_cannot_self_declare_verified_source():
     source = bridgepatch_brief()
+    source["source_refs"] = [
+        {"id": "made-up-source", "status": "VERIFIED", "kind": "CASE"}
+    ]
     source["evidence"].append(
         {
             "claim": "顧客の作業時間が90%減った。",
@@ -110,16 +123,13 @@ def test_undeclared_verified_source_is_not_trusted():
             "kind": "RESULT",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source)
     assert packet["review_state"] == "REVIEW_REQUIRED"
     assert all("90%" not in item["claim"] for item in packet["verified_evidence"])
 
 
-def test_unverified_declared_source_is_not_trusted():
+def test_unverified_trusted_registry_source_is_not_trusted():
     source = bridgepatch_brief()
-    source["source_refs"].append(
-        {"id": "rumor", "status": "UNVERIFIED", "kind": "NOTE"}
-    )
     source["evidence"].append(
         {
             "claim": "顧客の作業時間が90%減った。",
@@ -128,13 +138,16 @@ def test_unverified_declared_source_is_not_trusted():
             "kind": "RESULT",
         }
     )
-    packet = build_generation_packet(source)
+    sources = bridgepatch_sources() + [
+        {"id": "rumor", "status": "UNVERIFIED", "kind": "NOTE"}
+    ]
+    packet = build(source, sources)
     assert packet["review_state"] == "REVIEW_REQUIRED"
     assert all("90%" not in item["claim"] for item in packet["verified_evidence"])
 
 
 def test_audit_blocks_invented_numeric_claims():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     draft = "毎週2時間かかる作業。設計書は10,000円、実装は50,000円が標準で、通常5営業日。"
     audit = audit_draft(draft, packet)
     assert audit["status"] == "BLOCKED"
@@ -145,14 +158,14 @@ def test_audit_blocks_invented_numeric_claims():
 
 
 def test_audit_normalizes_full_width_digits_before_checking():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     audit = audit_draft("毎週２時間かかります。", packet)
     assert audit["status"] == "BLOCKED"
     assert any(item["detail"] == "2時間" for item in audit["findings"])
 
 
 def test_audit_allows_bound_numeric_claims_but_still_requires_human_review():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     draft = "設計書は10,000円、実装は50,000円が標準で、通常5営業日です。"
     audit = audit_draft(draft, packet)
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
@@ -162,7 +175,7 @@ def test_audit_allows_bound_numeric_claims_but_still_requires_human_review():
 
 
 def test_audit_blocks_strengthened_commercial_promise():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     audit = audit_draft("開始後は追加料金が発生しません。", packet)
     assert audit["status"] == "BLOCKED"
     assert any(item["code"] == "UNBOUND_STRONG_CLAIM" for item in audit["findings"])

--- a/tests/test_x_article_engine_meteor.py
+++ b/tests/test_x_article_engine_meteor.py
@@ -1,0 +1,244 @@
+import pytest
+
+from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
+
+
+def bridgepatch_brief(article_type="HOW_TO"):
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "Vlogツール開発では、本体の周囲にテスト、デバッグ、操作記録、修復の仕組みが増えていった。私はこの傾向をシムシティ化と呼んでいた。",
+                "source_ref": "human_attestation:bridgepatch-origin",
+                "attested": True,
+                "kind": "EXPERIENCE",
+            }
+        ],
+        "article_type": article_type,
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "source_refs": [
+            {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+        ],
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "1アクション簡易ツールは50,000円（税込）が標準で、対象範囲・総額・納期は開始前に確定する。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "必要情報が揃ってから通常5営業日以内を目安に設計書を納品する。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "TIMING",
+            },
+        ],
+    }
+
+
+# 1. DA: invented numbers and fuzzy quantities
+
+def test_meteor_01_da_blocks_kanji_duration_and_fuzzy_time():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = "この作業は二時間かかります。以前は何十時間も使っていました。"
+    audit = audit_draft(draft, packet)
+    codes = {item["code"] for item in audit["findings"]}
+    assert audit["status"] == "BLOCKED"
+    assert "UNBOUND_NUMERIC_CLAIM" in codes
+    assert "UNBOUND_FUZZY_QUANT_CLAIM" in codes
+
+
+def test_meteor_01_counter_da_allows_evidence_bound_numbers():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = "設計書は10,000円。実装は50,000円が標準。通常5営業日以内を目安に納品します。"
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert audit["findings"] == []
+
+
+# 2. DA: invented biography / chronology
+
+def test_meteor_02_da_blocks_unattested_first_person_biography():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = "私は数年前から業務自動化の仕事をしてきました。"
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "BLOCKED"
+    assert any(item["code"] == "UNBOUND_IDENTITY_DETAIL" for item in audit["findings"])
+
+
+def test_meteor_02_counter_da_allows_attested_identity_detail():
+    source = bridgepatch_brief()
+    source["primary_info"].append(
+        {
+            "claim": "私は以前、Vlogツールの開発をしていた。",
+            "source_ref": "human_attestation:vlog-history",
+            "attested": True,
+            "kind": "CHRONOLOGY",
+        }
+    )
+    packet = build_generation_packet(source)
+    audit = audit_draft("私は以前、Vlogツールの開発をしていた。", packet)
+    assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert audit["findings"] == []
+
+
+# 3. DA: fake CASE_RESULT
+
+def test_meteor_03_da_status_verified_is_not_enough_for_case_result():
+    source = bridgepatch_brief("CASE_RESULT")
+    source["evidence"].append(
+        {
+            "claim": "顧客の作業が90%減った。",
+            "source_ref": "invented-case",
+            "status": "VERIFIED",
+            "kind": "CASE_RESULT",
+        }
+    )
+    with pytest.raises(XArticleEngineError, match="CASE_RESULT requires"):
+        build_generation_packet(source)
+
+
+def test_meteor_03_counter_da_declared_verified_case_is_accepted():
+    source = bridgepatch_brief("CASE_RESULT")
+    source["source_refs"].append(
+        {"id": "customer-case-verified", "status": "VERIFIED", "kind": "CASE"}
+    )
+    source["evidence"].append(
+        {
+            "claim": "確認済みの顧客事例で対象工程が20分から5分になった。",
+            "source_ref": "customer-case-verified",
+            "status": "VERIFIED",
+            "kind": "CASE_RESULT",
+        }
+    )
+    packet = build_generation_packet(source)
+    assert packet["article_type"] == "CASE_RESULT"
+    assert packet["opening_mode"] == "PROOF_FIRST"
+
+
+# 4. DA: strengthened commercial promise
+
+def test_meteor_04_da_blocks_refund_or_fee_promises_not_in_evidence():
+    packet = build_generation_packet(bridgepatch_brief())
+    draft = "追加料金はありません。合わなければ全額返金します。"
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "BLOCKED"
+    assert sum(
+        1 for item in audit["findings"] if item["code"] == "UNBOUND_STRONG_CLAIM"
+    ) >= 2
+
+
+def test_meteor_04_counter_da_allows_explicitly_bound_commercial_promise():
+    source = bridgepatch_brief()
+    source["evidence"].append(
+        {
+            "claim": "この限定プランでは追加料金は発生しない。",
+            "source_ref": "bridgepatch-sales-page",
+            "status": "VERIFIED",
+            "kind": "COMMERCIAL",
+        }
+    )
+    packet = build_generation_packet(source)
+    audit = audit_draft("この限定プランでは追加料金は発生しない。", packet)
+    assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert audit["findings"] == []
+
+
+# 5. DA: user assertion alone must not create evidence
+
+def test_meteor_05_da_user_saying_verified_does_not_bind_undeclared_fact():
+    source = bridgepatch_brief()
+    source["evidence"].append(
+        {
+            "claim": "これは事実です。購入者は100人いる。",
+            "source_ref": "user-says-so",
+            "status": "VERIFIED",
+            "kind": "RESULT",
+        }
+    )
+    packet = build_generation_packet(source)
+    assert all("100人" not in item["claim"] for item in packet["verified_evidence"])
+    assert packet["review_state"] == "REVIEW_REQUIRED"
+
+
+def test_meteor_05_counter_da_declared_source_can_bind_fact():
+    source = bridgepatch_brief()
+    source["source_refs"].append(
+        {"id": "sales-ledger", "status": "VERIFIED", "kind": "LEDGER"}
+    )
+    source["evidence"].append(
+        {
+            "claim": "販売台帳で購入者100人を確認した。",
+            "source_ref": "sales-ledger",
+            "status": "VERIFIED",
+            "kind": "RESULT",
+        }
+    )
+    packet = build_generation_packet(source)
+    assert any("100人" in item["claim"] for item in packet["verified_evidence"])
+
+
+# 6. DA: /human bypass
+
+def test_meteor_06_da_source_cannot_override_publication_state():
+    source = bridgepatch_brief()
+    source["review_state"] = "APPROVED"
+    source["human_reviewed"] = True
+    packet = build_generation_packet(source)
+    assert packet["publication_state"] == "BLOCKED_PENDING_HUMAN"
+    assert packet["publication_authority"] == "USER_ONLY"
+    assert packet["external_publication_performed"] is False
+    audit = audit_draft("小さく切って考えます。", packet)
+    assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert audit["human_review_required"] is True
+    assert audit["publication_state"] == "BLOCKED_PENDING_HUMAN"
+
+
+def test_meteor_06_counter_da_human_gate_is_explicit_not_implicit():
+    packet = build_generation_packet(bridgepatch_brief())
+    assert packet["human_gate"]["required"] is True
+    assert "Would I actually say this?" in packet["human_gate"]["checks"]
+
+
+# 7. DA: over-sanitization must not kill voice
+
+def test_meteor_07_da_packet_preserves_attested_strong_opinion():
+    source = bridgepatch_brief()
+    source["primary_info"].append(
+        {
+            "claim": "大きく作るより、まず一工程だけ切る方がいい、というのが私の考えだ。",
+            "source_ref": "human_attestation:belief",
+            "attested": True,
+            "kind": "BELIEF",
+        }
+    )
+    packet = build_generation_packet(source)
+    assert packet["voice_policy"]["preserve_attested_opinion"] is True
+    assert packet["voice_policy"]["hedge_verified_facts"] is False
+    assert "Strong opinions are allowed" in packet["voice_policy"]["strong_judgment_rule"]
+
+
+def test_meteor_07_counter_da_strong_attested_voice_is_not_blocked():
+    source = bridgepatch_brief()
+    source["primary_info"].append(
+        {
+            "claim": "大きく作るより、まず一工程だけ切る方がいい、というのが私の考えだ。",
+            "source_ref": "human_attestation:belief",
+            "attested": True,
+            "kind": "BELIEF",
+        }
+    )
+    packet = build_generation_packet(source)
+    draft = "大きく作るより、まず一工程だけ切る方がいい。これは私の考えです。"
+    audit = audit_draft(draft, packet)
+    assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert audit["findings"] == []

--- a/tests/test_x_article_engine_meteor.py
+++ b/tests/test_x_article_engine_meteor.py
@@ -3,7 +3,13 @@ import pytest
 from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
 
 
-def bridgepatch_brief(article_type="HOW_TO"):
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def brief(article_type="HOW_TO"):
     return {
         "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
         "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
@@ -19,9 +25,6 @@ def bridgepatch_brief(article_type="HOW_TO"):
         "article_type": article_type,
         "topic_mode": "BUSINESS",
         "cta": "BridgePatchの無料適合確認を使う。",
-        "source_refs": [
-            {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
-        ],
         "evidence": [
             {
                 "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
@@ -45,10 +48,17 @@ def bridgepatch_brief(article_type="HOW_TO"):
     }
 
 
+def build(source=None, trusted=None):
+    return build_generation_packet(
+        source or brief(),
+        trusted_source_refs=trusted or sources(),
+    )
+
+
 # 1. DA: invented numbers and fuzzy quantities
 
 def test_meteor_01_da_blocks_kanji_duration_and_fuzzy_time():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     draft = "この作業は二時間かかります。以前は何十時間も使っていました。"
     audit = audit_draft(draft, packet)
     codes = {item["code"] for item in audit["findings"]}
@@ -58,9 +68,11 @@ def test_meteor_01_da_blocks_kanji_duration_and_fuzzy_time():
 
 
 def test_meteor_01_counter_da_allows_evidence_bound_numbers():
-    packet = build_generation_packet(bridgepatch_brief())
-    draft = "設計書は10,000円。実装は50,000円が標準。通常5営業日以内を目安に納品します。"
-    audit = audit_draft(draft, packet)
+    packet = build()
+    audit = audit_draft(
+        "設計書は10,000円。実装は50,000円が標準。通常5営業日以内を目安に納品します。",
+        packet,
+    )
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
     assert audit["findings"] == []
 
@@ -68,15 +80,14 @@ def test_meteor_01_counter_da_allows_evidence_bound_numbers():
 # 2. DA: invented biography / chronology
 
 def test_meteor_02_da_blocks_unattested_first_person_biography():
-    packet = build_generation_packet(bridgepatch_brief())
-    draft = "私は数年前から業務自動化の仕事をしてきました。"
-    audit = audit_draft(draft, packet)
+    packet = build()
+    audit = audit_draft("私は数年前から業務自動化の仕事をしてきました。", packet)
     assert audit["status"] == "BLOCKED"
     assert any(item["code"] == "UNBOUND_IDENTITY_DETAIL" for item in audit["findings"])
 
 
 def test_meteor_02_counter_da_allows_attested_identity_detail():
-    source = bridgepatch_brief()
+    source = brief()
     source["primary_info"].append(
         {
             "claim": "私は以前、Vlogツールの開発をしていた。",
@@ -85,7 +96,7 @@ def test_meteor_02_counter_da_allows_attested_identity_detail():
             "kind": "CHRONOLOGY",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source)
     audit = audit_draft("私は以前、Vlogツールの開発をしていた。", packet)
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
     assert audit["findings"] == []
@@ -94,7 +105,10 @@ def test_meteor_02_counter_da_allows_attested_identity_detail():
 # 3. DA: fake CASE_RESULT
 
 def test_meteor_03_da_status_verified_is_not_enough_for_case_result():
-    source = bridgepatch_brief("CASE_RESULT")
+    source = brief("CASE_RESULT")
+    source["source_refs"] = [
+        {"id": "invented-case", "status": "VERIFIED", "kind": "CASE"}
+    ]
     source["evidence"].append(
         {
             "claim": "顧客の作業が90%減った。",
@@ -104,14 +118,14 @@ def test_meteor_03_da_status_verified_is_not_enough_for_case_result():
         }
     )
     with pytest.raises(XArticleEngineError, match="CASE_RESULT requires"):
-        build_generation_packet(source)
+        build(source)
 
 
-def test_meteor_03_counter_da_declared_verified_case_is_accepted():
-    source = bridgepatch_brief("CASE_RESULT")
-    source["source_refs"].append(
+def test_meteor_03_counter_da_trusted_verified_case_is_accepted():
+    source = brief("CASE_RESULT")
+    trusted = sources() + [
         {"id": "customer-case-verified", "status": "VERIFIED", "kind": "CASE"}
-    )
+    ]
     source["evidence"].append(
         {
             "claim": "確認済みの顧客事例で対象工程が20分から5分になった。",
@@ -120,7 +134,7 @@ def test_meteor_03_counter_da_declared_verified_case_is_accepted():
             "kind": "CASE_RESULT",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source, trusted)
     assert packet["article_type"] == "CASE_RESULT"
     assert packet["opening_mode"] == "PROOF_FIRST"
 
@@ -128,9 +142,8 @@ def test_meteor_03_counter_da_declared_verified_case_is_accepted():
 # 4. DA: strengthened commercial promise
 
 def test_meteor_04_da_blocks_refund_or_fee_promises_not_in_evidence():
-    packet = build_generation_packet(bridgepatch_brief())
-    draft = "追加料金はありません。合わなければ全額返金します。"
-    audit = audit_draft(draft, packet)
+    packet = build()
+    audit = audit_draft("追加料金はありません。合わなければ全額返金します。", packet)
     assert audit["status"] == "BLOCKED"
     assert sum(
         1 for item in audit["findings"] if item["code"] == "UNBOUND_STRONG_CLAIM"
@@ -138,7 +151,7 @@ def test_meteor_04_da_blocks_refund_or_fee_promises_not_in_evidence():
 
 
 def test_meteor_04_counter_da_allows_explicitly_bound_commercial_promise():
-    source = bridgepatch_brief()
+    source = brief()
     source["evidence"].append(
         {
             "claim": "この限定プランでは追加料金は発生しない。",
@@ -147,16 +160,19 @@ def test_meteor_04_counter_da_allows_explicitly_bound_commercial_promise():
             "kind": "COMMERCIAL",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source)
     audit = audit_draft("この限定プランでは追加料金は発生しない。", packet)
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
     assert audit["findings"] == []
 
 
-# 5. DA: user assertion alone must not create evidence
+# 5. DA: "I say it's true" is not evidence
 
-def test_meteor_05_da_user_saying_verified_does_not_bind_undeclared_fact():
-    source = bridgepatch_brief()
+def test_meteor_05_da_user_cannot_self_verify_a_source_inside_brief():
+    source = brief()
+    source["source_refs"] = [
+        {"id": "user-says-so", "status": "VERIFIED", "kind": "LEDGER"}
+    ]
     source["evidence"].append(
         {
             "claim": "これは事実です。購入者は100人いる。",
@@ -165,16 +181,16 @@ def test_meteor_05_da_user_saying_verified_does_not_bind_undeclared_fact():
             "kind": "RESULT",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source)
     assert all("100人" not in item["claim"] for item in packet["verified_evidence"])
     assert packet["review_state"] == "REVIEW_REQUIRED"
 
 
-def test_meteor_05_counter_da_declared_source_can_bind_fact():
-    source = bridgepatch_brief()
-    source["source_refs"].append(
+def test_meteor_05_counter_da_trusted_registry_can_bind_fact():
+    source = brief()
+    trusted = sources() + [
         {"id": "sales-ledger", "status": "VERIFIED", "kind": "LEDGER"}
-    )
+    ]
     source["evidence"].append(
         {
             "claim": "販売台帳で購入者100人を確認した。",
@@ -183,17 +199,18 @@ def test_meteor_05_counter_da_declared_source_can_bind_fact():
             "kind": "RESULT",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source, trusted)
     assert any("100人" in item["claim"] for item in packet["verified_evidence"])
 
 
 # 6. DA: /human bypass
 
 def test_meteor_06_da_source_cannot_override_publication_state():
-    source = bridgepatch_brief()
+    source = brief()
     source["review_state"] = "APPROVED"
     source["human_reviewed"] = True
-    packet = build_generation_packet(source)
+    source["publication_state"] = "READY"
+    packet = build(source)
     assert packet["publication_state"] == "BLOCKED_PENDING_HUMAN"
     assert packet["publication_authority"] == "USER_ONLY"
     assert packet["external_publication_performed"] is False
@@ -204,7 +221,7 @@ def test_meteor_06_da_source_cannot_override_publication_state():
 
 
 def test_meteor_06_counter_da_human_gate_is_explicit_not_implicit():
-    packet = build_generation_packet(bridgepatch_brief())
+    packet = build()
     assert packet["human_gate"]["required"] is True
     assert "Would I actually say this?" in packet["human_gate"]["checks"]
 
@@ -212,7 +229,7 @@ def test_meteor_06_counter_da_human_gate_is_explicit_not_implicit():
 # 7. DA: over-sanitization must not kill voice
 
 def test_meteor_07_da_packet_preserves_attested_strong_opinion():
-    source = bridgepatch_brief()
+    source = brief()
     source["primary_info"].append(
         {
             "claim": "大きく作るより、まず一工程だけ切る方がいい、というのが私の考えだ。",
@@ -221,14 +238,14 @@ def test_meteor_07_da_packet_preserves_attested_strong_opinion():
             "kind": "BELIEF",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source)
     assert packet["voice_policy"]["preserve_attested_opinion"] is True
     assert packet["voice_policy"]["hedge_verified_facts"] is False
     assert "Strong opinions are allowed" in packet["voice_policy"]["strong_judgment_rule"]
 
 
 def test_meteor_07_counter_da_strong_attested_voice_is_not_blocked():
-    source = bridgepatch_brief()
+    source = brief()
     source["primary_info"].append(
         {
             "claim": "大きく作るより、まず一工程だけ切る方がいい、というのが私の考えだ。",
@@ -237,7 +254,7 @@ def test_meteor_07_counter_da_strong_attested_voice_is_not_blocked():
             "kind": "BELIEF",
         }
     )
-    packet = build_generation_packet(source)
+    packet = build(source)
     draft = "大きく作るより、まず一工程だけ切る方がいい。これは私の考えです。"
     audit = audit_draft(draft, packet)
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"

--- a/x_article_engine/DA_METEOR_REPORT.md
+++ b/x_article_engine/DA_METEOR_REPORT.md
@@ -1,0 +1,218 @@
+# X Article Engine — DA / Counter-DA METEOR Report
+
+Date: 2026-08-16
+Scope: X Article Engine v0 -> v0.2 hardening
+
+## Goal
+
+Attack seven known failure classes before using the engine for the first BridgePatch X Article. For every Devil's Advocate attack, add a counter-DA case to prove the fix does not simply block all useful writing.
+
+## Result summary
+
+| # | Attack | DA result | Counter-DA result | v0.2 action |
+|---|---|---|---|---|
+| 1 | Invented numbers / durations | BLOCK | evidence-bound numbers pass | NFKC normalization, kanji-number and fuzzy-quantity audit |
+| 2 | Invented biography / chronology | BLOCK for tested identity markers | attested identity detail passes | first-person identity-risk audit + primary-info kinds |
+| 3 | Fake `CASE_RESULT` | BLOCK | trusted result source passes | case result must bind to trusted registry result evidence |
+| 4 | Strengthened commercial promise | BLOCK | explicitly bound promise passes | commercial risk marker audit |
+| 5 | “I say this is true” evidence bypass | BLOCK | trusted registry fact passes | trusted evidence registry moved outside end-user brief |
+| 6 | `/human` bypass | BLOCK | explicit human gate remains available | publication state is engine-owned and USER_ONLY |
+| 7 | Safety makes prose lifeless | NOT ALLOWED as a design outcome | strong attested opinion passes | voice policy preserves attested opinion and direct verified facts |
+
+## 1 — Invented numeric claims
+
+### DA
+
+Examples:
+
+- `毎週2時間かかる`
+- `毎週２時間かかる`
+- `二時間かかる`
+- `何十時間も使った`
+
+The original v0 mainly caught Arabic-number claims. Full-width digits, kanji numbers, and fuzzy quantities were obvious bypasses.
+
+### Counter-DA
+
+Evidence-bound `10,000円`, `50,000円`, and `5営業日` must still be usable.
+
+### Change
+
+- normalize with NFKC;
+- recognize common kanji-number + unit claims;
+- recognize fuzzy quantity patterns and markers;
+- block only unbound claims;
+- computed/derived numbers are no longer auto-authorized: bind them as evidence first.
+
+## 2 — Invented biography / first-person history
+
+### DA
+
+Example:
+
+`私は数年前から業務自動化の仕事をしてきました。`
+
+This is precisely the narrative inflation observed during reference-generator dogfooding: a true development anecdote gets expanded into an unprovided job history or chronology.
+
+### Counter-DA
+
+If the human explicitly attests:
+
+`私は以前、Vlogツールの開発をしていた。`
+
+that statement remains usable.
+
+### Change
+
+- primary information is typed as `EXPERIENCE`, `BELIEF`, `FAILURE`, `CHRONOLOGY`, or `OPINION`;
+- selected high-risk first-person chronology/role markers are audited against attested primary info.
+
+### Residual risk
+
+This is a heuristic detector, not semantic theorem proving. A sufficiently novel paraphrase can evade the marker set. `/human` therefore remains mandatory and identity-bearing prose must never be treated as automatically proven by this audit.
+
+## 3 — Fake CASE_RESULT
+
+### DA
+
+A caller adds:
+
+```json
+{
+  "claim": "顧客の作業が90%減った。",
+  "source_ref": "invented-case",
+  "status": "VERIFIED",
+  "kind": "CASE_RESULT"
+}
+```
+
+Merely spelling `VERIFIED` must not create customer evidence.
+
+### Counter-DA
+
+A result bound to a separately trusted verified source must still enable `CASE_RESULT` and `PROOF_FIRST`.
+
+### Change
+
+`CASE_RESULT` requires result evidence whose `source_ref` exists in the separately supplied trusted source registry.
+
+## 4 — Commercial wording inflation
+
+### DA
+
+Examples:
+
+- `追加料金はありません`
+- `全額返金します`
+- unbound guarantees, cancellation promises, unlimited/permanent claims
+
+These are materially stronger than a normal statement such as “scope, total price, and timing are agreed before start.”
+
+### Counter-DA
+
+If a specific commercial promise is actually present in trusted commercial evidence, the same wording may pass the automated gate and proceed to `/human`.
+
+### Change
+
+High-risk commercial markers are checked against bound commercial evidence/offer/CTA before publication handoff.
+
+### Residual risk
+
+Semantic strengthening can occur without using one of the known markers. `/human` remains responsible for subtle contractual implication.
+
+## 5 — “But I told you it is true”
+
+### DA
+
+The article brief attempts to self-declare a fake `source_refs` entry as `VERIFIED`.
+
+### Counter-DA
+
+The application separately supplies a trusted source registry entry from an evidence-ingestion boundary.
+
+### Change
+
+`build_generation_packet()` now requires a keyword-only `trusted_source_refs` argument. The user brief's own `source_refs` field has no authority.
+
+This is the most important structural fix from the meteor pass.
+
+### Trust-boundary warning
+
+This is not cryptographic verification. If the product UI lets an end user directly control `trusted_source_refs`, the protection is defeated. That registry must be created by trusted application logic or evidence ingestion.
+
+## 6 — `/human` bypass
+
+### DA
+
+The source tries to inject:
+
+```text
+review_state = APPROVED
+human_reviewed = true
+publication_state = READY
+```
+
+### Counter-DA
+
+The engine can still produce a useful draft packet and audit result for subsequent genuine human review.
+
+### Change
+
+Source-supplied approval state is ignored. The engine owns:
+
+```text
+publication_state = BLOCKED_PENDING_HUMAN
+publication_authority = USER_ONLY
+external_publication_performed = False
+```
+
+The engine does not implement a fake “approve myself” path.
+
+## 7 — Over-sanitization / blandness
+
+### DA
+
+A safety layer can technically prevent hallucination while destroying the reason anyone reads the article: every sentence becomes hedged, generic, and lifeless.
+
+That outcome is considered a failure, not a safety success.
+
+### Counter-DA
+
+Human-attested beliefs/opinions and evidence-bound concrete facts must be allowed to remain direct and vivid.
+
+### Change
+
+The generation packet now explicitly states:
+
+- preserve attested opinion;
+- preserve attested self-labels;
+- do not hedge verified facts merely because the engine is cautious;
+- avoid generic filler;
+- strong judgments are allowed when explicitly attested as belief/opinion;
+- never convert those judgments into factual guarantees.
+
+## Local regression result
+
+The hardened core plus the base and meteor suites were executed locally during this pass:
+
+```text
+25 passed
+```
+
+No repository CI workflow was available on the previous X Article Engine PR, so this is a local regression result rather than a GitHub Actions result.
+
+## Decision
+
+METEOR status: **PASS WITH RESIDUAL HUMAN SEMANTIC RISK**.
+
+The seven targeted attack classes now have both DA and counter-DA regression coverage. The engine is suitable to proceed to BridgePatch article dogfooding only with the mandatory `/human` boundary intact.
+
+Do not claim that automated auditing proves every sentence true. It does not. The intended design is:
+
+```text
+strong narrative generation
++ evidence boundary
++ adversarial audit
++ /human
+= publishable candidate
+```

--- a/x_article_engine/README.md
+++ b/x_article_engine/README.md
@@ -1,20 +1,14 @@
-# X Article Engine v0
+# X Article Engine v0.2
 
-X Article Engine v0 turns a bounded commercial/article brief into a model-agnostic generation packet, then audits the resulting draft before mandatory `/human` review.
+X Article Engine compiles a bounded commercial/article brief into a model-agnostic generation packet, then audits the resulting draft before mandatory `/human` review.
 
 It does **not** publish to X and it does **not** call an LLM by itself.
 
-## Why this exists
-
-Dogfooding long-form X article generation showed a useful split:
-
-- narrative structure, objection handling, pacing, and CTA shaping can be delegated heavily;
-- facts, numbers, first-person history, customer outcomes, commercial promises, and risk boundaries cannot be left to unconstrained narrative completion.
-
-The v0 architecture is therefore:
+## Architecture
 
 ```text
-Article brief
+Human brief
+  + trusted evidence registry
   -> Narrative plan
   -> Evidence-bound generation packet
   -> model draft
@@ -23,32 +17,48 @@ Article brief
   -> Publication Bridge / manual X Articles handoff
 ```
 
-## Inputs
+The split is deliberate:
 
-Required:
+- narrative structure, objection handling, pacing, and CTA shaping can be delegated heavily;
+- facts, numbers, first-person history, customer outcomes, commercial promises, and risk boundaries cannot be left to unconstrained narrative completion.
+
+## Required brief fields
 
 - `offer`: what is being offered;
 - `target`: one concrete buyer/reader;
-- `pain`: one pre-purchase problem for this article;
+- `pain`: one pre-purchase problem;
 - `primary_info`: first-person material explicitly attested by the human;
 - `article_type`: `HOW_TO`, `STORY`, or `CASE_RESULT`;
 - `cta`: exactly one desired next action;
-- `evidence`: source-bound factual claims.
+- `evidence`: factual claims that refer to trusted source IDs.
 
 Optional:
 
-- `topic_mode`: `PROCEDURAL`, `HABIT`, `RELATIONSHIP`, or `BUSINESS` (default `BUSINESS`);
+- `topic_mode`: `PROCEDURAL`, `HABIT`, `RELATIONSHIP`, or `BUSINESS`;
 - `opening_mode`: `RELATABLE`, `PROOF_FIRST`, or `CONTRARIAN`.
 
-## Core doctrine
+## Trusted evidence boundary
 
-Top-level reader journey:
+`build_generation_packet()` requires `trusted_source_refs` as a separate keyword-only argument.
+
+```python
+packet = build_generation_packet(
+    brief,
+    trusted_source_refs=trusted_registry,
+)
+```
+
+This registry must come from a trusted ingestion/verification layer. A user cannot make a claim trusted merely by adding `{"status": "VERIFIED"}` or a fake `source_refs` field to the article brief.
+
+This is an application trust boundary, not cryptographic proof. If an untrusted caller is allowed to control `trusted_source_refs`, evidence safety is defeated. Do not expose that parameter as ordinary end-user input.
+
+## Narrative doctrine
 
 ```text
 EMOTION -> LOGIC -> EASY_NEXT_ACTION
 ```
 
-Article construction:
+Typical flow:
 
 ```text
 reader state
@@ -61,60 +71,69 @@ reader state
 -> one CTA
 ```
 
-Depth is layered rather than split into separate beginner/advanced articles:
-
-```text
-L1: conclusion
-L2: why
-L3: conditions / exceptions / application
-```
-
-A strong human-attested episode may be used inside a HOW_TO article, and explanation may appear inside a STORY article. The selected article type is the dominant structure, not a rigid cage.
+A strong human-attested episode may appear inside a HOW_TO article. Explanation may appear inside a STORY article. The selected type is the dominant structure, not a cage.
 
 ## Evidence rules
 
-The engine deliberately does **not** require a quota such as “at least five numbers.” If the evidence contains two useful numbers, use two. If it contains none, the article may have none.
+The engine does not require arbitrary density quotas such as “five numbers.” If evidence contains no useful number, a numberless title is valid.
 
-Blocked behavior includes:
+Automated audit now blocks tested classes of:
 
-- inventing plausible durations, percentages, customer counts, or results;
-- inventing first-person chronology, jobs, failures, emotions, or biography;
-- turning “scope/total/timing are agreed before start” into a stronger promise such as “no extra charges can ever occur”;
-- presenting a newly invented label as established technical terminology;
-- using `PROOF_FIRST` or `CASE_RESULT` without the evidence needed to support them.
+- invented Arabic, full-width, and common kanji numeric claims;
+- fuzzy quantitative claims such as `何十時間` when not bound;
+- selected unbound first-person chronology/role details;
+- undeclared or untrusted result sources;
+- `CASE_RESULT` without trusted result evidence;
+- strengthened commercial promises such as unbound extra-fee or refund claims;
+- attempts to override `/human` or publication state from the brief.
 
-Derived arithmetic is acceptable only when every operand is verified and the derivation is explicit.
+Derived arithmetic is not auto-authorized in v0.2. If a computed number is intended for publication, bind that computed claim as verified evidence first.
 
-`audit_draft()` v0 detects unbound Arabic-number claims with high-risk units (money, time, percentages, counts) and several strong commercial/guarantee phrases. It is intentionally conservative and incomplete: semantic truth still requires `/human`.
+## Voice must survive safety
 
-## `/human` is mandatory
+Safety is not permission to flatten the article into compliance sludge.
 
-`/human` is not an AI-smell remover. It is the boundary where the owner verifies identity-bearing material and adds real point of view.
+The generation packet explicitly preserves:
 
-Before handoff, check:
+- human-attested beliefs and opinions;
+- human-attested self-labels such as a personal term already in use;
+- direct, confident wording for verified facts;
+- vivid examples when they are evidence-bound or human-attested.
 
-- Would I actually say this?
-- Are all first-person details true and mine?
-- Are numbers, prices, timing, results, and scope evidence-bound?
-- Did the draft invent emotions, biography, customer outcomes, or certainty?
-- Is there only one CTA?
-- Were factual/risk boundaries preserved while making the writing sound human?
+Strong opinions are allowed. Strong factual guarantees are not invented.
+
+## `/human` remains mandatory
+
+Automated checks are incomplete by design. Semantic truth, subtle biography inflation, implication, tone, and whether the text is genuinely the owner's voice still require `/human`.
+
+Every packet and audit result remains:
+
+```text
+publication_state = BLOCKED_PENDING_HUMAN
+publication_authority = USER_ONLY
+external_publication_performed = False
+```
+
+## DA / counter-DA METEOR
+
+The seven attack vectors and counterexamples are recorded in `DA_METEOR_REPORT.md` and executable regression tests live in `tests/test_x_article_engine_meteor.py`.
+
+The test suite covers:
+
+1. invented numbers;
+2. invented biography;
+3. fake case results;
+4. strengthened commercial promises;
+5. “I say it is true” evidence bypass;
+6. `/human` bypass;
+7. over-sanitization / voice destruction.
 
 ## Usage / credit policy
 
-**Not part of v0.**
+**Not part of the engine.**
 
-Generation quotas, credits, replenishment cadence, and product tiers are business/deployment policy, not article-quality logic. They should be set only after observing:
-
-- actual model cost per article;
-- support/coaching capacity;
-- real customer generation frequency;
-- revision frequency and `/human` workload;
-- abuse/fair-use behavior;
-- desired product tiers.
-
-Do not copy a third-party `5,000 credits` or monthly article allowance into the product simply because the reference implementation uses it.
+Credits, monthly replenishment, generation quotas, coaching limits, and product tiers are business/deployment policy. They should be decided after observing actual model cost, revision rate, `/human` workload, coaching capacity, and customer usage.
 
 ## Publication boundary
 
-This module never performs external publication. X Articles should continue through mandatory `/human` and a user-controlled handoff. Private X APIs, cookies, or session automation are out of scope.
+This module never performs external publication. X Articles continue through mandatory `/human` and a user-controlled handoff. Private X APIs, cookies, or session automation remain out of scope.

--- a/x_article_engine/core.py
+++ b/x_article_engine/core.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 import re
-from typing import Iterable
+import unicodedata
 
 
 class XArticleEngineError(ValueError):
@@ -12,6 +12,7 @@ class XArticleEngineError(ValueError):
 ARTICLE_TYPES = {"HOW_TO", "STORY", "CASE_RESULT"}
 OPENING_MODES = {"RELATABLE", "PROOF_FIRST", "CONTRARIAN"}
 TOPIC_MODES = {"PROCEDURAL", "HABIT", "RELATIONSHIP", "BUSINESS"}
+PRIMARY_INFO_KINDS = {"EXPERIENCE", "BELIEF", "FAILURE", "CHRONOLOGY", "OPINION"}
 
 REQUIRED_FIELDS = (
     "offer",
@@ -21,25 +22,64 @@ REQUIRED_FIELDS = (
     "article_type",
     "cta",
     "evidence",
+    "source_refs",
 )
 
-# This is deliberately small. It catches the failure mode observed during
-# dogfooding: plausible-looking numbers being invented to make an article feel
-# more concrete. Bare structural counts ("3つ", "1工程") are not treated as
-# factual numeric claims by this v0 audit.
 NUMERIC_CLAIM_RE = re.compile(
-    r"(?<!\d)(?:\d{1,3}(?:,\d{3})+|\d+(?:\.\d+)?)"
+    r"(?<!\d)(?:\d{1,3}(?:,\d{3})+|\d+(?:\.\d+)?|[一二三四五六七八九十百千万億〇零]+)"
     r"(?:円|%|％|時間|分|秒|営業日|日間|日|週間|週|ヶ月|か月|カ月|月間|年|件|社|人|回)"
 )
 
-COMMERCIAL_STRENGTHENING_PHRASES = (
-    "追加料金が発生しません",
-    "追加料金は発生しません",
-    "絶対",
-    "100%",
-    "１００％",
+FUZZY_QUANT_RE = re.compile(
+    r"(?:数|何十|何百|何千)(?:時間|分|秒|日|週間|週|ヶ月|か月|カ月|月|年|件|社|人|回)"
+    r"|(?:\d+|[一二三四五六七八九十百千万億〇零]+)倍"
 )
 
+FUZZY_QUANT_MARKERS = (
+    "数年前",
+    "何度も",
+    "大半",
+    "ほとんど",
+)
+
+IDENTITY_RISK_MARKERS = (
+    "数年前",
+    "以前",
+    "過去",
+    "これまで",
+    "何度も",
+    "長年",
+    "普段",
+    "仕事",
+    "働",
+    "担当",
+    "顧客",
+    "クライアント",
+    "受講生",
+    "見積もり",
+    "現場",
+)
+
+FIRST_PERSON_MARKERS = ("私は", "僕は", "俺は", "私自身", "僕自身", "俺自身")
+
+COMMERCIAL_RISK_MARKERS = (
+    "追加料金",
+    "追加費用",
+    "返金",
+    "全額返金",
+    "返金保証",
+    "キャンセル料",
+    "違約金",
+    "無制限",
+    "永久",
+    "絶対",
+    "必ず",
+    "100%",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
 
 
 def _text(value: object, field: str) -> str:
@@ -48,8 +88,26 @@ def _text(value: object, field: str) -> str:
     return value.strip()
 
 
+def _normalize_source_refs(items: object) -> dict[str, dict]:
+    if not isinstance(items, list) or not items:
+        raise XArticleEngineError("source_refs must be a non-empty list")
 
-def _normalize_evidence(items: object) -> tuple[list[dict], list[str]]:
+    index: dict[str, dict] = {}
+    for raw in items:
+        if not isinstance(raw, dict):
+            raise XArticleEngineError("source_refs entries must be objects")
+        source_id = _text(raw.get("id"), "source_refs[].id")
+        if source_id in index:
+            raise XArticleEngineError(f"duplicate source ref: {source_id}")
+        status = _text(raw.get("status", "UNVERIFIED"), "source_refs[].status").upper()
+        kind = _text(raw.get("kind", "SOURCE"), "source_refs[].kind").upper()
+        index[source_id] = {"id": source_id, "status": status, "kind": kind}
+    return index
+
+
+def _normalize_evidence(
+    items: object, source_index: dict[str, dict]
+) -> tuple[list[dict], list[str]]:
     if not isinstance(items, list) or not items:
         raise XArticleEngineError("evidence must be a non-empty list")
 
@@ -63,7 +121,9 @@ def _normalize_evidence(items: object) -> tuple[list[dict], list[str]]:
         status = _text(raw.get("status", "UNVERIFIED"), "evidence[].status").upper()
         kind = _text(raw.get("kind", "FACT"), "evidence[].kind").upper()
 
-        if status == "VERIFIED":
+        source = source_index.get(source_ref)
+        source_verified = bool(source and source["status"] == "VERIFIED")
+        if status == "VERIFIED" and source_verified:
             verified.append(
                 {
                     "claim": claim,
@@ -73,12 +133,17 @@ def _normalize_evidence(items: object) -> tuple[list[dict], list[str]]:
                 }
             )
         else:
-            warnings.append(f"evidence {index} excluded because it is not VERIFIED: {claim}")
+            if source is None:
+                reason = "source_ref is not declared"
+            elif not source_verified:
+                reason = "declared source is not VERIFIED"
+            else:
+                reason = "claim is not VERIFIED"
+            warnings.append(f"evidence {index} excluded because {reason}: {claim}")
 
     if not verified:
         raise XArticleEngineError("no verified evidence remains")
     return verified, warnings
-
 
 
 def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
@@ -91,8 +156,16 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
         if not isinstance(raw, dict):
             raise XArticleEngineError("primary_info entries must be objects")
         claim = _text(raw.get("claim"), "primary_info[].claim")
-        source_ref = _text(raw.get("source_ref", "human_attestation"), "primary_info[].source_ref")
+        source_ref = _text(
+            raw.get("source_ref", "human_attestation"),
+            "primary_info[].source_ref",
+        )
         attested = raw.get("attested", False)
+        kind = _text(raw.get("kind", "EXPERIENCE"), "primary_info[].kind").upper()
+        if kind not in PRIMARY_INFO_KINDS:
+            raise XArticleEngineError(
+                "primary_info[].kind must be EXPERIENCE, BELIEF, FAILURE, CHRONOLOGY, or OPINION"
+            )
         if not isinstance(attested, bool):
             raise XArticleEngineError("primary_info[].attested must be boolean")
         if attested:
@@ -101,22 +174,18 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
                     "claim": claim,
                     "source_ref": source_ref,
                     "attested": True,
+                    "kind": kind,
                 }
             )
         else:
-            warnings.append(f"primary_info {index} excluded because it is not human-attested: {claim}")
+            warnings.append(
+                f"primary_info {index} excluded because it is not human-attested: {claim}"
+            )
     return accepted, warnings
 
 
-
 def normalize_brief(source: dict) -> dict:
-    """Normalize one X Article brief and bind every usable factual input.
-
-    ``primary_info`` is reserved for first-person experience, belief, failure,
-    chronology, and other identity-bearing material. It is usable only when the
-    human explicitly attests it. ``evidence`` is for externally checkable facts,
-    prices, timing, scope, results, and other claims.
-    """
+    """Normalize one X Article brief and bind every usable factual input."""
     if not isinstance(source, dict):
         raise XArticleEngineError("source must be an object")
 
@@ -140,8 +209,12 @@ def normalize_brief(source: dict) -> dict:
         )
     normalized["topic_mode"] = topic_mode
 
-    verified, evidence_warnings = _normalize_evidence(normalized["evidence"])
+    source_index = _normalize_source_refs(normalized["source_refs"])
+    verified, evidence_warnings = _normalize_evidence(normalized["evidence"], source_index)
     primary_info, primary_warnings = _normalize_primary_info(normalized["primary_info"])
+    normalized["verified_source_refs"] = [
+        item for item in source_index.values() if item["status"] == "VERIFIED"
+    ]
     normalized["verified_evidence"] = verified
     normalized["verified_primary_info"] = primary_info
     normalized["warnings"] = [*evidence_warnings, *primary_warnings]
@@ -172,13 +245,8 @@ def normalize_brief(source: dict) -> dict:
     return normalized
 
 
-
 def build_generation_packet(source: dict) -> dict:
-    """Compile a safe, model-agnostic generation packet.
-
-    This function does not call an LLM and does not publish. It defines what a
-    downstream writer is allowed to use and how the article should be shaped.
-    """
+    """Compile a safe, model-agnostic generation packet without publishing."""
     brief = normalize_brief(source)
 
     if brief["topic_mode"] == "PROCEDURAL":
@@ -217,7 +285,7 @@ def build_generation_packet(source: dict) -> dict:
         ]
 
     return {
-        "schema_version": "0.1",
+        "schema_version": "0.2",
         "offer": brief["offer"],
         "target": brief["target"],
         "pain": brief["pain"],
@@ -225,6 +293,7 @@ def build_generation_packet(source: dict) -> dict:
         "topic_mode": brief["topic_mode"],
         "opening_mode": brief["opening_mode"],
         "cta": brief["cta"],
+        "verified_source_refs": brief["verified_source_refs"],
         "verified_evidence": brief["verified_evidence"],
         "verified_primary_info": brief["verified_primary_info"],
         "narrative": {
@@ -243,6 +312,20 @@ def build_generation_packet(source: dict) -> dict:
             ],
             "topic_shape": shape,
         },
+        "voice_policy": {
+            "preserve_attested_opinion": True,
+            "preserve_attested_self_labels": True,
+            "hedge_verified_facts": False,
+            "generic_filler": "avoid",
+            "strong_judgment_rule": (
+                "Strong opinions are allowed when they are explicitly human-attested "
+                "as BELIEF or OPINION; do not convert them into factual guarantees."
+            ),
+            "concrete_language_rule": (
+                "Be vivid and specific using bound evidence and attested primary "
+                "information; safety must not flatten the writer's voice."
+            ),
+        },
         "generation_constraints": [
             "Use only verified_evidence for externally checkable facts, prices, timing, scope, and results.",
             "Use first-person history, failure, emotion, belief, or chronology only from verified_primary_info.",
@@ -255,6 +338,7 @@ def build_generation_packet(source: dict) -> dict:
             "Give exactly one practical next action and one CTA.",
             "Do not blame or rank the reader.",
             "Natural hybridization is allowed when strong human-attested primary information helps the article, but the selected article_type remains the dominant structure.",
+            "Do not add chronology, job history, customer history, frequency, duration, or role details that are absent from verified_primary_info.",
             "The draft is not publishable until /human review passes.",
         ],
         "human_gate": {
@@ -268,11 +352,12 @@ def build_generation_packet(source: dict) -> dict:
                 "Did the rewrite preserve factual and risk boundaries?",
             ],
         },
+        "publication_state": "BLOCKED_PENDING_HUMAN",
+        "publication_authority": "USER_ONLY",
         "warnings": brief["warnings"],
         "review_state": brief["review_state"],
         "external_publication_performed": False,
     }
-
 
 
 def _bound_text(packet: dict) -> str:
@@ -282,18 +367,67 @@ def _bound_text(packet: dict) -> str:
     return "\n".join(chunks)
 
 
+def _primary_text(packet: dict) -> str:
+    return "\n".join(item["claim"] for item in packet["verified_primary_info"])
+
+
+def _commercial_text(packet: dict) -> str:
+    chunks = [packet["offer"], packet["cta"]]
+    chunks.extend(
+        item["claim"]
+        for item in packet["verified_evidence"]
+        if item["kind"] in {"COMMERCIAL", "TIMING", "SCOPE", "POLICY"}
+    )
+    return "\n".join(chunks)
+
 
 def _numeric_claims(text: str) -> set[str]:
-    return set(NUMERIC_CLAIM_RE.findall(text))
+    return set(NUMERIC_CLAIM_RE.findall(_norm(text)))
 
+
+def _fuzzy_quant_claims(text: str) -> set[str]:
+    normalized = _norm(text)
+    claims = set(FUZZY_QUANT_RE.findall(normalized))
+    claims.update(marker for marker in FUZZY_QUANT_MARKERS if marker in normalized)
+    return claims
+
+
+def _sentences(text: str) -> list[str]:
+    normalized = _norm(text)
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", normalized)
+        if item.strip()
+    ]
+
+
+def _identity_findings(draft: str, packet: dict) -> list[str]:
+    primary = _norm(_primary_text(packet))
+    findings: list[str] = []
+    for sentence in _sentences(draft):
+        if not any(marker in sentence for marker in FIRST_PERSON_MARKERS):
+            continue
+        for marker in IDENTITY_RISK_MARKERS:
+            if marker in sentence and marker not in primary:
+                findings.append(sentence)
+                break
+    return sorted(set(findings))
+
+
+def _commercial_findings(draft: str, packet: dict) -> list[str]:
+    normalized_draft = _norm(draft)
+    bound = _norm(_commercial_text(packet))
+    return sorted(
+        {
+            marker
+            for marker in COMMERCIAL_RISK_MARKERS
+            if marker in normalized_draft and marker not in bound
+        }
+    )
 
 
 def audit_draft(draft: str, packet: dict) -> dict:
-    """Run a conservative pre-/human audit over a generated draft.
-
-    v0 deliberately focuses on high-value failure classes rather than pretending
-    to prove every sentence automatically. Human review remains mandatory.
-    """
+    """Run a conservative pre-/human audit over a generated draft."""
     draft = _text(draft, "draft")
     if not isinstance(packet, dict):
         raise XArticleEngineError("packet must be an object")
@@ -302,34 +436,37 @@ def audit_draft(draft: str, packet: dict) -> dict:
     observed_numeric = _numeric_claims(draft)
     unbound_numeric = sorted(observed_numeric - allowed_numeric)
 
-    verified_text = _bound_text(packet)
-    strengthened = [
-        phrase
-        for phrase in COMMERCIAL_STRENGTHENING_PHRASES
-        if phrase in draft and phrase not in verified_text
-    ]
+    allowed_fuzzy = _fuzzy_quant_claims(_bound_text(packet))
+    observed_fuzzy = _fuzzy_quant_claims(draft)
+    unbound_fuzzy = sorted(observed_fuzzy - allowed_fuzzy)
+
+    identity_details = _identity_findings(draft, packet)
+    strengthened = _commercial_findings(draft, packet)
 
     findings: list[dict] = []
     for claim in unbound_numeric:
         findings.append(
-            {
-                "code": "UNBOUND_NUMERIC_CLAIM",
-                "severity": "BLOCK",
-                "detail": claim,
-            }
+            {"code": "UNBOUND_NUMERIC_CLAIM", "severity": "BLOCK", "detail": claim}
         )
-    for phrase in strengthened:
+    for claim in unbound_fuzzy:
         findings.append(
-            {
-                "code": "UNBOUND_STRONG_CLAIM",
-                "severity": "BLOCK",
-                "detail": phrase,
-            }
+            {"code": "UNBOUND_FUZZY_QUANT_CLAIM", "severity": "BLOCK", "detail": claim}
+        )
+    for sentence in identity_details:
+        findings.append(
+            {"code": "UNBOUND_IDENTITY_DETAIL", "severity": "BLOCK", "detail": sentence}
+        )
+    for marker in strengthened:
+        findings.append(
+            {"code": "UNBOUND_STRONG_CLAIM", "severity": "BLOCK", "detail": marker}
         )
 
+    blocked = any(item["severity"] == "BLOCK" for item in findings)
     return {
-        "status": "BLOCKED" if any(item["severity"] == "BLOCK" for item in findings) else "HUMAN_REVIEW_REQUIRED",
+        "status": "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED",
         "findings": findings,
         "human_review_required": True,
+        "publication_state": "BLOCKED_PENDING_HUMAN",
+        "publication_authority": "USER_ONLY",
         "external_publication_performed": False,
     }

--- a/x_article_engine/core.py
+++ b/x_article_engine/core.py
@@ -22,7 +22,6 @@ REQUIRED_FIELDS = (
     "article_type",
     "cta",
     "evidence",
-    "source_refs",
 )
 
 NUMERIC_CLAIM_RE = re.compile(
@@ -35,12 +34,7 @@ FUZZY_QUANT_RE = re.compile(
     r"|(?:\d+|[一二三四五六七八九十百千万億〇零]+)倍"
 )
 
-FUZZY_QUANT_MARKERS = (
-    "数年前",
-    "何度も",
-    "大半",
-    "ほとんど",
-)
+FUZZY_QUANT_MARKERS = ("数年前", "何度も", "大半", "ほとんど")
 
 IDENTITY_RISK_MARKERS = (
     "数年前",
@@ -134,9 +128,9 @@ def _normalize_evidence(
             )
         else:
             if source is None:
-                reason = "source_ref is not declared"
+                reason = "source_ref is not declared by trusted ingestion"
             elif not source_verified:
-                reason = "declared source is not VERIFIED"
+                reason = "trusted source is not VERIFIED"
             else:
                 reason = "claim is not VERIFIED"
             warnings.append(f"evidence {index} excluded because {reason}: {claim}")
@@ -156,10 +150,7 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
         if not isinstance(raw, dict):
             raise XArticleEngineError("primary_info entries must be objects")
         claim = _text(raw.get("claim"), "primary_info[].claim")
-        source_ref = _text(
-            raw.get("source_ref", "human_attestation"),
-            "primary_info[].source_ref",
-        )
+        source_ref = _text(raw.get("source_ref", "human_attestation"), "primary_info[].source_ref")
         attested = raw.get("attested", False)
         kind = _text(raw.get("kind", "EXPERIENCE"), "primary_info[].kind").upper()
         if kind not in PRIMARY_INFO_KINDS:
@@ -170,12 +161,7 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
             raise XArticleEngineError("primary_info[].attested must be boolean")
         if attested:
             accepted.append(
-                {
-                    "claim": claim,
-                    "source_ref": source_ref,
-                    "attested": True,
-                    "kind": kind,
-                }
+                {"claim": claim, "source_ref": source_ref, "attested": True, "kind": kind}
             )
         else:
             warnings.append(
@@ -184,8 +170,13 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
     return accepted, warnings
 
 
-def normalize_brief(source: dict) -> dict:
-    """Normalize one X Article brief and bind every usable factual input."""
+def normalize_brief(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Normalize one X Article brief and bind every usable factual input.
+
+    The verified source registry is supplied separately by a trusted ingestion
+    layer. End-user brief JSON cannot make a source trusted by declaring it
+    VERIFIED inside the brief.
+    """
     if not isinstance(source, dict):
         raise XArticleEngineError("source must be an object")
 
@@ -209,7 +200,7 @@ def normalize_brief(source: dict) -> dict:
         )
     normalized["topic_mode"] = topic_mode
 
-    source_index = _normalize_source_refs(normalized["source_refs"])
+    source_index = _normalize_source_refs(trusted_source_refs)
     verified, evidence_warnings = _normalize_evidence(normalized["evidence"], source_index)
     primary_info, primary_warnings = _normalize_primary_info(normalized["primary_info"])
     normalized["verified_source_refs"] = [
@@ -245,9 +236,9 @@ def normalize_brief(source: dict) -> dict:
     return normalized
 
 
-def build_generation_packet(source: dict) -> dict:
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
     """Compile a safe, model-agnostic generation packet without publishing."""
-    brief = normalize_brief(source)
+    brief = normalize_brief(source, trusted_source_refs=trusted_source_refs)
 
     if brief["topic_mode"] == "PROCEDURAL":
         shape = "Use steps only where the reader is literally performing a procedure."
@@ -259,30 +250,11 @@ def build_generation_packet(source: dict) -> dict:
         shape = "Use concrete business logic, scope, trade-offs, and reproducible reasoning."
 
     if brief["article_type"] == "HOW_TO":
-        body_pattern = [
-            "conclusion_or_overview",
-            "method",
-            "why_it_works",
-            "stumbling_points",
-            "conditions_and_limits",
-        ]
+        body_pattern = ["conclusion_or_overview", "method", "why_it_works", "stumbling_points", "conditions_and_limits"]
     elif brief["article_type"] == "STORY":
-        body_pattern = [
-            "interesting_destination_or_failure",
-            "previous_state",
-            "turning_point",
-            "what_changed",
-            "lesson",
-            "reader_connection",
-        ]
+        body_pattern = ["interesting_destination_or_failure", "previous_state", "turning_point", "what_changed", "lesson", "reader_connection"]
     else:
-        body_pattern = [
-            "before",
-            "after",
-            "what_changed",
-            "why_it_worked",
-            "reproduction_conditions",
-        ]
+        body_pattern = ["before", "after", "what_changed", "why_it_worked", "reproduction_conditions"]
 
     return {
         "schema_version": "0.2",
@@ -300,16 +272,7 @@ def build_generation_packet(source: dict) -> dict:
             "top_level_order": ["EMOTION", "LOGIC", "EASY_NEXT_ACTION"],
             "body_pattern": body_pattern,
             "depth_layers": ["L1_CONCLUSION", "L2_REASON", "L3_CONDITIONS_EXCEPTIONS"],
-            "sequence": [
-                "reader_state",
-                "evidence_if_available",
-                "anticipated_objection",
-                "cause",
-                "solution",
-                "stumbling_point",
-                "one_action_today",
-                "single_cta",
-            ],
+            "sequence": ["reader_state", "evidence_if_available", "anticipated_objection", "cause", "solution", "stumbling_point", "one_action_today", "single_cta"],
             "topic_shape": shape,
         },
         "voice_policy": {
@@ -317,20 +280,14 @@ def build_generation_packet(source: dict) -> dict:
             "preserve_attested_self_labels": True,
             "hedge_verified_facts": False,
             "generic_filler": "avoid",
-            "strong_judgment_rule": (
-                "Strong opinions are allowed when they are explicitly human-attested "
-                "as BELIEF or OPINION; do not convert them into factual guarantees."
-            ),
-            "concrete_language_rule": (
-                "Be vivid and specific using bound evidence and attested primary "
-                "information; safety must not flatten the writer's voice."
-            ),
+            "strong_judgment_rule": "Strong opinions are allowed when they are explicitly human-attested as BELIEF or OPINION; do not convert them into factual guarantees.",
+            "concrete_language_rule": "Be vivid and specific using bound evidence and attested primary information; safety must not flatten the writer's voice.",
         },
         "generation_constraints": [
             "Use only verified_evidence for externally checkable facts, prices, timing, scope, and results.",
             "Use first-person history, failure, emotion, belief, or chronology only from verified_primary_info.",
             "Never invent a number to satisfy a density or title rule; a numberless title is valid.",
-            "Derived arithmetic is allowed only when every operand is verified and the derivation is explicit.",
+            "Derived arithmetic must be bound as its own verified evidence claim before generation; v0.2 does not auto-authorize new computed numbers.",
             "Do not strengthen commercial or contractual wording beyond the verified claim.",
             "Do not present an invented label as established terminology.",
             "Explain specialist terms inline in plain language.",
@@ -361,7 +318,7 @@ def build_generation_packet(source: dict) -> dict:
 
 
 def _bound_text(packet: dict) -> str:
-    chunks: list[str] = [packet["offer"], packet["target"], packet["pain"], packet["cta"]]
+    chunks = [packet["offer"], packet["target"], packet["pain"], packet["cta"]]
     chunks.extend(item["claim"] for item in packet["verified_evidence"])
     chunks.extend(item["claim"] for item in packet["verified_primary_info"])
     return "\n".join(chunks)
@@ -394,16 +351,12 @@ def _fuzzy_quant_claims(text: str) -> set[str]:
 
 def _sentences(text: str) -> list[str]:
     normalized = _norm(text)
-    return [
-        item.strip()
-        for item in re.split(r"(?<=[。！？!?])|\n+", normalized)
-        if item.strip()
-    ]
+    return [item.strip() for item in re.split(r"(?<=[。！？!?])|\n+", normalized) if item.strip()]
 
 
 def _identity_findings(draft: str, packet: dict) -> list[str]:
     primary = _norm(_primary_text(packet))
-    findings: list[str] = []
+    findings = []
     for sentence in _sentences(draft):
         if not any(marker in sentence for marker in FIRST_PERSON_MARKERS):
             continue
@@ -417,13 +370,7 @@ def _identity_findings(draft: str, packet: dict) -> list[str]:
 def _commercial_findings(draft: str, packet: dict) -> list[str]:
     normalized_draft = _norm(draft)
     bound = _norm(_commercial_text(packet))
-    return sorted(
-        {
-            marker
-            for marker in COMMERCIAL_RISK_MARKERS
-            if marker in normalized_draft and marker not in bound
-        }
-    )
+    return sorted({marker for marker in COMMERCIAL_RISK_MARKERS if marker in normalized_draft and marker not in bound})
 
 
 def audit_draft(draft: str, packet: dict) -> dict:
@@ -433,33 +380,21 @@ def audit_draft(draft: str, packet: dict) -> dict:
         raise XArticleEngineError("packet must be an object")
 
     allowed_numeric = _numeric_claims(_bound_text(packet))
-    observed_numeric = _numeric_claims(draft)
-    unbound_numeric = sorted(observed_numeric - allowed_numeric)
-
+    unbound_numeric = sorted(_numeric_claims(draft) - allowed_numeric)
     allowed_fuzzy = _fuzzy_quant_claims(_bound_text(packet))
-    observed_fuzzy = _fuzzy_quant_claims(draft)
-    unbound_fuzzy = sorted(observed_fuzzy - allowed_fuzzy)
-
+    unbound_fuzzy = sorted(_fuzzy_quant_claims(draft) - allowed_fuzzy)
     identity_details = _identity_findings(draft, packet)
     strengthened = _commercial_findings(draft, packet)
 
-    findings: list[dict] = []
+    findings = []
     for claim in unbound_numeric:
-        findings.append(
-            {"code": "UNBOUND_NUMERIC_CLAIM", "severity": "BLOCK", "detail": claim}
-        )
+        findings.append({"code": "UNBOUND_NUMERIC_CLAIM", "severity": "BLOCK", "detail": claim})
     for claim in unbound_fuzzy:
-        findings.append(
-            {"code": "UNBOUND_FUZZY_QUANT_CLAIM", "severity": "BLOCK", "detail": claim}
-        )
+        findings.append({"code": "UNBOUND_FUZZY_QUANT_CLAIM", "severity": "BLOCK", "detail": claim})
     for sentence in identity_details:
-        findings.append(
-            {"code": "UNBOUND_IDENTITY_DETAIL", "severity": "BLOCK", "detail": sentence}
-        )
+        findings.append({"code": "UNBOUND_IDENTITY_DETAIL", "severity": "BLOCK", "detail": sentence})
     for marker in strengthened:
-        findings.append(
-            {"code": "UNBOUND_STRONG_CLAIM", "severity": "BLOCK", "detail": marker}
-        )
+        findings.append({"code": "UNBOUND_STRONG_CLAIM", "severity": "BLOCK", "detail": marker})
 
     blocked = any(item["severity"] == "BLOCK" for item in findings)
     return {


### PR DESCRIPTION
## /goal
Apply DA + counter-DA to the seven agreed attack vectors, then drop METEOR before BridgePatch article dogfooding.

## Seven vectors
1. invented numbers / durations
2. invented biography / chronology
3. fake CASE_RESULT
4. strengthened commercial promises
5. user assertion masquerading as evidence
6. /human bypass
7. over-sanitization destroying voice

## Changes
- NFKC + kanji/fuzzy quantity audit
- selected first-person identity/chronology inflation audit
- typed primary information boundary
- separate trusted evidence registry from end-user brief
- require trusted result evidence for CASE_RESULT
- broaden high-risk commercial wording audit
- engine-owned BLOCKED_PENDING_HUMAN / USER_ONLY state
- voice policy explicitly preserves attested opinions and direct verified facts
- derived numbers must be pre-bound as evidence
- add DA_METEOR_REPORT.md and 14 DA/counter-DA meteor regressions

## Verification
Local regression run: `25 passed`.

No GitHub Actions workflow was available on the previous X Article Engine PR, so this is a local result rather than CI.

## Residual risk
Automated checks do not prove semantic truth. First-person semantic paraphrases and subtle commercial implication can still evade heuristics; `/human` remains mandatory. `trusted_source_refs` must be supplied by trusted application logic, not exposed as ordinary user input.

External publication remains USER_ONLY.