### PR TITLE
Add material-first anti-AI-smell audit layer

### DIFF
--- a/tests/test_x_article_engine_ai_humanity.py
+++ b/tests/test_x_article_engine_ai_humanity.py
@@ -1,0 +1,113 @@
+from x_article_engine import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "私はこの状態をシムシティ化と呼んでいる。",
+                "source_ref": "human_attestation:label",
+                "attested": True,
+                "kind": "OPINION",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def packet():
+    return build_generation_packet(brief(), trusted_source_refs=sources())
+
+
+def test_packet_adds_material_first_and_ai_smell_policy():
+    result = packet()
+    assert result["schema_version"] == "0.6"
+    assert "recipe_vs_ingredients" in result["material_first_policy"]
+    assert "abstract_word_rule" in result["anti_ai_smell_policy"]
+    assert "specificity_without_hallucination" in result["specificity_policy"]
+
+
+def test_empty_abstract_words_are_reviewed_not_automatically_blocked():
+    result = audit_draft(
+        "全体の構造を理解することが重要です。\n"
+        "BridgePatch（ブリッジパッチ）は無料適合確認から始めます。",
+        packet(),
+    )
+    codes = [item["code"] for item in result["findings"]]
+    assert "ABSTRACT_WORD_WITHOUT_PAYLOAD" in codes
+    assert result["ai_smell_gate"] == "REVIEW"
+
+
+def test_concrete_use_of_design_word_is_not_flagged_as_empty_abstraction():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の設計では、入力→処理→出力を先に書きます。",
+        packet(),
+    )
+    empty_abstract = [
+        item for item in result["findings"] if item["code"] == "ABSTRACT_WORD_WITHOUT_PAYLOAD"
+    ]
+    assert not empty_abstract
+
+
+def test_model_coined_label_is_blocked():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）を作っています。\n"
+        "この現象を『自動化迷子現象』と呼んでいます。",
+        packet(),
+    )
+    assert any(item["code"] == "MODEL_COINED_LABEL_RISK" for item in result["findings"])
+    assert result["status"] == "BLOCKED"
+
+
+def test_attested_source_originated_label_is_allowed():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）を作っています。\n"
+        "この状態を『シムシティ化』と呼んでいます。",
+        packet(),
+    )
+    assert not any(item["code"] == "MODEL_COINED_LABEL_RISK" for item in result["findings"])
+
+
+def test_boilerplate_and_giant_subject_are_review_findings():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）を使うことが可能です。\n"
+        "多くの人は自動化で困っているのではないでしょうか。",
+        packet(),
+    )
+    codes = {item["code"] for item in result["findings"]}
+    assert "AI_BOILERPLATE_PHRASE" in codes
+    assert "GENERIC_OVERSIZED_SUBJECT" in codes
+
+
+def test_human_gate_contains_material_quality_checks():
+    checks = "\n".join(packet()["human_gate"]["checks"])
+    assert "構造・設計・本質" in checks
+    assert "three concrete things" in checks
+    assert "could only have come from" in checks

--- a/x_article_engine/AI_HUMANITY_KNOWLEDGE.md
+++ b/x_article_engine/AI_HUMANITY_KNOWLEDGE.md
@@ -1,0 +1,253 @@
+# X Article Engine — Material-First / Anti-AI-Smell Knowledge
+
+## Source boundary
+
+This knowledge was extracted from a public long-form X article supplied during dogfooding.
+
+We import writing doctrine, not the article's medical examples, third-party revenue results, impression counts, or other factual claims. Any such claim must separately pass the normal evidence boundary before it can appear in generated copy.
+
+## Core lesson
+
+AI-sounding prose is often not a model-style problem. It is a **material problem**.
+
+When the model does not have enough concrete material, it tends to preserve the shape of an article by filling space with:
+
+- abstract nouns;
+- generic advice;
+- neat but weak lists;
+- giant subjects;
+- invented labels;
+- padded wording;
+- summaries that repeat what was already said.
+
+The answer is not simply “sound more human.”
+
+The answer is:
+
+```text
+specific target
++ evidence
++ lived primary information
++ real failure
++ proper nouns
++ real objections
++ actual opinion
++ a writing recipe
+= material-rich draft
+```
+
+Writing rules are the recipe. Evidence and lived knowledge are the ingredients.
+
+## 1. Abstract nouns are not banned — empty abstraction is
+
+Words such as:
+
+- 構造
+- 設計
+- 本質
+- 重要
+- 最適化
+
+can be useful.
+
+The failure mode is using them instead of saying what is actually happening.
+
+Bad:
+
+> 全体の構造を理解し、適切に設計することが重要です。
+
+Better:
+
+> 最初に、何が入ってきて、何をして、どこへ出すかを決めます。
+
+If deleting the abstract word removes most of the meaning, the sentence probably did not contain enough material.
+
+## 2. Lists must be earned
+
+Do not manufacture:
+
+> ポイントは3つあります。
+
+just because three items look tidy.
+
+Use a list when:
+
+- the items are genuinely parallel;
+- each item is strong enough to deserve independent attention;
+- a list is clearer than prose.
+
+If ordinary prose is clearer, use prose.
+
+## 3. Do not hide thin content behind formatting
+
+Long bullet blocks can make a draft look organized while avoiding causal explanation.
+
+The engine should prefer:
+
+```text
+claim
+-> why
+-> example
+-> exception
+```
+
+when that is what the reader needs.
+
+## 4. Do not end with a generic recap
+
+A final `まとめ` that repeats the article is usually dead weight.
+
+Prefer one of these endings:
+
+- return to the opening pain and show what changed;
+- pay off an earlier promise;
+- give one action the reader can do now;
+- let the offer become the natural next step.
+
+## 5. Avoid giant unsupported subjects
+
+Watch for:
+
+- 多くの人は
+- 現代人は
+- 誰もが
+- みんなが
+- 一般的に
+
+These phrases are often used when the real target has not been specified.
+
+Write to the configured reader or describe the observed situation instead.
+
+## 6. Direct language beats reflexive hedging
+
+Do not automatically end claims with:
+
+- 〜ではないでしょうか
+- 〜と言えるでしょう
+
+If the sentence is a verified fact, state the fact.
+
+If it is an opinion, mark it as the writer's opinion and say it directly.
+
+If uncertainty is real, keep the uncertainty.
+
+The goal is not false confidence. The goal is to remove automatic cowardly phrasing.
+
+## 7. Do not invent terminology to create authority
+
+The pattern:
+
+> これを○○と呼んでいます。
+
+is prohibited when the label was invented by the model.
+
+A source-originated self-label is different.
+
+For example, if the human explicitly uses `シムシティ化`, the article may preserve it because it is primary information. It should still explain the term on first use if a general reader may not know the reference.
+
+## 8. Compress padded phrases
+
+Prefer:
+
+- `できます`
+
+over
+- `することが可能です`
+
+Prefer the shortest natural Japanese that preserves meaning.
+
+## 9. The target changes the material that matters
+
+A broad target produces broad advice.
+
+The target should be specific enough that the engine can decide:
+
+- which pain matters;
+- which example matters;
+- which objection matters;
+- which explanation depth matters;
+- which offer bridge feels natural.
+
+Do not add fake specificity when the target is vague. Surface the target problem instead.
+
+## 10. Specificity must be evidence-bound
+
+Concrete writing is not permission to hallucinate.
+
+Use exact numbers only when verified.
+
+Use lived scenes only when attested.
+
+Use proper nouns only when known.
+
+Use direct opinions only when genuinely supplied by the human.
+
+If those ingredients are missing, shorten or narrow the article.
+
+## 11. Five useful ingredient classes
+
+When available, prioritize:
+
+1. exact verified numbers;
+2. real failure or frustration;
+3. proper nouns and actual tools/products;
+4. likely reader objections supplied by the brief or framed clearly as questions;
+5. the writer's real opinion, rule, anger, or judgment.
+
+These are not quotas. Do not invent missing classes to complete the set.
+
+## 12. Human review test: “What could only have come from me?”
+
+Before publication, identify the sentences that could not have been produced from generic model averages alone.
+
+They should come from:
+
+- evidence;
+- the writer's lived experience;
+- a failure;
+- a real opinion;
+- specific context;
+- a real constraint;
+- an actual offer.
+
+If almost every sentence could fit anyone, the article is still thin.
+
+## 13. Reader learning test
+
+Ask:
+
+> この読者が「知らなかった」と言える具体的なことを3つ挙げられるか？
+
+This is a diagnostic, not a generation quota.
+
+If there are fewer than three, do **not** fabricate three facts.
+
+Instead:
+
+- narrow the article;
+- add genuine material;
+- improve the explanation;
+- or accept that the article should be shorter.
+
+## BridgePatch implication
+
+The current BridgePatch article should now combine:
+
+```text
+attested pain
+-> real Vlog-development friction
+-> unfamiliar words explained immediately
+-> no empty 構造/設計/本質 filler
+-> no forced three-point list
+-> シムシティ化 only because it is human-originated
+-> concrete mechanism
+-> one-process rule
+-> reader analogy
+-> BridgePatch（ブリッジパッチ）
+-> exact evidence-bound commercial terms
+-> one action / CTA
+```
+
+The goal is not to disguise AI usage.
+
+The goal is to prevent the model from replacing missing human material with generic prose.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .deep_readable import audit_draft, build_generation_packet
+from .ai_humanity import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/ai_humanity.py
+++ b/x_article_engine/ai_humanity.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import deep_readable as _deep
+
+
+ABSTRACT_FILLER_MARKERS = (
+    "構造",
+    "設計",
+    "本質",
+    "重要です",
+    "大切です",
+    "最適化",
+)
+
+GENERIC_SUBJECT_MARKERS = (
+    "多くの人は",
+    "多くの人が",
+    "現代人は",
+    "誰もが",
+    "みんなが",
+    "一般的に",
+)
+
+AI_BOILERPLATE_MARKERS = (
+    "いかがでしたでしょうか",
+    "することが可能です",
+    "することができます",
+    "〜ではないでしょうか",
+    "ではないでしょうか",
+    "と言えるでしょう",
+)
+
+FORCED_LIST_PATTERNS = (
+    re.compile(r"ポイントは\s*[三3]つ(?:です|あります)"),
+    re.compile(r"理由は\s*[三3]つ(?:です|あります)"),
+    re.compile(r"方法は\s*[三3]つ(?:です|あります)"),
+)
+
+COINED_LABEL_RE = re.compile(
+    r"(?:これ|この状態|こうした状態|この現象|この問題)を[^。\n]{0,50}(?:と呼んでいます|と呼びます|と名付けています)"
+)
+
+SUMMARY_MARKERS = (
+    "■ まとめ",
+    "■まとめ",
+    "最後にまとめると",
+    "ここまでをまとめると",
+)
+
+CONCRETE_SIGNAL_RE = re.compile(
+    r"(?:\d|円|%|％|時間|分|日|件|回|人|社|月|年|→|：|:|「|」|Excel|CSV|AI|X|BridgePatch|CapCut|Claude|GitHub)"
+)
+
+BULLET_RE = re.compile(r"^\s*(?:[-・●▪︎]|\d+[.．)]|[①-⑳])")
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    normalized = _norm(text)
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", normalized)
+        if item.strip()
+    ]
+
+
+def _primary_text(packet: dict) -> str:
+    return "\n".join(
+        item.get("claim", "") for item in packet.get("verified_primary_info", [])
+    )
+
+
+def _abstract_filler_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        markers = [marker for marker in ABSTRACT_FILLER_MARKERS if marker in sentence]
+        if not markers:
+            continue
+        if CONCRETE_SIGNAL_RE.search(sentence):
+            continue
+        if len(sentence) >= 90:
+            continue
+        findings.append(
+            {
+                "code": "ABSTRACT_WORD_WITHOUT_PAYLOAD",
+                "severity": "REVIEW",
+                "detail": sentence,
+                "markers": markers,
+            }
+        )
+    return findings
+
+
+def _generic_subject_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    return [
+        {
+            "code": "GENERIC_OVERSIZED_SUBJECT",
+            "severity": "REVIEW",
+            "detail": marker,
+        }
+        for marker in GENERIC_SUBJECT_MARKERS
+        if marker in normalized
+    ]
+
+
+def _boilerplate_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    findings = [
+        {
+            "code": "AI_BOILERPLATE_PHRASE",
+            "severity": "REVIEW",
+            "detail": marker,
+        }
+        for marker in AI_BOILERPLATE_MARKERS
+        if marker in normalized
+    ]
+    for pattern in FORCED_LIST_PATTERNS:
+        match = pattern.search(normalized)
+        if match:
+            findings.append(
+                {
+                    "code": "FORCED_LIST_FRAME",
+                    "severity": "REVIEW",
+                    "detail": match.group(0),
+                }
+            )
+    return findings
+
+
+def _summary_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    return [
+        {
+            "code": "REDUNDANT_SUMMARY_RISK",
+            "severity": "REVIEW",
+            "detail": marker,
+        }
+        for marker in SUMMARY_MARKERS
+        if marker in normalized
+    ]
+
+
+def _bullet_escape_findings(draft: str) -> list[dict]:
+    lines = [line.strip() for line in _norm(draft).splitlines() if line.strip()]
+    if len(lines) < 10:
+        return []
+    bullet_count = sum(1 for line in lines if BULLET_RE.match(line))
+    ratio = bullet_count / len(lines)
+    if bullet_count >= 8 and ratio >= 0.45:
+        return [
+            {
+                "code": "EXCESSIVE_BULLET_ESCAPE",
+                "severity": "REVIEW",
+                "detail": f"{bullet_count}/{len(lines)} non-empty lines are bullets",
+            }
+        ]
+    return []
+
+
+def _coined_label_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    primary = _norm(_primary_text(packet))
+    findings: list[dict] = []
+    for match in COINED_LABEL_RE.finditer(normalized):
+        phrase = match.group(0)
+        if phrase not in primary and not any(
+            token and token in primary
+            for token in re.findall(r"[「『]([^」』]+)[」』]", phrase)
+        ):
+            findings.append(
+                {
+                    "code": "MODEL_COINED_LABEL_RISK",
+                    "severity": "BLOCK",
+                    "detail": phrase,
+                }
+            )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Add material-first and anti-AI-smell writing doctrine to the v0.5 packet."""
+    packet = _deep.build_generation_packet(
+        source,
+        trusted_source_refs=trusted_source_refs,
+    )
+    packet["schema_version"] = "0.6"
+
+    packet["material_first_policy"] = {
+        "principle": "The model may organize material, but it may not manufacture material to make prose feel specific.",
+        "available_material": [
+            "verified external facts and exact numbers",
+            "human-attested failures and lived scenes",
+            "human-attested opinions and judgments",
+            "specific tools, products, places, documents, and other proper nouns when evidence-bound or attested",
+            "reader objections that are supplied or safely inferred as questions rather than claimed facts",
+        ],
+        "recipe_vs_ingredients": (
+            "Writing rules are the recipe. Evidence, primary experience, target detail, numbers, failures, proper nouns, and opinions are the ingredients. A better recipe cannot compensate for missing ingredients."
+        ),
+        "no_padding_rule": (
+            "When material is thin, shorten the article or request/flag missing material; do not pad with abstract nouns, generic advice, invented jargon, or fake specificity."
+        ),
+    }
+
+    packet["anti_ai_smell_policy"] = {
+        "abstract_word_rule": (
+            "Words such as 構造, 設計, 本質, 重要, and 最適化 are allowed only when the sentence immediately says what concrete thing they refer to."
+        ),
+        "list_rule": (
+            "Do not force 'three points' or a numbered list merely because it looks organized. Use a list only when the items are genuinely parallel and each item earns its place."
+        ),
+        "prose_rule": "If ordinary prose is clearer than bullets, write prose.",
+        "summary_rule": (
+            "Do not add a generic final summary that merely repeats the article. Close by paying off the opening, giving the one next action, or making the CTA natural."
+        ),
+        "subject_rule": (
+            "Avoid unsupported giant subjects such as 多くの人 or 現代人. Name the actual target or describe the observed situation."
+        ),
+        "assertion_rule": (
+            "Prefer a direct evidence-bound statement or clearly labeled opinion over reflexive hedging such as 〜ではないでしょうか."
+        ),
+        "coined_term_rule": (
+            "Do not invent 'これを○○と呼びます' terminology. Source-originated self-labels such as an attested シムシティ化 may be preserved and explained."
+        ),
+        "compression_rule": (
+            "Replace padded constructions such as 〜することが可能です with the shortest natural wording such as できます when meaning is preserved."
+        ),
+    }
+
+    packet["specificity_policy"] = {
+        "target_first": (
+            "A specific reader changes what details matter. Do not write for everyone when the offer is for someone in a concrete situation."
+        ),
+        "specificity_without_hallucination": (
+            "Specificity must come from evidence or human-attested material. If a useful number or proper noun is unavailable, do not invent one just to sound human."
+        ),
+        "translation_rule": (
+            "When a verified technical number or concept can be translated into a familiar comparison without changing its meaning, use the comparison after the original fact."
+        ),
+    }
+
+    packet["generation_constraints"].extend(
+        [
+            "Do not use abstract nouns such as 構造, 設計, 本質, 重要, or 最適化 as substitutes for missing content; immediately name the concrete object, action, condition, or trade-off they refer to.",
+            "Do not force three-point lists, bullet lists, or a final summary for visual neatness. Structure must follow the material, not the other way around.",
+            "Avoid unsupported giant subjects such as 多くの人, 現代人, or 誰もが; write to the configured target or the observed situation.",
+            "Prefer direct natural Japanese over padded AI boilerplate such as 〜することが可能です or generic 〜ではないでしょうか hedging.",
+            "Do not invent a named concept using 'これを○○と呼びます'. Preserve a coined label only when it exists in human-attested primary information, and explain it on first use when unfamiliar.",
+            "If the available evidence and primary information cannot support three genuinely new concrete takeaways, do not fake them. Shorten, narrow, or surface the material gap.",
+            "Use failure, exact experience, proper nouns, exact verified numbers, objections, and real opinion when available; these are content ingredients, not decorative style tokens.",
+        ]
+    )
+
+    packet["human_gate"]["checks"].extend(
+        [
+            "If I delete words like 構造・設計・本質, does concrete meaning remain in the surrounding sentences?",
+            "Are any bullet lists present because the ideas are genuinely parallel, or because the draft escaped into formatting?",
+            "Does the ending add a payoff or next action instead of repeating the article as a generic summary?",
+            "Did the draft use a giant subject such as 多くの人 without evidence or need?",
+            "Can I name at least three concrete things this intended reader could genuinely say they learned from this article? If not, is the article too thin?",
+            "Which sentences could only have come from my evidence, experience, failure, judgment, or specific context rather than from a generic model average?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run v0.5 safety/comprehension audit plus deterministic AI-smell heuristics."""
+    result = _deep.audit_draft(draft, packet)
+    findings = [
+        *result.get("findings", []),
+        *_coined_label_findings(draft, packet),
+        *_abstract_filler_findings(draft),
+        *_generic_subject_findings(draft),
+        *_boilerplate_findings(draft),
+        *_summary_findings(draft),
+        *_bullet_escape_findings(draft),
+    ]
+    blocked = any(item.get("severity") == "BLOCK" for item in findings)
+    review_count = sum(1 for item in findings if item.get("severity") == "REVIEW")
+    result["findings"] = findings
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["ai_smell_review_count"] = review_count
+    result["ai_smell_gate"] = "REVIEW" if review_count else "CLEAN_BY_HEURISTIC"
+    return result


### PR DESCRIPTION
## Summary
- add X Article Engine v0.6 material-first / anti-AI-smell layer
- treat writing rules as recipe and evidence/primary information as ingredients
- review empty abstraction (`構造`, `設計`, `本質`, etc.) without banning legitimate concrete usage
- review giant unsupported subjects, reflexive hedging, padded wording, forced 3-point frames, redundant summaries, and bullet-list escape
- block model-invented `これを○○と呼びます` labels unless the label is present in human-attested primary information
- add human checks for "what could only have come from me?" and the 3-concrete-learnings diagnostic
- preserve all v0.5 evidence, terminology, deep-readable, /human, and USER_ONLY boundaries

## Source boundary
The public reference article supplied during dogfooding is used only for writing doctrine. Its medical examples, third-party revenue/impression results, and other factual claims are not imported as truth.

## Design decision
AI-smell findings such as abstraction, generic subjects, and boilerplate are REVIEW findings rather than publication BLOCKs. The goal is to remove generic model-average prose without making the engine afraid to write. Evidence violations and model-invented authority labels can still block.

## Verification
Regression tests were added for v0.6 composition, abstraction review, concrete abstraction allowance, model-coined labels, attested labels, and boilerplate/giant-subject review. No CI result is claimed here.

Publication remains `/human` gated and USER_ONLY.