### PR TITLE
Add value-driven long-form reader filtering layer

### DIFF
--- a/tests/test_x_article_engine_longform_filter.py
+++ b/tests/test_x_article_engine_longform_filter.py
@@ -1,0 +1,105 @@
+from x_article_engine import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def test_packet_adds_value_driven_longform_layer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.7"
+    assert "length_rule" in packet["longform_policy"]
+    assert "section_utility_rule" in packet["longform_policy"]
+    assert "heading_rule" in packet["longform_policy"]
+    assert "why_rule" in packet["longform_policy"]
+    assert "cta_continuity_rule" in packet["longform_policy"]
+    assert "selective_attrition" in packet["longform_reader_journey"]
+
+
+def test_reference_metrics_and_fixed_length_are_not_imported_as_truth():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    rendered = repr(packet)
+    assert "8,645" not in rendered
+    assert "1.8万" not in rendered
+    assert "868万円" not in rendered
+    assert "6,000字" not in rendered
+    assert "a fixed character count required for filtering" in rendered
+
+
+def test_dense_mobile_paragraph_is_reviewed_not_blocked_by_longform_layer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = "これは読みやすさを確認するための文章です。" * 20
+    result = audit_draft(draft, packet)
+    codes = [item["code"] for item in result["findings"]]
+    assert "DENSE_MOBILE_PARAGRAPH" in codes
+    assert result["status"] in {"HUMAN_REVIEW_REQUIRED", "BLOCKED"}
+
+
+def test_long_draft_without_scan_path_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    paragraph = "手作業が増える理由を一つずつ説明します。ここでは範囲を小さく切る考え方を扱います。"
+    draft = "\n\n".join([paragraph] * 80)
+    result = audit_draft(draft, packet)
+    codes = [item["code"] for item in result["findings"]]
+    assert "LONGFORM_WEAK_SCAN_PATH" in codes
+
+
+def test_long_draft_with_informative_headings_has_scan_path():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    paragraph = "手作業が増える理由を一つずつ説明します。範囲を小さく切ると、どこで止めるかを決めやすくなります。"
+    sections = []
+    for heading in [
+        "■ なぜ仕事が増え続けるのか",
+        "■ 全部ではなく一工程だけ切る",
+        "■ 失敗したら人に戻せるようにする",
+        "■ その考えを仕事に使う",
+    ]:
+        sections.append(heading + "\n\n" + "\n\n".join([paragraph] * 18))
+    draft = "\n\n".join(sections)
+    result = audit_draft(draft, packet)
+    codes = [item["code"] for item in result["findings"]]
+    assert "LONGFORM_WEAK_SCAN_PATH" not in codes
+
+
+def test_human_gate_checks_section_utility_and_cta_continuity():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "Could I delete a section" in checks
+    assert "scan only the headings" in checks
+    assert "why it matters" in checks
+    assert "commercial break" in checks

--- a/x_article_engine/LONGFORM_FILTER_KNOWLEDGE.md
+++ b/x_article_engine/LONGFORM_FILTER_KNOWLEDGE.md
@@ -1,0 +1,218 @@
+# X Article Engine — Value-Driven Long-Form Knowledge
+
+## Source boundary
+
+This doctrine was extracted from a public long-form X article supplied during dogfooding.
+
+We learn the writing strategy, not the reference author's metrics, revenue claims, save counts, conversion rates, or any universal claim that long articles automatically create better buyers.
+
+Those factual claims remain ordinary evidence and must pass the evidence gate before appearing in another article.
+
+## Core lesson
+
+A long article does not need every reader to finish.
+
+Its job can be narrower:
+
+- let weakly interested readers leave;
+- make it unusually easy for the intended reader to keep going;
+- give that reader enough depth to understand the mechanism, writer, and offer before the CTA.
+
+But length is not magic.
+
+The useful principle is:
+
+```text
+selective audience
++ useful depth
++ low reading friction
++ coherent CTA
+```
+
+not:
+
+```text
+more characters = better buyers
+```
+
+## 1. Length follows value
+
+Never stretch a short point into a long article.
+
+Every section must add at least one thing that was not already earned elsewhere:
+
+- evidence;
+- lived detail;
+- mechanism;
+- example;
+- objection;
+- exception;
+- decision rule;
+- practical action;
+- offer bridge.
+
+If a section can disappear without changing what the intended reader understands or does, cut it.
+
+## 2. It is okay for uninterested readers to leave
+
+Do not write for universal completion.
+
+A commercial X article can intentionally prioritize the reader who has real interest in the problem.
+
+This is a strategy, not a guaranteed causal fact.
+
+Good framing:
+
+> この記事は、全員に最後まで読んでもらうより、この問題を本気で解決したい人が迷わず読み進められることを優先する。
+
+Bad framing:
+
+> 長文を最後まで読む人は必ず濃い見込み客になる。
+
+The second claim requires evidence and is too broad as a default doctrine.
+
+## 3. Headings are a second reading layer
+
+Long articles have two readers:
+
+1. the person reading every line;
+2. the person scanning before deciding whether to commit.
+
+Headings should therefore carry the argument.
+
+A reader scanning only headings should still see:
+
+```text
+problem
+-> cause
+-> what changed
+-> why it matters
+-> objection / limit
+-> solution
+-> next step
+```
+
+Headings should explain location and direction, not merely tease.
+
+## 4. Mobile layout is part of comprehension
+
+A correct article can still fail because it looks expensive to read.
+
+Prefer:
+
+- short paragraphs;
+- frequent whitespace;
+- clear transitions;
+- no giant unbroken text walls.
+
+Do not impose a rigid sentence-per-line rule. The goal is low visual friction on a phone.
+
+## 5. Answer first, then reason
+
+When the reader is waiting for an answer, do not make them cross a long explanation just to discover the conclusion.
+
+Prefer:
+
+```text
+answer / conclusion
+-> why
+-> mechanism
+-> conditions / exception
+```
+
+This does not mean every paragraph starts with a conclusion. It means do not manufacture suspense where clarity is more valuable.
+
+## 6. Every method needs a why
+
+A method without a reason can be copied but not adapted.
+
+Whenever the article tells the reader to do something important, include why it matters.
+
+The desired end state is not:
+
+> I can copy the author's steps.
+
+It is:
+
+> I understand the rule well enough to decide when to use it myself.
+
+## 7. CTA should continue the article
+
+Do not stop an educational story for an unrelated advertisement.
+
+Prefer:
+
+```text
+problem
+-> mechanism
+-> practical handling
+-> here is the next step if you want help doing exactly this
+```
+
+The CTA should feel like the next page, not a commercial break.
+
+For BridgePatch, that means the article should naturally establish why one-process scoping matters before BridgePatch（ブリッジパッチ） appears as help with that exact task.
+
+## 8. Do not confuse distribution with selection
+
+A long-form commercial article may accept lower universal completion if it improves depth with the intended reader.
+
+But do not treat:
+
+- length;
+- saves;
+- time spent;
+- likes;
+- list size;
+- impressions;
+
+as proof of qualified demand by themselves.
+
+The commercial question remains:
+
+> Did the intended reader finish with a clearer reason to care about the relevant offer?
+
+## 9. Close with payoff, not padding
+
+A long article already asked for significant attention.
+
+Do not repay that attention with a generic recap of everything the reader just read.
+
+Prefer one of:
+
+- return to the opening pain and show what changed;
+- give the one next action;
+- surface the decision rule;
+- make the CTA the natural continuation.
+
+## 10. What we deliberately do not import
+
+Do not import as engine truth:
+
+- the reference author's likes or saves;
+- the reference author's list size or sales;
+- any fixed article length;
+- any claim that long-form readers are inherently better customers;
+- any platform-specific tactic whose value depends on current X behavior.
+
+## BridgePatch implication
+
+The first BridgePatch article can now use this combined flow:
+
+```text
+raw frustration
+-> concrete endless-fix loop
+-> compact orientation
+-> first clear insight
+-> why the problem expanded
+-> unfamiliar terms explained on first use
+-> シムシティ化 as an attested label
+-> obvious objection: testing still matters
+-> one-process boundary and rollback logic
+-> why this is useful to ordinary office work
+-> BridgePatch（ブリッジパッチ） as the continuation
+-> exact evidence-bound commercial terms
+-> one next action
+```
+
+The article may be long if the material earns it. It must not be long because the engine has a target character count.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .ai_humanity import audit_draft, build_generation_packet
+from .longform_filter import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/longform_filter.py
+++ b/x_article_engine/longform_filter.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import ai_humanity as _humanity
+
+
+LONGFORM_REVIEW_THRESHOLD_CHARS = 2400
+DENSE_PARAGRAPH_THRESHOLD_CHARS = 260
+MIN_HEADINGS_FOR_LONGFORM_REVIEW = 3
+
+HEADING_RE = re.compile(
+    r"^\s*(?:■|#{1,4}\s+|【[^】]{1,80}】|[0-9０-９]+[.．]\s*[^\n]{1,80}$)"
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _nonempty_paragraphs(text: str) -> list[str]:
+    normalized = _norm(text).replace("\r\n", "\n")
+    return [item.strip() for item in re.split(r"\n\s*\n+", normalized) if item.strip()]
+
+
+def _heading_lines(text: str) -> list[str]:
+    return [
+        line.strip()
+        for line in _norm(text).splitlines()
+        if line.strip() and HEADING_RE.match(line)
+    ]
+
+
+def _layout_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    normalized = _norm(draft)
+
+    if len(normalized) >= LONGFORM_REVIEW_THRESHOLD_CHARS:
+        headings = _heading_lines(normalized)
+        if len(headings) < MIN_HEADINGS_FOR_LONGFORM_REVIEW:
+            findings.append(
+                {
+                    "code": "LONGFORM_WEAK_SCAN_PATH",
+                    "severity": "REVIEW",
+                    "detail": (
+                        f"long draft has only {len(headings)} recognizable headings; "
+                        "check whether a mobile reader can follow the story by scanning headings"
+                    ),
+                }
+            )
+
+    for paragraph in _nonempty_paragraphs(normalized):
+        if len(paragraph) > DENSE_PARAGRAPH_THRESHOLD_CHARS and "\n" not in paragraph:
+            findings.append(
+                {
+                    "code": "DENSE_MOBILE_PARAGRAPH",
+                    "severity": "REVIEW",
+                    "detail": paragraph[:120],
+                }
+            )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Add value-driven long-form and qualified-reader filtering doctrine to v0.6."""
+    packet = _humanity.build_generation_packet(
+        source,
+        trusted_source_refs=trusted_source_refs,
+    )
+    packet["schema_version"] = "0.7"
+
+    article_goal = source.get("article_goal", "QUALIFIED_READER_EDUCATION")
+    if not isinstance(article_goal, str) or not article_goal.strip():
+        raise _humanity._deep._terminology._core.XArticleEngineError(
+            "article_goal must be a non-empty string when provided"
+        )
+    article_goal = article_goal.strip().upper()
+
+    packet["longform_policy"] = {
+        "article_goal": article_goal,
+        "length_rule": (
+            "Length follows useful material and the intended reader journey. Never stretch a short idea into a long article merely to look substantial."
+        ),
+        "qualified_reader_rule": (
+            "A long article may intentionally prioritize the intended, highly interested reader over universal completion, but length alone never proves reader quality. Treat filtering as a strategy, not a guaranteed fact."
+        ),
+        "section_utility_rule": (
+            "Every section must earn its space by adding at least one of: new evidence, lived detail, mechanism, example, objection handling, exception, decision rule, action, or offer bridge. Otherwise cut it."
+        ),
+        "mobile_rule": (
+            "Write for a phone screen: short paragraphs, visible whitespace, and clear transitions. Avoid walls of text."
+        ),
+        "heading_rule": (
+            "Headings should carry the argument. A scanning reader should understand the progression from the headings alone without headings becoming clickbait."
+        ),
+        "answer_first_rule": (
+            "Within a section, prefer the answer or conclusion before the supporting reason when delaying the answer would create needless friction."
+        ),
+        "why_rule": (
+            "When giving a method or instruction, explain why it matters so the reader can judge when to apply it without the author present."
+        ),
+        "cta_continuity_rule": (
+            "Default to a CTA that feels like the next step of the same problem and mechanism. Do not interrupt the article with an unrelated commercial break."
+        ),
+        "ending_rule": (
+            "End by paying off the opening, clarifying the one next action, or continuing naturally into the CTA. Do not add length with a redundant recap."
+        ),
+    }
+
+    packet["longform_reader_journey"] = {
+        "sequence": [
+            "hook_or_lived_pain",
+            "orientation",
+            "first_clear_answer",
+            "why_it_matters",
+            "mechanism",
+            "concrete_scene_or_example",
+            "objection_and_exception",
+            "deeper_implication",
+            "callback_to_earlier_idea",
+            "offer_as_continuation",
+            "one_next_action",
+        ],
+        "selective_attrition": (
+            "Do not contort the article to keep every possible reader. Make it easy for the intended reader to continue and acceptable for an uninterested reader to leave."
+        ),
+        "scan_path": (
+            "Use headings as a second reading layer: someone scanning headings should still know where the article is going."
+        ),
+    }
+
+    packet["reference_learning_boundary"].setdefault("not_imported_as_truth", []).extend(
+        [
+            "reference article like/save ratios",
+            "reference article revenue and list conversion results",
+            "a universal claim that long articles produce better buyers",
+            "a fixed character count required for filtering",
+        ]
+    )
+
+    packet["generation_constraints"].extend(
+        [
+            "Do not optimize for brevity by deleting necessary mechanism, evidence, objection handling, or explanation. Long-form is allowed when each section earns its space.",
+            "Do not optimize for length either. If the useful material is exhausted, stop rather than padding.",
+            "For long-form drafts, make headings informative enough that a scanning reader can follow the argument from headings alone.",
+            "Use short mobile-friendly paragraphs and whitespace; avoid dense walls of text.",
+            "Prefer a clear answer before its explanation when withholding the answer would only create friction.",
+            "Whenever a method is important, explain why it works or why the reader should care; procedure without rationale is incomplete.",
+            "Treat reader filtering as a strategic intent, not as a guaranteed causal claim about long articles or buyer quality.",
+            "Place the CTA as the natural next step of the article's problem and mechanism rather than as an unrelated mid-article commercial interruption.",
+        ]
+    )
+
+    packet["human_gate"]["checks"].extend(
+        [
+            "If this article is long, does every section add a new fact, lived detail, mechanism, example, objection, exception, decision rule, action, or offer bridge?",
+            "Could I delete a section without losing anything? If yes, delete it.",
+            "Can someone scan only the headings and still understand the article's progression?",
+            "Does the mobile layout avoid walls of text and give the reader visual breathing room?",
+            "Where I tell the reader what to do, did I also explain why it matters?",
+            "Does the CTA feel like the next step of the same article rather than a commercial break?",
+            "Am I claiming that length itself creates qualified buyers without evidence, or merely using length as an intentional filtering strategy?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run v0.6 safety/humanity audit plus conservative long-form layout review."""
+    result = _humanity.audit_draft(draft, packet)
+    findings = [*result.get("findings", []), *_layout_findings(draft)]
+    blocked = any(item.get("severity") == "BLOCK" for item in findings)
+    review_count = sum(1 for item in findings if item.get("severity") == "REVIEW")
+    result["findings"] = findings
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["longform_review_count"] = sum(
+        1
+        for item in findings
+        if item.get("code") in {"LONGFORM_WEAK_SCAN_PATH", "DENSE_MOBILE_PARAGRAPH"}
+    )
+    result["review_count"] = review_count
+    return result

--- a/x_article_engine/longform_filter.py
+++ b/x_article_engine/longform_filter.py
@@ -4,6 +4,7 @@ import re
 import unicodedata
 
 from . import ai_humanity as _humanity
+from .core import XArticleEngineError
 
 
 LONGFORM_REVIEW_THRESHOLD_CHARS = 2400
@@ -72,9 +73,7 @@ def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) ->
 
     article_goal = source.get("article_goal", "QUALIFIED_READER_EDUCATION")
     if not isinstance(article_goal, str) or not article_goal.strip():
-        raise _humanity._deep._terminology._core.XArticleEngineError(
-            "article_goal must be a non-empty string when provided"
-        )
+        raise XArticleEngineError("article_goal must be a non-empty string when provided")
     article_goal = article_goal.strip().upper()
 
     packet["longform_policy"] = {


### PR DESCRIPTION
## Summary
- add X Article Engine v0.7 long-form strategy layer on top of v0.6
- allow long articles when each section earns its space; never pad to a target length
- treat long-form as selective reader strategy, not proof of buyer quality
- require scannable headings, mobile-friendly spacing, answer-first clarity, and rationale for important methods
- make CTA continuity part of the article rather than a detached commercial break
- add conservative review findings for weak heading scan paths and dense mobile paragraphs
- preserve evidence, terminology, anti-AI-smell, /human, and USER_ONLY publication boundaries

## Source boundary
A public long-form X article supplied during dogfooding is used only for writing doctrine. Its likes, saves, list size, sales, and any fixed character counts are not imported as engine truth.

## Design decision
The engine does not assume that longer articles create better buyers. It may use long-form intentionally for a highly interested target reader, while treating that filtering effect as strategy rather than guaranteed causation.

## Verification
Regression tests were added for v0.7 composition, reference-metric isolation, mobile density review, and heading scan-path review. No CI result is claimed here.

Publication remains `/human` gated and USER_ONLY.