### PR TITLE
Add layered reader depth and market-gap strategy

### DIFF
--- a/tests/test_x_article_engine_depth_market.py
+++ b/tests/test_x_article_engine_depth_market.py
@@ -1,0 +1,102 @@
+from x_article_engine import build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計と実装へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "私はこの状態をシムシティ化と呼んでいた。",
+                "source_ref": "human_attestation:label",
+                "attested": True,
+                "kind": "OPINION",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def test_packet_uses_v08_depth_market_layer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.8"
+    assert "beginner_layer" in packet["audience_depth_policy"]
+    assert "intermediate_layer" in packet["audience_depth_policy"]
+    assert "advanced_layer" in packet["audience_depth_policy"]
+    assert "primary_source_preference" in packet["source_depth_policy"]
+    assert "commercial_cta_rule" in packet["desire_timing_policy"]
+    assert "candidate_patterns" in packet["market_gap_policy"]
+    assert "speed_rule" in packet["speed_quality_policy"]
+    assert packet["reach_conversion_policy"]["axes"] == [
+        "READ_OR_REACH",
+        "QUALIFIED_COMMERCIAL_PROGRESS",
+    ]
+
+
+def test_reference_metrics_and_speed_story_are_not_imported_as_truth():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    boundary = "\n".join(packet["reference_learning_boundary"]["not_imported_as_truth"])
+    assert "impression" in boundary
+    assert "follower" in boundary
+    assert "creation time" in boundary
+    assert "being first" in boundary
+    assert "260万" not in boundary
+    assert "700" not in boundary
+    assert "154" not in boundary
+    assert "5時間" not in boundary
+
+
+def test_counterpoint_policy_rejects_manufactured_conflict_as_doctrine():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    policy = packet["market_gap_policy"]
+    assert "evidence or a genuine human-attested belief" in policy["counterpoint_rule"]
+    assert "Do not manufacture faction conflict" in policy["conflict_rule"]
+
+
+def test_asset_timing_does_not_expand_commercial_cta_count():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    timing = packet["desire_timing_policy"]
+    assert "utility asset" in timing["utility_asset_rule"].lower()
+    assert "multiple competing commercial CTAs" in timing["utility_asset_rule"]
+    assert "singular" in timing["commercial_cta_rule"]
+
+
+def test_human_gate_checks_depth_source_market_and_reach_conversion():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "first-time reader" in checks
+    assert "comparison numbers" in checks
+    assert "strongest available source" in checks
+    assert "controversy" in checks
+    assert "reach/read metrics" in checks

--- a/x_article_engine/AUDIENCE_DEPTH_MARKET_GAP_KNOWLEDGE.md
+++ b/x_article_engine/AUDIENCE_DEPTH_MARKET_GAP_KNOWLEDGE.md
@@ -1,0 +1,239 @@
+# X Article Engine — Audience Depth / Market Gap Knowledge
+
+## Source boundary
+
+This knowledge was extracted from a public long-form X article supplied during dogfooding.
+
+We are learning **writing and positioning doctrine**, not importing the reference author's metrics, timing advantage, factual product claims, or causal conclusions as engine truth.
+
+Reference-specific claims such as impression counts, follower growth, list growth, creation time, release timing, and named product performance remain evidence that would need separate verification before use.
+
+## Core lesson
+
+A strong article can serve different knowledge depths without becoming three separate articles.
+
+The progression is:
+
+```text
+UNDERSTAND
+-> APPLY
+-> THINK DEEPER
+```
+
+The article should not call people beginner/intermediate/advanced unless that label is actually useful. Those are authoring layers, not reader rankings.
+
+## 1. Beginner layer: make the thing legible
+
+The first layer removes decoding cost.
+
+Useful tools:
+
+- explain unfamiliar terms immediately;
+- give a baseline when a verified number is meaningless in isolation;
+- state the first useful conclusion early;
+- translate technical difference into ordinary consequences without changing the claim.
+
+The desired reader state is:
+
+> やっと何の話か分かった。
+
+This extends the existing terminology and broad-entry doctrines.
+
+## 2. Intermediate layer: make it usable
+
+Once the topic is understandable, add material that helps a reader evaluate or try it.
+
+Useful tools:
+
+- strong primary/official evidence where appropriate;
+- concrete examples;
+- actual inputs and outputs;
+- conditions and exceptions;
+- realistic use cases;
+- explicit mechanism.
+
+The desired reader state is:
+
+> 自分ならどう使うか想像できる。
+
+Do not invent examples that sound plausible but are not evidence-bound or human-attested when they are presented as factual events.
+
+## 3. Advanced layer: leave a decision rule or viewpoint
+
+Depth is not more jargon.
+
+A deeper layer can be:
+
+- a trade-off;
+- a second-order effect;
+- a decision criterion;
+- why an asset or CTA belongs at a particular point;
+- a human-attested interpretation;
+- a human-attested viewpoint.
+
+The desired reader state is:
+
+> そこまで考えるのか。
+
+Do not invent an author's philosophy merely because the article needs a memorable ending.
+
+## 4. Comparison numbers need both sides
+
+A number can be true and still be unhelpful.
+
+```text
+80.3%
+```
+
+may not tell a general reader whether the value is large or small.
+
+When comparison is necessary, use an evidence-bound baseline:
+
+```text
+current value
+vs
+previous / competitor / ordinary baseline
+-> explain the difference
+```
+
+Both sides of the comparison must be evidence-bound. The engine must not create a fake baseline to make a verified number look impressive.
+
+## 5. Source depth matters
+
+For fresh technical/product/platform claims, primary or official material is often the strongest starting point.
+
+The important doctrine is not “official sources only forever.”
+
+It is:
+
+```text
+important claim
+-> trace to strongest available source
+-> preserve date and scope
+-> then explain it
+```
+
+A summary of someone else's summary should not silently become proof.
+
+## 6. Put utility where usefulness becomes obvious
+
+A prompt, template, calculator, checklist, example, or resource is more useful after the reader understands the problem it solves.
+
+```text
+show problem / capability
+-> reader sees why the asset matters
+-> provide the asset
+```
+
+This is a timing rule, not a manipulation rule.
+
+Do not create fake anxiety, scarcity, or emotional pressure simply to manufacture a “desire peak.”
+
+The commercial CTA remains singular unless the article brief explicitly defines another safe structure.
+
+## 7. Market gap before angle
+
+A useful article angle can come from an information gap outside the writer:
+
+- a fresh change nobody has yet explained clearly;
+- a common claim with a well-supported missing counterpoint;
+- a genuine disagreement where readers need a comparison or decision boundary;
+- a popular topic missing a practical example;
+- a repeated question nobody has answered well.
+
+This changes the starting question from:
+
+> 今日は何を書こう？
+
+into:
+
+> 今この読者が必要としているのに、まだ十分に埋まっていない情報は何か？
+
+Market whitespace is a hypothesis. It does not guarantee reach.
+
+## 8. Do not manufacture contrarianism
+
+“Everyone says A, so say B” is not a safe doctrine by itself.
+
+Use a counterpoint only when:
+
+- evidence supports it; or
+- it is a genuine human-attested belief/opinion with an honest basis.
+
+Do not invent conflict, humiliation, or faction warfare merely because controversy can attract attention.
+
+If a real split exists, the useful article explains:
+
+```text
+side A says X
+side B says Y
+what evidence/conditions differ
+when each view is useful
+what decision rule the reader can use
+```
+
+## 9. Speed is an amplifier
+
+For current events, timing may matter.
+
+But speed comes after destination and evidence:
+
+```text
+who / what outcome
+-> market gap
+-> evidence
+-> useful article
+-> speed
+```
+
+Publishing first is not automatically valuable.
+
+If the article is thin, wrong, or detached from the offer, speed can amplify the wrong thing.
+
+## 10. Reach and commercial progress are separate axes
+
+Use a simple 2x2 diagnostic:
+
+```text
+low reach  / low qualified progress
+high reach / low qualified progress
+low reach  / high qualified progress
+high reach / high qualified progress
+```
+
+Strong reach can hide weak business relevance.
+
+Strong commercial relevance with low reach may indicate a distribution problem rather than an offer/article problem.
+
+Do not collapse both into one metric.
+
+## BridgePatch implication
+
+For the current BridgePatch article, the useful progression is not “technical depth for experts.”
+
+It is:
+
+```text
+BEGINNER
+「あー、めんどくさくてキレそう」
+-> what happened
+-> unfamiliar words explained immediately
+-> simple reason endless repair happens
+
+INTERMEDIATE
+-> concrete development loop
+-> why one-process boundaries reduce uncontrolled scope
+-> what must still be checked
+-> input / action / output / excluded area / failure return
+
+ADVANCED
+-> the deeper judgment:
+   automation is not only about making a task run;
+   where to stop and where to return to a human can matter just as much
+-> why BridgePatch exists in this form
+
+CTA
+-> BridgePatch（ブリッジパッチ） free fit check as the next step of that same mechanism
+```
+
+The article does not need to announce these layers. The reader should simply feel the depth increase naturally.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .longform_filter import audit_draft, build_generation_packet
+from .depth_market import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/depth_market.py
+++ b/x_article_engine/depth_market.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from . import longform_filter as _longform
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Add layered-reader depth, source depth, desire timing, and market-gap doctrine.
+
+    This layer learns article strategy from a public reference article while keeping
+    its metrics, timing, product claims, and causal conclusions outside engine truth.
+    Evidence, /human, and USER_ONLY publication boundaries remain unchanged.
+    """
+    packet = _longform.build_generation_packet(
+        source,
+        trusted_source_refs=trusted_source_refs,
+    )
+    packet["schema_version"] = "0.8"
+
+    packet["audience_depth_policy"] = {
+        "principle": (
+            "Use one broad entrance, then progressively add depth so a first-time reader can enter "
+            "without forcing an experienced reader to stay at beginner level."
+        ),
+        "beginner_layer": {
+            "reader_state": "I finally understand what this means.",
+            "tools": [
+                "translate unfamiliar terms immediately",
+                "give comparison context for evidence-bound numbers when a single number has no intuitive meaning",
+                "state the first useful conclusion early",
+            ],
+        },
+        "intermediate_layer": {
+            "reader_state": "I can picture how this applies and want to try or evaluate it.",
+            "tools": [
+                "use primary or official sources when they are the best available evidence for fresh technical claims",
+                "show concrete examples, cases, inputs, outputs, or before/after mechanics",
+                "surface conditions and exceptions that matter in practice",
+            ],
+        },
+        "advanced_layer": {
+            "reader_state": "I learned a deeper decision rule, implication, or viewpoint.",
+            "tools": [
+                "explain why information or an asset appears at that point in the article",
+                "show trade-offs, second-order effects, or decision criteria",
+                "end with a human-attested viewpoint when one exists rather than inventing authority",
+            ],
+        },
+        "anti_label_rule": (
+            "Do not call readers beginner/intermediate/advanced inside the article unless that labeling is useful. "
+            "The layers are an authoring model, not a ranking of people."
+        ),
+    }
+
+    packet["source_depth_policy"] = {
+        "primary_source_preference": (
+            "For fresh, technical, product, policy, or platform claims, prefer primary/official sources when available and appropriate. "
+            "Do not turn 'official-only' into a blanket rule when a trustworthy secondary source is the better evidence for a different claim."
+        ),
+        "anti_summary_of_summary": (
+            "When source depth matters, avoid building a factual section entirely from other people's summaries. "
+            "Trace important claims back to the strongest available source before treating them as evidence."
+        ),
+        "freshness_rule": (
+            "If the article depends on current or newly released information, preserve the date/scope in the evidence and do not generalize it into timeless doctrine."
+        ),
+    }
+
+    packet["desire_timing_policy"] = {
+        "principle": (
+            "Place a useful asset, example, prompt, template, or next-step option after the reader understands why it is valuable, "
+            "not before the value is legible."
+        ),
+        "utility_asset_rule": (
+            "A prompt/template/resource may appear at the moment of maximum practical relevance as article content. "
+            "This does not authorize multiple competing commercial CTAs."
+        ),
+        "commercial_cta_rule": (
+            "Keep the commercial CTA singular and make it the natural continuation of the same problem and mechanism."
+        ),
+        "anti_manipulation_rule": (
+            "Do not manufacture anxiety, fake scarcity, or emotional pressure merely to create a desire peak. "
+            "The peak should come from genuine understanding of usefulness."
+        ),
+    }
+
+    packet["market_gap_policy"] = {
+        "principle": (
+            "Before choosing an angle, inspect what the intended audience currently lacks: missing explanation, unanswered question, fresh change, "
+            "under-served counterpoint, or an emerging split that creates confusion."
+        ),
+        "candidate_patterns": [
+            "fresh information with an unmet explanation need",
+            "a widely repeated claim with a well-evidenced counterpoint",
+            "a field split where readers need a clearer comparison or decision rule",
+            "a common topic where a missing practical example or first-party lesson creates a useful gap",
+        ],
+        "whitespace_rule": (
+            "Market whitespace is a hypothesis about reader need, not proof of reach. Do not claim an empty slot guarantees impressions or sales."
+        ),
+        "counterpoint_rule": (
+            "Do not take the opposite side merely because opposition attracts attention. A counterpoint must be supported by evidence or a genuine human-attested belief."
+        ),
+        "conflict_rule": (
+            "Do not manufacture faction conflict, humiliation, or outrage for distribution. If a real disagreement matters, clarify the competing claims and useful decision boundary."
+        ),
+    }
+
+    packet["speed_quality_policy"] = {
+        "order": [
+            "commercial_or_reader_goal",
+            "market_gap_hypothesis",
+            "evidence_collection",
+            "article_depth",
+            "speed_or_release_timing",
+        ],
+        "speed_rule": (
+            "Speed can matter for time-sensitive topics, but it is an amplifier, not a substitute for evidence, usefulness, or a clear destination."
+        ),
+        "quality_floor": (
+            "Do not publish a thin or unsafe article solely to be first. If freshness matters, compress the workflow rather than lowering evidence and comprehension boundaries."
+        ),
+    }
+
+    packet["reach_conversion_policy"] = {
+        "axes": ["READ_OR_REACH", "QUALIFIED_COMMERCIAL_PROGRESS"],
+        "matrix": [
+            "low reach / low commercial progress",
+            "high reach / low commercial progress",
+            "low reach / high commercial progress",
+            "high reach / high commercial progress",
+        ],
+        "diagnostic_rule": (
+            "Do not let strong attention metrics hide weak movement toward the intended business or reader outcome. "
+            "Diagnose distribution and qualified progress separately."
+        ),
+        "goal_rule": (
+            "For BridgePatch-style articles, the useful end state is not generic virality; it is an intended reader who understands the problem, "
+            "sees the one-process approach as relevant, and can take the single fit-check next step."
+        ),
+    }
+
+    packet["reference_learning_boundary"].setdefault("not_imported_as_truth", []).extend(
+        [
+            "reference article impression, follower, or list-growth results",
+            "reference article creation time, release-time advantage, or taxi/coworking anecdote as a universal tactic",
+            "a universal claim that being first captures the whole market",
+            "a universal claim that beginner/intermediate/advanced readers behave in fixed ways",
+            "a universal claim that contrarian or factional posts will grow reach",
+        ]
+    )
+
+    packet["generation_constraints"].extend(
+        [
+            "Build depth progressively: first make the idea understandable, then make it applicable, then add a deeper decision rule, implication, or attested viewpoint when the material supports it.",
+            "When an evidence-bound number is meaningful only in comparison, provide a relevant evidence-bound baseline or plain-language context rather than presenting the number in isolation.",
+            "For fresh technical claims, prefer the strongest available primary/official evidence when appropriate; do not import another author's summary as proof.",
+            "Place prompts, templates, examples, or other utility assets after the reader understands why they are useful; do not use placement to manufacture pressure.",
+            "Before writing a distribution-sensitive article, identify a plausible information gap or reader need, but never treat market whitespace as guaranteed reach.",
+            "Do not manufacture a contrarian stance or faction conflict for engagement. Use counterpoints only when supported by evidence or genuine human-attested judgment.",
+            "Treat speed as an amplifier after reader goal, evidence, and article destination are clear. Do not sacrifice evidence or comprehension merely to publish first.",
+            "Evaluate attention and qualified commercial progress separately; a high-reach article can still fail its intended business objective.",
+            "If an attested human viewpoint can pay off the article, prefer that to a generic summary. If no such viewpoint exists, do not invent one.",
+        ]
+    )
+
+    packet["human_gate"]["checks"].extend(
+        [
+            "Does the article let a first-time reader understand the topic before increasing depth?",
+            "After the beginner-friendly explanation, is there enough mechanism, evidence, example, exception, or decision logic to reward a more experienced reader?",
+            "Are comparison numbers evidence-bound on both sides, rather than one verified number plus an invented baseline?",
+            "For fresh technical claims, did I use the strongest available source and preserve the claim's date/scope?",
+            "Are prompts, examples, templates, or CTA-like assets placed after their usefulness becomes clear rather than before?",
+            "Did I choose the article angle because there is a real information need, or merely because controversy might get attention?",
+            "If I used a counterpoint, is it actually mine or evidence-supported rather than manufactured for reach?",
+            "Am I separating reach/read metrics from qualified progress toward the offer?",
+            "Does the ending leave a real human judgment, decision rule, or next action instead of generic recap?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run all v0.7 deterministic checks; v0.8 depth/market checks remain semantic /human gates."""
+    return _longform.audit_draft(draft, packet)


### PR DESCRIPTION
## Summary
- add X Article Engine v0.8 audience-depth and market-gap strategy layer on top of v0.7
- progressively serve first-time, practical, and advanced reader needs without labeling or ranking readers
- prefer strong primary/official evidence for fresh technical claims while preserving evidence scope/date
- place prompts/templates/resources only after their usefulness becomes clear; keep the commercial CTA singular
- add market-gap discovery for fresh unmet explanation needs, evidence-backed counterpoints, real disagreements, and missing practical examples
- reject manufactured contrarianism/faction conflict as a growth tactic
- treat speed as an amplifier after reader/commercial goal, market gap, evidence, and depth are clear
- separate reach/read performance from qualified commercial progress
- preserve all evidence, terminology, anti-AI-smell, long-form, /human, and USER_ONLY publication boundaries

## Source boundary
A public long-form X article supplied during dogfooding is used only for writing/positioning doctrine. Its impression count, follower/list growth, creation time, release timing, and claimed causal effects are not imported as engine truth.

## BridgePatch implication
The current article can now move naturally from an emotionally understandable lived-pain entrance, to practical one-process mechanics, to a deeper human judgment about boundaries/fallbacks, and then to BridgePatch（ブリッジパッチ） as the single next step.

## Verification
Regression tests were added for v0.8 composition, reference-metric isolation, anti-manufactured-conflict policy, CTA/resource timing, and /human checks. No CI result is claimed here.

Publication remains `/human` gated and USER_ONLY.