### PR TITLE
Teach X Article Engine broad-entry deep-body structure

### DIFF
--- a/tests/test_x_article_engine_deep_readable.py
+++ b/tests/test_x_article_engine_deep_readable.py
@@ -1,0 +1,86 @@
+from x_article_engine import build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def test_packet_uses_deep_readable_layer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.5"
+    assert packet["opening_mode"] == "LIVED_PAIN"
+    assert packet["terminology_policy"]["explain_on_first_use"] is True
+    assert packet["product_naming_policy"]["first_mention_format"] == "BridgePatch（ブリッジパッチ）"
+    assert "entry_rule" in packet["comprehension_doctrine"]
+    assert "transition_rule" in packet["claim_layer_policy"]
+    assert "promise_payoff_rule" in packet["reader_progression_policy"]
+    assert "anti_metric_trap" in packet["commercial_article_policy"]
+
+
+def test_reference_article_platform_claims_are_not_imported_as_truth():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    rendered = repr(packet["reference_learning_boundary"])
+    # Writing lessons are imported; specific platform claims are explicitly not.
+    assert "platform algorithm weights" in rendered
+    assert "ranking constants" in rendered
+    assert "time windows" in rendered
+    assert "20.0" not in rendered
+    assert "48時間" not in rendered
+    assert "PageRank" not in rendered
+    assert "Agatha" not in rendered
+
+
+def test_commercial_priority_puts_reader_and_offer_before_distribution():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    priorities = packet["commercial_article_policy"]["priority_order"]
+    assert priorities == [
+        "WHO_TO_REACH",
+        "WHAT_TO_HELP_THEM_UNDERSTAND",
+        "WHAT_STATE_TO_LEAVE_THEM_IN",
+        "HOW_TO_MAXIMIZE_DISTRIBUTION",
+    ]
+
+
+def test_human_gate_checks_fact_interpretation_boundary_and_payoff():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "source-backed fact" in checks
+    assert "forward promise" in checks
+    assert "first-time reader" in checks

--- a/x_article_engine/DEEP_READABLE_KNOWLEDGE.md
+++ b/x_article_engine/DEEP_READABLE_KNOWLEDGE.md
@@ -1,0 +1,196 @@
+# X Article Engine — Broad Entry / Deep Body Knowledge
+
+## Source boundary
+
+This knowledge was extracted from a public long-form X article supplied during dogfooding.
+
+We are learning **writing structure**, not treating the article's claims about X ranking, weights, time windows, internal systems, or business results as verified facts.
+
+Those claims may only enter a generated article if they separately pass the normal evidence boundary.
+
+## Core lesson
+
+A strong educational sales article can have both:
+
+- an entrance understandable to someone hearing the topic for the first time;
+- a body deep enough that an experienced reader still gets a useful distinction, mechanism, exception, or implication.
+
+Accessibility is not simplification into emptiness.
+
+```text
+wide entrance
+-> orient the reader
+-> define unfamiliar terms
+-> simple mechanism
+-> example
+-> objection / exception
+-> deeper mechanism
+-> synthesis
+-> relevant offer
+```
+
+## 1. Orient before going deep
+
+A strong hook can create attention without creating understanding.
+
+When the article is about a dense mechanism, follow the hook or lived scene with a compact orientation when useful:
+
+1. what happened;
+2. what it means;
+3. what this article covers.
+
+This is not a mandatory literal heading called “3 lines.” It is a comprehension pattern.
+
+## 2. Define terms at first use
+
+This works together with `TERMINOLOGY_KNOWLEDGE.md`.
+
+Do not make the reader hold an unknown word in memory while waiting for a definition later.
+
+Use:
+
+```text
+term -> immediate plain-language meaning -> continue
+```
+
+Then use the short term normally after the first explanation.
+
+## 3. Narrow claims need early scope boundaries
+
+If a fact applies only to one part of a product, one recommendation surface, one workflow, one period, or one condition, say so close to the first claim.
+
+A narrow true claim must not become a broad misleading claim because the qualification arrived several sections later.
+
+## 4. Fact, experience, interpretation, and opinion are different layers
+
+Use four visible layers:
+
+- `VERIFIED_FACT`: source-bound external fact;
+- `HUMAN_EXPERIENCE`: attested first-person event/result;
+- `INTERPRETATION`: what the writer infers from the facts;
+- `OPINION`: the writer's judgment or preference.
+
+The transition matters.
+
+Good:
+
+> ここまでは確認できる事実です。ここからは私の解釈です。
+
+Bad:
+
+> A fact is followed by an inference with no signal, making the inference look equally proven.
+
+## 5. Answer the obvious objection near the claim
+
+When a reasonable reader is likely to think:
+
+> でも、それなら○○は？
+
+answer it close to the claim that causes the question.
+
+This prevents the reader from carrying unresolved doubt through the rest of the article.
+
+## 6. Use callbacks and payoffs
+
+Long articles feel coherent when later sections deliberately reconnect to earlier ideas.
+
+A useful pattern is:
+
+```text
+seed idea
+-> go deeper
+-> return to seed
+-> reveal why it mattered
+```
+
+A forward promise such as “this connects later” is allowed only if the article actually returns and pays it off.
+
+Unpaid promises are clickbait inside the article.
+
+## 7. Separate distribution from business objective
+
+For a commercial article, raw reach is not the final target.
+
+Use two axes:
+
+```text
+READ AXIS
+Can the intended reader enter, understand, and keep reading?
+
+COMMERCIAL AXIS
+Does the intended reader finish with a clearer reason to care about the relevant offer?
+```
+
+Platform engagement may help distribution, but it is not a substitute for qualified interest.
+
+The order is:
+
+```text
+what is being offered
+-> who should care
+-> what they should understand / feel by the end
+-> how to keep them reading
+-> then distribution optimization
+```
+
+## 8. The offer should emerge from the mechanism
+
+Do not teach one thing and then append an unrelated advertisement.
+
+Prefer:
+
+```text
+problem
+-> mechanism
+-> practical way to handle it
+-> offer is the implementation / assistance path for that same mechanism
+```
+
+This makes the CTA feel like the next step rather than a commercial interruption.
+
+## 9. Own failure can beat abstract authority
+
+If a verified first-person failure directly explains why the current method exists, it can be stronger than generic expert positioning.
+
+Use it only when attested.
+
+The point is not self-deprecation. The point is causal credibility:
+
+```text
+I hit this problem
+-> this is what made it painful
+-> this changed how I approach it
+-> this is the method I now use
+```
+
+## 10. What we deliberately do not import
+
+Do not import as engine truth:
+
+- third-party algorithm weights;
+- ranking constants;
+- post-age windows;
+- platform-internal component names;
+- third-party revenue or impression results;
+- tactical conclusions that depend on current platform behavior.
+
+Those are evidence, not writing doctrine.
+
+## BridgePatch implication
+
+For the current BridgePatch article, the combined doctrine is now:
+
+```text
+attested raw pain
+-> concrete development scene
+-> first-use explanations for unfamiliar words
+-> why the endless work happened
+-> シムシティ化 explained in plain language
+-> one-process boundary
+-> reader analogy
+-> BridgePatch（ブリッジパッチ） as the natural consequence
+-> exact evidence-bound commercial terms
+-> one next action / CTA
+```
+
+The opening should remain emotionally real. The middle should become progressively clearer and deeper, not progressively more technical and exclusionary.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .terminology import audit_draft, build_generation_packet
+from .deep_readable import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/deep_readable.py
+++ b/x_article_engine/deep_readable.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+from . import terminology as _terminology
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Build an evidence-bound article packet with broad-entry/deep-body teaching rules.
+
+    This layer learns writing structure from public reference articles without
+    importing their time-sensitive platform claims as facts. It extends the
+    terminology-aware packet and keeps /human + USER_ONLY publication intact.
+    """
+    packet = _terminology.build_generation_packet(
+        source,
+        trusted_source_refs=trusted_source_refs,
+    )
+
+    packet["schema_version"] = "0.5"
+    packet["comprehension_doctrine"] = {
+        "entry_rule": "Make the entrance understandable to a reader who has never heard the concept before.",
+        "depth_rule": "After the reader is oriented, go deep enough that an experienced reader still learns something.",
+        "orientation_rule": (
+            "After a strong hook or lived scene, if the article becomes concept-dense, give a compact 2-3 line orientation: what happened, what it means, and what scope this article covers."
+        ),
+        "scope_rule": (
+            "State the scope early when a claim applies only to one surface, workflow, feature, period, or condition; do not let a narrow fact sound universal."
+        ),
+        "analogy_rule": "Explain abstract mechanisms with one familiar analogy before adding technical detail.",
+    }
+
+    packet["claim_layer_policy"] = {
+        "separate": ["VERIFIED_FACT", "HUMAN_EXPERIENCE", "INTERPRETATION", "OPINION"],
+        "verified_fact": "State directly when evidence-bound.",
+        "human_experience": "Use only attested primary information.",
+        "interpretation": "Signal clearly that the sentence is an interpretation, inference, or reading rather than source fact.",
+        "opinion": "Allow strong human-attested judgment without upgrading it into a factual guarantee.",
+        "transition_rule": "When moving from source-backed fact to interpretation, tell the reader the boundary changed.",
+    }
+
+    packet["reader_progression_policy"] = {
+        "sequence": [
+            "hook_or_lived_pain",
+            "orientation_if_needed",
+            "plain_language_definition",
+            "simple_mechanism",
+            "concrete_example",
+            "obvious_reader_objection",
+            "scope_or_exception",
+            "deeper_mechanism",
+            "synthesis_callback",
+            "one_action",
+            "single_cta",
+        ],
+        "objection_rule": (
+            "When a reasonable reader is likely to think 'but what about X?', answer it near the claim instead of waiting until the end."
+        ),
+        "callback_rule": (
+            "Reuse an earlier concept near the synthesis so the article feels connected rather than like separate sections."
+        ),
+        "promise_payoff_rule": (
+            "A forward promise such as 'this connects later' is allowed only when the article actually returns to it and pays it off."
+        ),
+    }
+
+    packet["commercial_article_policy"] = {
+        "priority_order": [
+            "WHO_TO_REACH",
+            "WHAT_TO_HELP_THEM_UNDERSTAND",
+            "WHAT_STATE_TO_LEAVE_THEM_IN",
+            "HOW_TO_MAXIMIZE_DISTRIBUTION",
+        ],
+        "read_axis": "The article must be understandable and compelling enough to keep the intended reader moving.",
+        "sell_axis": (
+            "By the end, the intended reader should understand why the offer is relevant; the goal is product curiosity or qualified next-step interest, not raw reach alone."
+        ),
+        "anti_metric_trap": (
+            "Do not treat impressions, likes, replies, saves, shares, or any single platform metric as the business objective unless the brief explicitly makes it the objective."
+        ),
+        "offer_bridge_rule": (
+            "The offer should appear as the natural consequence of the article's problem and mechanism, not as a detached advertisement appended at the end."
+        ),
+    }
+
+    packet["reference_learning_boundary"] = {
+        "imported": [
+            "broad entrance plus deep body",
+            "early scope clarification",
+            "fact-versus-interpretation labeling",
+            "nearby objection handling",
+            "callbacks and promise/payoff structure",
+            "read-through plus commercial-relevance dual objective",
+        ],
+        "not_imported_as_truth": [
+            "platform algorithm weights",
+            "ranking constants",
+            "time windows",
+            "named internal systems",
+            "reference author's business results",
+        ],
+    }
+
+    packet["generation_constraints"].extend(
+        [
+            "Open broadly enough for a first-time reader, then deepen the explanation; do not confuse accessibility with shallowness.",
+            "If a technical or dense section follows the hook, orient the reader in 2-3 short lines before the deep explanation when that improves comprehension.",
+            "State narrow scope and exceptions near the first claim they qualify.",
+            "Keep verified facts, human experience, interpretation, and opinion visibly distinct; explicitly signal the transition from fact to interpretation.",
+            "Answer the most obvious reasonable objection close to the claim that creates it.",
+            "Use callbacks to earlier ideas when synthesizing the article, and never make a forward promise that is not paid off later.",
+            "For commercial articles, optimize both read-through and qualified product curiosity; do not substitute raw platform engagement for business relevance.",
+            "Do not import time-sensitive claims, algorithm constants, or third-party results from a reference article unless they separately enter verified_evidence.",
+        ]
+    )
+
+    packet["human_gate"]["checks"].extend(
+        [
+            "Can a first-time reader enter the article without prior domain knowledge while an experienced reader still gets a deeper mechanism or useful distinction?",
+            "Did I clearly separate source-backed fact from my interpretation or opinion?",
+            "Did I state important scope limits close to the claim they limit?",
+            "Did every forward promise or callback actually pay off?",
+            "Does the article leave the intended reader more interested in the relevant offer rather than merely chasing engagement metrics?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run evidence + terminology audit; semantic teaching checks remain /human."""
+    return _terminology.audit_draft(draft, packet)


### PR DESCRIPTION
## Summary
- add v0.5 deep-readable article layer on top of evidence + terminology gates
- teach broad entrance / deep body progression
- add optional compact orientation after hook when concept density increases
- separate verified fact, human experience, interpretation, and opinion
- answer obvious objections near the claims that create them
- add callbacks plus promise/payoff discipline
- optimize commercial articles for both read-through and qualified product curiosity
- explicitly keep platform algorithm claims, constants, named internals, and third-party results out unless separately verified

## Dogfood source
A public long-form X article supplied during review demonstrated a strong pattern: explain a difficult topic so a first-time reader can enter, while still going deep enough for experienced readers. We import that writing structure, not its time-sensitive claims about X ranking behavior.

## BridgePatch implication
The current article can now keep the lived-pain opening, explain unfamiliar words on first use, progressively deepen the mechanism, distinguish fact from interpretation, and let BridgePatch（ブリッジパッチ） emerge naturally from the mechanism.

## Verification
Regression tests were added for v0.5 policy composition and for the boundary that reference-specific algorithm values are not imported as engine truth. No CI result is claimed here.

Publication remains /human gated and USER_ONLY.