### PR TITLE
Teach X Article Engine first-use terminology

### DIFF
--- a/tests/test_x_article_engine_terminology.py
+++ b/tests/test_x_article_engine_terminology.py
@@ -1,0 +1,149 @@
+from x_article_engine import audit_draft, build_generation_packet
+
+
+def source():
+    return {
+        "offer": "BridgePatchで一工程の手作業を小さく改善する。",
+        "target": "毎週、転記や確認を手作業している小規模事業者。",
+        "pain": "AIを使えそうでも、何をどう渡せばいいか分からない。",
+        "primary_info": [
+            {
+                "claim": "動画編集でCapCutに挑戦したが挫折し、自分が迷わないよう機能を削ったツールを作った。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            }
+        ],
+        "article_type": "HOW_TO",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "terms_to_explain": [
+            {
+                "term": "CapCut",
+                "explanation": "スマホなどで使える動画編集アプリ",
+                "anchors": ["動画編集", "アプリ"],
+                "min_anchor_matches": 2,
+            }
+        ],
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def trusted():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def packet():
+    return build_generation_packet(source(), trusted_source_refs=trusted())
+
+
+def test_packet_defaults_to_general_non_technical_reader():
+    result = packet()
+    assert result["schema_version"] == "0.4"
+    assert result["reader_model"]["knowledge_level"] == "GENERAL_NON_TECH"
+    assert result["terminology_policy"]["explain_on_first_use"] is True
+
+
+def test_first_product_mention_requires_katakana_reading_once():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatchでは、まず作業を一工程だけ切ります。",
+        result,
+    )
+    assert audit["status"] == "BLOCKED"
+    assert any(
+        item["code"] == "MISSING_PRODUCT_READING_ON_FIRST_USE"
+        for item in audit["findings"]
+    )
+
+
+def test_product_reading_once_then_plain_name_passes_product_gate():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）は一工程だけを扱います。後でBridgePatchの無料確認を使えます。",
+        result,
+    )
+    assert not any(
+        item["code"].startswith("MISSING_PRODUCT") or item["code"] == "REPEATED_PRODUCT_READING"
+        for item in audit["findings"]
+    )
+
+
+def test_repeated_product_reading_is_blocked():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）を紹介します。後でもBridgePatch（ブリッジパッチ）を使います。",
+        result,
+    )
+    assert any(item["code"] == "REPEATED_PRODUCT_READING" for item in audit["findings"])
+
+
+def test_csv_without_first_use_explanation_is_blocked():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）ではCSVを受け取って処理します。",
+        result,
+    )
+    assert any(
+        item["code"] == "UNEXPLAINED_TERM_ON_FIRST_USE" and item["detail"] == "CSV"
+        for item in audit["findings"]
+    )
+
+
+def test_csv_with_plain_language_explanation_passes_term_gate():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）では、CSVというExcelなどで開ける表形式のデータファイルを扱えます。",
+        result,
+    )
+    assert not any(
+        item["code"] == "UNEXPLAINED_TERM_ON_FIRST_USE" and item["detail"] == "CSV"
+        for item in audit["findings"]
+    )
+
+
+def test_debug_without_explanation_is_blocked():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。次にデバッグをしました。",
+        result,
+    )
+    assert any(
+        item["code"] == "UNEXPLAINED_TERM_ON_FIRST_USE" and item["detail"] == "デバッグ"
+        for item in audit["findings"]
+    )
+
+
+def test_debug_with_plain_language_explanation_passes_term_gate():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。デバッグ、つまりプログラムの不具合の原因を探して直す作業も必要になりました。",
+        result,
+    )
+    assert not any(
+        item["code"] == "UNEXPLAINED_TERM_ON_FIRST_USE" and item["detail"] == "デバッグ"
+        for item in audit["findings"]
+    )
+
+
+def test_custom_capcut_term_is_explained_on_first_use():
+    result = packet()
+    audit = audit_draft(
+        "BridgePatch（ブリッジパッチ）を作る前、CapCutという動画編集アプリに挑戦しました。",
+        result,
+    )
+    assert not any(
+        item["code"] == "UNEXPLAINED_TERM_ON_FIRST_USE" and item["detail"] == "CapCut"
+        for item in audit["findings"]
+    )

--- a/x_article_engine/TERMINOLOGY_KNOWLEDGE.md
+++ b/x_article_engine/TERMINOLOGY_KNOWLEDGE.md
@@ -1,0 +1,69 @@
+# X Article Engine — General-reader terminology knowledge
+
+## Principle
+
+If the intended reader may not know a word, do not force them to leave the article to understand it.
+
+The first occurrence of an unfamiliar term should contain a short plain-language explanation in the same sentence or immediately after it. The explanation should make the article easier to read, not feel like a dictionary entry.
+
+Default assumption for sales / educational X Articles: the reader is a general non-technical reader unless the brief explicitly says otherwise.
+
+## First-occurrence rule
+
+Good:
+
+- `CSVという、Excelなどで開ける表形式のデータファイル`
+- `デバッグ、つまりプログラムの不具合の原因を探して直す作業`
+- `CapCutという動画編集アプリ`
+
+Bad:
+
+- `CSVを読み込む`
+- `デバッグする`
+- `APIで連携する`
+
+when the article has not yet explained those terms.
+
+After the first explanation, the short term may be used normally.
+
+## Do not label the reader
+
+Do not write things such as:
+
+- `非エンジニアには分からないと思いますが`
+- `IT音痴でも分かるように`
+- `初心者向けに説明すると`
+
+Those labels can make the reader feel ranked or talked down to. Explain the term naturally without classifying the reader.
+
+## Product-name reading
+
+When a product or service name is visually unfamiliar, the first natural introduction should include a katakana reading exactly once.
+
+Example:
+
+`BridgePatch（ブリッジパッチ）`
+
+Later mentions use only:
+
+`BridgePatch`
+
+Do not repeat the reading every time.
+
+## General-reader glossary seed
+
+This is a starting set, not an exhaustive dictionary. Add terms when dogfooding shows that a general reader may stumble.
+
+- `CSV`: a table-shaped data file that can be opened in spreadsheet software such as Excel.
+- `デバッグ`: finding the cause of a program problem and fixing it.
+- `ログ`: a record of what a program did and when.
+- `API`: a mechanism that lets one service or program exchange information with another.
+- `リポジトリ`: a place where program files and their change history are stored together.
+- `プロンプト`: the instruction or request given to an AI.
+- `自動化`: making a repeated manual step run by a program or AI under defined conditions.
+
+## Writing rule
+
+Prefer a tiny appositive explanation over a footnote or glossary section. The reader should learn the word exactly where they encounter it.
+
+The goal is not to eliminate technical words. The goal is to make every necessary word understandable without breaking reading flow.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,9 +1,5 @@
-from .core import (
-    XArticleEngineError,
-    audit_draft,
-    build_generation_packet,
-    normalize_brief,
-)
+from .core import XArticleEngineError, normalize_brief
+from .terminology import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/terminology.py
+++ b/x_article_engine/terminology.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+from copy import deepcopy
+import unicodedata
+
+from . import core as _core
+
+
+DEFAULT_READER_MODEL = "GENERAL_NON_TECH"
+EXPLANATION_WINDOW_CHARS = 180
+
+DEFAULT_GENERAL_READER_GLOSSARY = (
+    {
+        "term": "CSV",
+        "explanation": "Excelなどで開ける、表の形でデータを保存するファイル",
+        "anchors": ("Excel", "表", "データ", "ファイル"),
+        "min_anchor_matches": 2,
+    },
+    {
+        "term": "デバッグ",
+        "explanation": "プログラムの不具合の原因を探して直す作業",
+        "anchors": ("不具合", "原因", "直"),
+        "min_anchor_matches": 2,
+    },
+    {
+        "term": "ログ",
+        "explanation": "プログラムがいつ何をしたか残す記録",
+        "anchors": ("プログラム", "記録", "残"),
+        "min_anchor_matches": 2,
+    },
+    {
+        "term": "API",
+        "explanation": "サービスやプログラム同士が情報をやり取りするための仕組み",
+        "anchors": ("情報", "やり取り", "仕組み"),
+        "min_anchor_matches": 2,
+    },
+    {
+        "term": "リポジトリ",
+        "explanation": "プログラムのファイルと変更履歴をまとめて保管する場所",
+        "anchors": ("ファイル", "変更", "履歴", "保管"),
+        "min_anchor_matches": 2,
+    },
+    {
+        "term": "プロンプト",
+        "explanation": "AIに渡す指示やお願い",
+        "anchors": ("AI", "指示"),
+        "min_anchor_matches": 2,
+    },
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _optional_text(value: object, field: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise _core.XArticleEngineError(f"{field} must be a non-empty string when provided")
+    return value.strip()
+
+
+def _normalize_term(raw: object, field: str) -> dict:
+    if not isinstance(raw, dict):
+        raise _core.XArticleEngineError(f"{field} entries must be objects")
+    term = _optional_text(raw.get("term"), f"{field}[].term")
+    explanation = _optional_text(raw.get("explanation"), f"{field}[].explanation")
+    if term is None or explanation is None:
+        raise _core.XArticleEngineError(f"{field} entries require term and explanation")
+
+    anchors_raw = raw.get("anchors")
+    if anchors_raw is None:
+        anchors = [explanation]
+    else:
+        if not isinstance(anchors_raw, (list, tuple)) or not anchors_raw:
+            raise _core.XArticleEngineError(f"{field}[].anchors must be a non-empty list")
+        anchors = []
+        for item in anchors_raw:
+            anchor = _optional_text(item, f"{field}[].anchors[]")
+            if anchor is None:
+                raise _core.XArticleEngineError(f"{field}[].anchors[] cannot be empty")
+            anchors.append(anchor)
+
+    minimum = raw.get("min_anchor_matches", min(2, len(anchors)))
+    if not isinstance(minimum, int) or minimum < 1 or minimum > len(anchors):
+        raise _core.XArticleEngineError(
+            f"{field}[].min_anchor_matches must be between 1 and len(anchors)"
+        )
+
+    return {
+        "term": term,
+        "explanation": explanation,
+        "anchors": anchors,
+        "min_anchor_matches": minimum,
+    }
+
+
+def _compile_glossary(source: dict) -> list[dict]:
+    merged: dict[str, dict] = {}
+    for item in DEFAULT_GENERAL_READER_GLOSSARY:
+        normalized = _normalize_term(deepcopy(item), "default_glossary")
+        merged[_norm(normalized["term"])] = normalized
+
+    custom = source.get("terms_to_explain", [])
+    if not isinstance(custom, list):
+        raise _core.XArticleEngineError("terms_to_explain must be a list")
+    for item in custom:
+        normalized = _normalize_term(item, "terms_to_explain")
+        merged[_norm(normalized["term"])] = normalized
+    return list(merged.values())
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Build the core packet and add general-reader comprehension policy.
+
+    The wrapper keeps the evidence and publication boundaries in ``core`` intact,
+    while adding a deterministic first-occurrence terminology contract.
+    """
+    packet = _core.build_generation_packet(
+        source,
+        trusted_source_refs=trusted_source_refs,
+    )
+
+    reader_model = _optional_text(
+        source.get("reader_knowledge_level", DEFAULT_READER_MODEL),
+        "reader_knowledge_level",
+    )
+    product_name = _optional_text(source.get("product_name"), "product_name")
+    product_reading = _optional_text(source.get("product_reading"), "product_reading")
+    if (product_name is None) != (product_reading is None):
+        raise _core.XArticleEngineError(
+            "product_name and product_reading must be provided together"
+        )
+
+    glossary = _compile_glossary(source)
+    packet["schema_version"] = "0.4"
+    packet["reader_model"] = {
+        "knowledge_level": reader_model,
+        "default_assumption": (
+            "Assume a general non-technical reader unless the brief explicitly says otherwise."
+        ),
+    }
+    packet["terminology_policy"] = {
+        "explain_on_first_use": True,
+        "placement": "same_sentence_or_immediately_after",
+        "style": "short_plain_language_apposition_not_dictionary_entry",
+        "when_in_doubt": "explain",
+        "do_not_label_reader": True,
+        "glossary": glossary,
+    }
+    packet["product_naming_policy"] = {
+        "product_name": product_name,
+        "product_reading": product_reading,
+        "first_mention_format": (
+            f"{product_name}（{product_reading}）"
+            if product_name and product_reading
+            else None
+        ),
+        "reading_occurrences": 1 if product_name else 0,
+        "later_mentions": product_name,
+    }
+
+    packet["generation_constraints"].extend(
+        [
+            "Assume the reader may not know technical or industry-specific terms. Explain each unfamiliar term at its first occurrence in the same sentence or immediately after it.",
+            "After an unfamiliar term has been explained once, use the short term normally; do not repeatedly re-explain it.",
+            "Do not call the reader an IT novice, non-engineer, beginner, or similar label merely to justify an explanation; just explain the word naturally.",
+            "If product_naming_policy.first_mention_format is set, use that exact product-name-plus-katakana-reading form at the first natural product introduction and use only the product name thereafter.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "Could a general non-technical reader understand every necessary unfamiliar word without leaving the article?",
+            "Are unfamiliar terms explained exactly where they first appear, rather than much later?",
+            "If a product reading is configured, is it shown only on the first product mention?",
+        ]
+    )
+    return packet
+
+
+def _product_name_findings(draft: str, packet: dict) -> list[dict]:
+    policy = packet.get("product_naming_policy") or {}
+    name = policy.get("product_name")
+    reading = policy.get("product_reading")
+    expected = policy.get("first_mention_format")
+    if not name or not reading or not expected:
+        return []
+
+    normalized = _norm(draft)
+    normalized_name = _norm(name)
+    normalized_expected = _norm(expected)
+    first = normalized.find(normalized_name)
+    if first < 0:
+        return [
+            {
+                "code": "MISSING_PRODUCT_INTRODUCTION",
+                "severity": "BLOCK",
+                "detail": expected,
+            }
+        ]
+
+    findings = []
+    if not normalized.startswith(normalized_expected, first):
+        findings.append(
+            {
+                "code": "MISSING_PRODUCT_READING_ON_FIRST_USE",
+                "severity": "BLOCK",
+                "detail": expected,
+            }
+        )
+    if normalized.count(normalized_expected) > 1:
+        findings.append(
+            {
+                "code": "REPEATED_PRODUCT_READING",
+                "severity": "BLOCK",
+                "detail": expected,
+            }
+        )
+    return findings
+
+
+def _term_findings(draft: str, packet: dict) -> list[dict]:
+    policy = packet.get("terminology_policy") or {}
+    if not policy.get("explain_on_first_use"):
+        return []
+
+    normalized = _norm(draft)
+    findings = []
+    for item in policy.get("glossary", []):
+        term = _norm(item["term"])
+        position = normalized.find(term)
+        if position < 0:
+            continue
+        window = normalized[position : position + EXPLANATION_WINDOW_CHARS]
+        anchors = [_norm(anchor) for anchor in item.get("anchors", [])]
+        matches = sum(1 for anchor in anchors if anchor in window)
+        minimum = int(item.get("min_anchor_matches", 1))
+        if matches < minimum:
+            findings.append(
+                {
+                    "code": "UNEXPLAINED_TERM_ON_FIRST_USE",
+                    "severity": "BLOCK",
+                    "detail": item["term"],
+                    "expected_explanation": item["explanation"],
+                }
+            )
+    return findings
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run core evidence audit plus reader-comprehension checks."""
+    result = _core.audit_draft(draft, packet)
+    findings = [
+        *result.get("findings", []),
+        *_product_name_findings(draft, packet),
+        *_term_findings(draft, packet),
+    ]
+    blocked = any(item.get("severity") == "BLOCK" for item in findings)
+    result["findings"] = findings
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    return result


### PR DESCRIPTION
## Summary
- default sales/educational articles to a general non-technical reader model
- explain unfamiliar terms on first use, in-place, rather than assuming technical knowledge
- add a seed glossary for CSV, デバッグ, ログ, API, リポジトリ, and プロンプト
- allow article-specific glossary entries such as CapCut
- require unfamiliar product names to show a configured katakana reading on the first mention only
- add deterministic audit findings for missing first-use explanations and product-reading errors
- keep evidence, /human, and USER_ONLY publication boundaries unchanged

## Dogfood finding
BridgePatch draft review showed that terms such as CSV and デバッグ were clear to an engineer but could lose a general reader. The article should not make the reader leave the page to decode a necessary word.

## Writing doctrine
Use the term if it is useful, but explain it naturally where it first appears. Do not label the reader as IT音痴, beginner, or non-engineer just to justify an explanation.

For BridgePatch, the first natural product introduction is expected to be `BridgePatch（ブリッジパッチ）`; later mentions use only `BridgePatch`.

## Verification
Regression tests were added for the terminology and product-reading gate. No CI result is claimed in this PR body.