### PR TITLE
Teach X Article Engine lived-pain openings

### DIFF
--- a/tests/test_x_article_engine_lived_pain.py
+++ b/tests/test_x_article_engine_lived_pain.py
@@ -1,0 +1,131 @@
+import pytest
+
+from x_article_engine import XArticleEngineError, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "小さいが放置できない手作業が残り続ける。",
+        "primary_info": [
+            {
+                "claim": "あーめんどくさくてキレそう、と自前のプログラムを前に頭を抱えた。",
+                "source_ref": "human_attestation:bridgepatch-pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "CapCutで動画編集に挑戦して挫折し、自分が迷わないよう機能を削ったツールを作った。",
+                "source_ref": "human_attestation:bridgepatch-failure",
+                "attested": True,
+                "kind": "FAILURE",
+            },
+            {
+                "claim": "人にも使ってもらおうとすると予期しない操作や動作不良のチェックが増え、直す、チェックする、また直すという無限修正の感覚になった。",
+                "source_ref": "human_attestation:bridgepatch-friction",
+                "attested": True,
+                "kind": "EXPERIENCE",
+            },
+            {
+                "claim": "直接1円にもならないが、放置するとクレームの元になり得るので手を抜けない仕事だと感じた。",
+                "source_ref": "human_attestation:bridgepatch-stakes",
+                "attested": True,
+                "kind": "OPINION",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:bridgepatch-origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "HOW_TO",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def build(source=None):
+    return build_generation_packet(source or brief(), trusted_source_refs=sources())
+
+
+def test_lived_pain_is_selected_when_attested_pain_exists():
+    packet = build()
+    assert packet["schema_version"] == "0.3"
+    assert packet["opening_mode"] == "LIVED_PAIN"
+    assert packet["article_type"] == "HOW_TO"
+    assert len(packet["lived_pain_anchors"]) == 3
+
+
+def test_lived_pain_sequence_shows_pain_before_explanation():
+    packet = build()
+    sequence = packet["narrative"]["sequence"]
+    assert sequence[:6] == [
+        "raw_pain_line",
+        "concrete_scene",
+        "failed_attempt_or_trigger",
+        "friction_loop",
+        "cost_or_stakes",
+        "origin_statement_if_attested",
+    ]
+    assert sequence.index("mechanism") < sequence.index("solution")
+    assert sequence.index("solution") < sequence.index("reader_bridge")
+
+
+def test_lived_pain_preserves_raw_voice_in_policy():
+    packet = build()
+    assert packet["voice_policy"]["preserve_attested_raw_pain"] is True
+    assert packet["voice_policy"]["preserve_colloquial_force"] is True
+    assert "sanitize" in packet["voice_policy"]["lived_pain_rule"]
+
+
+def test_explicit_lived_pain_requires_attested_anchor():
+    source = brief()
+    source["primary_info"] = [
+        {
+            "claim": "一工程だけ切る方がいいと考えている。",
+            "source_ref": "human_attestation:belief",
+            "attested": True,
+            "kind": "BELIEF",
+        }
+    ]
+    source["opening_mode"] = "LIVED_PAIN"
+
+    with pytest.raises(XArticleEngineError, match="LIVED_PAIN requires"):
+        build(source)
+
+
+def test_relational_mode_remains_available_without_lived_pain_anchor():
+    source = brief()
+    source["primary_info"] = [
+        {
+            "claim": "一工程だけ切る方がいいと考えている。",
+            "source_ref": "human_attestation:belief",
+            "attested": True,
+            "kind": "BELIEF",
+        }
+    ]
+    packet = build(source)
+    assert packet["opening_mode"] == "RELATABLE"
+
+
+def test_human_gate_checks_felt_pain_and_scene_truth():
+    packet = build()
+    checks = packet["human_gate"]["checks"]
+    assert any("make the pain felt" in item for item in checks)
+    assert any("scene detail" in item for item in checks)

--- a/x_article_engine/LIVED_PAIN_KNOWLEDGE.md
+++ b/x_article_engine/LIVED_PAIN_KNOWLEDGE.md
@@ -1,0 +1,133 @@
+# X Article Engine — Lived Pain Knowledge
+
+## Why this was added
+
+The first BridgePatch dogfood draft was logically clear but emotionally weak. It opened by explaining the reader's repetitive-work problem instead of making the pain felt.
+
+Human review supplied a stronger first-party origin scene:
+
+- video editing with CapCut was attempted and abandoned;
+- a simpler self-made tool was built by cutting functions and reducing choices;
+- making it usable by other people created a large validation burden;
+- unexpected operations had to be anticipated;
+- fix -> check -> fix -> full check -> another breakage became an apparent endless-repair loop;
+- the work produced no direct revenue, but skipping it could create defects and complaints;
+- that frustration became part of the origin of the work that later became BridgePatch thinking.
+
+The lesson is not to copy those exact sentences into every article. The lesson is a narrative rule.
+
+## Core doctrine
+
+**Do not explain pain first when strong human-attested lived pain exists. Show it first.**
+
+A weak opening says:
+
+```text
+You probably have repetitive work.
+AI may help.
+Here is why the work remains.
+```
+
+A lived-pain opening says:
+
+```text
+raw frustration
+-> concrete scene
+-> failed attempt / trigger
+-> repeated friction loop
+-> emotional or economic cost
+-> "this is why I started doing this"
+-> mechanism
+-> solution
+-> reader bridge
+-> offer
+```
+
+The first version describes a problem. The second lets the reader experience why the problem mattered enough to create a solution.
+
+## LIVED_PAIN opening mode
+
+Use `LIVED_PAIN` when there is human-attested primary information of kind `PAIN`, `FAILURE`, or `ORIGIN` that is directly relevant to the article's central pain.
+
+Recommended sequence:
+
+1. `raw_pain_line`
+   - Preserve the emotional force of a real line such as frustration, confusion, exhaustion, or disbelief.
+   - Do not replace it with a polite marketing summary.
+
+2. `concrete_scene`
+   - What was the person actually trying to do?
+   - Use only attested details.
+
+3. `failed_attempt_or_trigger`
+   - What forced the person into the problem?
+   - Failure is useful only when it is real.
+
+4. `friction_loop`
+   - Show the repeated work as actions, not abstractions.
+   - Example shape: fix -> check -> fix -> check -> full check -> another breakage.
+
+5. `cost_or_stakes`
+   - Explain why the annoying work cannot simply be ignored.
+   - Revenue, complaints, risk, time, responsibility, or emotional load may be used only when attested/evidence-bound.
+
+6. `origin_statement`
+   - If attested, state that this pain became the reason the person started the work/product/approach.
+
+7. `mechanism`
+   - Generalize from the lived scene into a reusable explanation.
+
+8. `solution`
+   - Give the reader the useful method.
+
+9. `reader_bridge`
+   - Connect the writer's specific pain to the reader's analogous pain without pretending the situations are identical.
+
+10. `single_cta`
+   - Offer one next action.
+
+## Voice rules
+
+- Preserve attested roughness, irritation, humor, self-criticism, and colloquial rhythm when they carry meaning.
+- Do not sanitize `あーめんどくさい` into `課題を感じていました` unless the human asks for a formal tone.
+- Short action repetition can be stronger than explanation: `直す。チェックする。また直す。`
+- A coined self-label such as `シムシティ化` is allowed when it came from the human source; do not present it as established industry terminology.
+- Do not fabricate dialogue, chronology, duration, frequency, job history, or emotional intensity to make the scene cinematic.
+
+## Pain before product
+
+The offer should feel like the consequence of the problem, not the reason the article exists.
+
+Preferred causal order:
+
+```text
+I hit this pain
+-> I tried to solve it
+-> I learned why it kept expanding
+-> I changed the way I cut the problem
+-> the same principle applies to this reader's work
+-> this is what BridgePatch now helps with
+```
+
+Avoid:
+
+```text
+BridgePatch exists
+-> therefore let me manufacture a relatable problem around it
+```
+
+## Relationship to article types
+
+`LIVED_PAIN` is an opening mode, not a replacement article type.
+
+- `HOW_TO + LIVED_PAIN`: lived pain proves why the method exists, then the method dominates.
+- `STORY + LIVED_PAIN`: the pain loop and turning point dominate, followed by a useful reader connection.
+- `CASE_RESULT + LIVED_PAIN`: only when verified customer-result evidence exists; first-party pain must not substitute for a customer case.
+
+## Human gate question
+
+Add this question during `/human`:
+
+> Does the opening make the pain felt before it explains the pain, and is every emotional/detail claim actually mine?
+
+If the answer is no, either restore the real first-party scene or use another opening mode rather than inventing one.

--- a/x_article_engine/core.py
+++ b/x_article_engine/core.py
@@ -10,9 +10,18 @@ class XArticleEngineError(ValueError):
 
 
 ARTICLE_TYPES = {"HOW_TO", "STORY", "CASE_RESULT"}
-OPENING_MODES = {"RELATABLE", "PROOF_FIRST", "CONTRARIAN"}
+OPENING_MODES = {"RELATABLE", "PROOF_FIRST", "CONTRARIAN", "LIVED_PAIN"}
 TOPIC_MODES = {"PROCEDURAL", "HABIT", "RELATIONSHIP", "BUSINESS"}
-PRIMARY_INFO_KINDS = {"EXPERIENCE", "BELIEF", "FAILURE", "CHRONOLOGY", "OPINION"}
+PRIMARY_INFO_KINDS = {
+    "EXPERIENCE",
+    "BELIEF",
+    "FAILURE",
+    "CHRONOLOGY",
+    "OPINION",
+    "PAIN",
+    "ORIGIN",
+}
+LIVED_PAIN_KINDS = {"PAIN", "FAILURE", "ORIGIN"}
 
 REQUIRED_FIELDS = (
     "offer",
@@ -155,7 +164,7 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
         kind = _text(raw.get("kind", "EXPERIENCE"), "primary_info[].kind").upper()
         if kind not in PRIMARY_INFO_KINDS:
             raise XArticleEngineError(
-                "primary_info[].kind must be EXPERIENCE, BELIEF, FAILURE, CHRONOLOGY, or OPINION"
+                "primary_info[].kind must be EXPERIENCE, BELIEF, FAILURE, CHRONOLOGY, OPINION, PAIN, or ORIGIN"
             )
         if not isinstance(attested, bool):
             raise XArticleEngineError("primary_info[].attested must be boolean")
@@ -168,6 +177,10 @@ def _normalize_primary_info(items: object) -> tuple[list[dict], list[str]]:
                 f"primary_info {index} excluded because it is not human-attested: {claim}"
             )
     return accepted, warnings
+
+
+def _has_lived_pain(primary_info: list[dict]) -> bool:
+    return any(item["kind"] in LIVED_PAIN_KINDS for item in primary_info)
 
 
 def normalize_brief(source: dict, *, trusted_source_refs: list[dict]) -> dict:
@@ -220,16 +233,23 @@ def normalize_brief(source: dict, *, trusted_source_refs: list[dict]) -> dict:
 
     opening_mode = normalized.get("opening_mode")
     if opening_mode is None:
-        opening_mode = "PROOF_FIRST" if any(
-            item["kind"] in {"RESULT", "CASE_RESULT"} for item in verified
-        ) else "RELATABLE"
+        if any(item["kind"] in {"RESULT", "CASE_RESULT"} for item in verified):
+            opening_mode = "PROOF_FIRST"
+        elif _has_lived_pain(primary_info):
+            opening_mode = "LIVED_PAIN"
+        else:
+            opening_mode = "RELATABLE"
     opening_mode = _text(opening_mode, "opening_mode").upper()
     if opening_mode not in OPENING_MODES:
         raise XArticleEngineError(
-            "opening_mode must be RELATABLE, PROOF_FIRST, or CONTRARIAN"
+            "opening_mode must be RELATABLE, PROOF_FIRST, CONTRARIAN, or LIVED_PAIN"
         )
     if opening_mode == "PROOF_FIRST" and not verified:
         raise XArticleEngineError("PROOF_FIRST requires verified evidence")
+    if opening_mode == "LIVED_PAIN" and not _has_lived_pain(primary_info):
+        raise XArticleEngineError(
+            "LIVED_PAIN requires human-attested PAIN, FAILURE, or ORIGIN primary_info"
+        )
     normalized["opening_mode"] = opening_mode
 
     normalized["review_state"] = "REVIEW_REQUIRED" if normalized["warnings"] else "DRAFT"
@@ -250,14 +270,67 @@ def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) ->
         shape = "Use concrete business logic, scope, trade-offs, and reproducible reasoning."
 
     if brief["article_type"] == "HOW_TO":
-        body_pattern = ["conclusion_or_overview", "method", "why_it_works", "stumbling_points", "conditions_and_limits"]
+        body_pattern = [
+            "conclusion_or_overview",
+            "method",
+            "why_it_works",
+            "stumbling_points",
+            "conditions_and_limits",
+        ]
     elif brief["article_type"] == "STORY":
-        body_pattern = ["interesting_destination_or_failure", "previous_state", "turning_point", "what_changed", "lesson", "reader_connection"]
+        body_pattern = [
+            "interesting_destination_or_failure",
+            "previous_state",
+            "turning_point",
+            "what_changed",
+            "lesson",
+            "reader_connection",
+        ]
     else:
-        body_pattern = ["before", "after", "what_changed", "why_it_worked", "reproduction_conditions"]
+        body_pattern = [
+            "before",
+            "after",
+            "what_changed",
+            "why_it_worked",
+            "reproduction_conditions",
+        ]
+
+    lived_pain_anchors = [
+        item for item in brief["verified_primary_info"] if item["kind"] in LIVED_PAIN_KINDS
+    ]
+    if brief["opening_mode"] == "LIVED_PAIN":
+        narrative_sequence = [
+            "raw_pain_line",
+            "concrete_scene",
+            "failed_attempt_or_trigger",
+            "friction_loop",
+            "cost_or_stakes",
+            "origin_statement_if_attested",
+            "mechanism",
+            "solution",
+            "reader_bridge",
+            "one_action_today",
+            "single_cta",
+        ]
+        opening_doctrine = (
+            "Show human-attested pain before explaining it. Let the offer emerge as a consequence "
+            "of the problem rather than manufacturing a problem around the offer."
+        )
+    else:
+        narrative_sequence = [
+            "reader_state",
+            "evidence_if_available",
+            "anticipated_objection",
+            "cause",
+            "solution",
+            "stumbling_point",
+            "one_action_today",
+            "single_cta",
+        ]
+        opening_doctrine = "Use the selected opening mode without inventing scene details."
 
     return {
-        "schema_version": "0.2",
+        "schema_version": "0.3",
         "offer": brief["offer"],
         "target": brief["target"],
         "pain": brief["pain"],
@@ -268,26 +341,31 @@ def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) ->
         "verified_source_refs": brief["verified_source_refs"],
         "verified_evidence": brief["verified_evidence"],
         "verified_primary_info": brief["verified_primary_info"],
+        "lived_pain_anchors": lived_pain_anchors,
         "narrative": {
             "top_level_order": ["EMOTION", "LOGIC", "EASY_NEXT_ACTION"],
             "body_pattern": body_pattern,
             "depth_layers": ["L1_CONCLUSION", "L2_REASON", "L3_CONDITIONS_EXCEPTIONS"],
-            "sequence": ["reader_state", "evidence_if_available", "anticipated_objection", "cause", "solution", "stumbling_point", "one_action_today", "single_cta"],
+            "sequence": narrative_sequence,
+            "opening_doctrine": opening_doctrine,
             "topic_shape": shape,
         },
         "voice_policy": {
             "preserve_attested_opinion": True,
             "preserve_attested_self_labels": True,
+            "preserve_attested_raw_pain": True,
+            "preserve_colloquial_force": True,
             "hedge_verified_facts": False,
             "generic_filler": "avoid",
             "strong_judgment_rule": "Strong opinions are allowed when they are explicitly human-attested as BELIEF or OPINION; do not convert them into factual guarantees.",
             "concrete_language_rule": "Be vivid and specific using bound evidence and attested primary information; safety must not flatten the writer's voice.",
+            "lived_pain_rule": "Do not sanitize a real frustration line into polite marketing language when LIVED_PAIN is active. Short repeated actions may be used to make a real friction loop felt.",
         },
         "generation_constraints": [
             "Use only verified_evidence for externally checkable facts, prices, timing, scope, and results.",
-            "Use first-person history, failure, emotion, belief, or chronology only from verified_primary_info.",
+            "Use first-person history, failure, emotion, belief, pain, origin, or chronology only from verified_primary_info.",
             "Never invent a number to satisfy a density or title rule; a numberless title is valid.",
-            "Derived arithmetic must be bound as its own verified evidence claim before generation; v0.2 does not auto-authorize new computed numbers.",
+            "Derived arithmetic must be bound as its own verified evidence claim before generation; v0.3 does not auto-authorize new computed numbers.",
             "Do not strengthen commercial or contractual wording beyond the verified claim.",
             "Do not present an invented label as established terminology.",
             "Explain specialist terms inline in plain language.",
@@ -295,7 +373,10 @@ def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) ->
             "Give exactly one practical next action and one CTA.",
             "Do not blame or rank the reader.",
             "Natural hybridization is allowed when strong human-attested primary information helps the article, but the selected article_type remains the dominant structure.",
-            "Do not add chronology, job history, customer history, frequency, duration, or role details that are absent from verified_primary_info.",
+            "Do not add chronology, job history, customer history, frequency, duration, role details, dialogue, or emotional intensity that are absent from verified_primary_info.",
+            "When opening_mode is LIVED_PAIN, start from an attested pain/failure/origin anchor rather than a generic summary of the target reader's pain.",
+            "When opening_mode is LIVED_PAIN, show the concrete friction loop before abstracting it into a general lesson.",
+            "When opening_mode is LIVED_PAIN, connect the lived scene to the reader by analogy; do not claim their situation is identical.",
             "The draft is not publishable until /human review passes.",
         ],
         "human_gate": {
@@ -305,6 +386,8 @@ def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) ->
                 "Are all first-person details true and mine?",
                 "Are all numbers, prices, timing, results, and scope evidence-bound?",
                 "Did the draft invent emotion, biography, customer outcomes, or certainty?",
+                "If LIVED_PAIN is active, does the opening make the pain felt before explaining it?",
+                "If LIVED_PAIN is active, are every scene detail and emotional line actually mine?",
                 "Does the CTA still match the offer and only ask for one next action?",
                 "Did the rewrite preserve factual and risk boundaries?",
             ],
@@ -370,7 +453,13 @@ def _identity_findings(draft: str, packet: dict) -> list[str]:
 def _commercial_findings(draft: str, packet: dict) -> list[str]:
     normalized_draft = _norm(draft)
     bound = _norm(_commercial_text(packet))
-    return sorted({marker for marker in COMMERCIAL_RISK_MARKERS if marker in normalized_draft and marker not in bound})
+    return sorted(
+        {
+            marker
+            for marker in COMMERCIAL_RISK_MARKERS
+            if marker in normalized_draft and marker not in bound
+        }
+    )
 
 
 def audit_draft(draft: str, packet: dict) -> dict:
@@ -388,13 +477,21 @@ def audit_draft(draft: str, packet: dict) -> dict:
 
     findings = []
     for claim in unbound_numeric:
-        findings.append({"code": "UNBOUND_NUMERIC_CLAIM", "severity": "BLOCK", "detail": claim})
+        findings.append(
+            {"code": "UNBOUND_NUMERIC_CLAIM", "severity": "BLOCK", "detail": claim}
+        )
     for claim in unbound_fuzzy:
-        findings.append({"code": "UNBOUND_FUZZY_QUANT_CLAIM", "severity": "BLOCK", "detail": claim})
+        findings.append(
+            {"code": "UNBOUND_FUZZY_QUANT_CLAIM", "severity": "BLOCK", "detail": claim}
+        )
     for sentence in identity_details:
-        findings.append({"code": "UNBOUND_IDENTITY_DETAIL", "severity": "BLOCK", "detail": sentence})
+        findings.append(
+            {"code": "UNBOUND_IDENTITY_DETAIL", "severity": "BLOCK", "detail": sentence}
+        )
     for marker in strengthened:
-        findings.append({"code": "UNBOUND_STRONG_CLAIM", "severity": "BLOCK", "detail": marker})
+        findings.append(
+            {"code": "UNBOUND_STRONG_CLAIM", "severity": "BLOCK", "detail": marker}
+        )
 
     blocked = any(item["severity"] == "BLOCK" for item in findings)
     return {


### PR DESCRIPTION
## Summary
- add `LIVED_PAIN` opening mode
- add `PAIN` and `ORIGIN` human-attested primary-info kinds
- when strong lived pain exists, show it before explaining the problem
- encode the sequence `raw pain -> scene -> trigger -> friction loop -> stakes -> origin -> mechanism -> solution -> reader bridge -> CTA`
- preserve attested colloquial force instead of sanitizing it into generic marketing prose
- keep HOW_TO / STORY / CASE_RESULT as the dominant article types
- add dedicated lived-pain knowledge and regression tests

## Dogfood finding
The first BridgePatch draft was logically clear but emotionally weak because it started by explaining the reader's pain. Human review showed that the actual product-origin frustration was a much stronger opening and was already available as first-party evidence.

## Safety boundary
`LIVED_PAIN` can activate only from human-attested `PAIN`, `FAILURE`, or `ORIGIN` material. It must not invent scene details, dialogue, chronology, duration, or emotional intensity.

Publication remains blocked pending `/human` and USER_ONLY.

## Verification
New regression tests are included. No CI result is claimed in this PR body.