### PR TITLE
METEOR harden X Article Engine v0.9 knowledge synthesis

### DIFF
--- a/.github/workflows/x-article-engine-meteor.yml
+++ b/.github/workflows/x-article-engine-meteor.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
 
       - name: Install test dependency
         run: python -m pip install --upgrade pytest

--- a/.github/workflows/x-article-engine-meteor.yml
+++ b/.github/workflows/x-article-engine-meteor.yml
@@ -1,0 +1,39 @@
+name: X Article Engine METEOR
+
+on:
+  pull_request:
+    paths:
+      - "x_article_engine/**"
+      - "tests/test_x_article_engine*.py"
+      - ".github/workflows/x-article-engine-meteor.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "x_article_engine/**"
+      - "tests/test_x_article_engine*.py"
+      - ".github/workflows/x-article-engine-meteor.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  x-article-engine:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install test dependency
+        run: python -m pip install --upgrade pytest
+
+      - name: Run X Article Engine regression and METEOR suite
+        run: python -m pytest -q tests/test_x_article_engine*.py

--- a/.github/workflows/x-article-engine-meteor.yml
+++ b/.github/workflows/x-article-engine-meteor.yml
@@ -17,6 +17,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: x-article-engine-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   x-article-engine:
     runs-on: ubuntu-latest

--- a/tests/test_x_article_engine.py
+++ b/tests/test_x_article_engine.py
@@ -1,6 +1,6 @@
 import pytest
 
-from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
+from x_article_engine.core import XArticleEngineError, audit_draft, build_generation_packet
 
 
 def bridgepatch_sources():
@@ -61,7 +61,7 @@ def build(source=None, sources=None):
 
 def test_build_packet_preserves_human_and_evidence_boundaries():
     packet = build()
-    assert packet["schema_version"] == "0.2"
+    assert packet["schema_version"] == "0.3"
     assert packet["article_type"] == "HOW_TO"
     assert packet["opening_mode"] == "RELATABLE"
     assert packet["human_gate"]["required"] is True

--- a/tests/test_x_article_engine_ai_humanity.py
+++ b/tests/test_x_article_engine_ai_humanity.py
@@ -1,4 +1,4 @@
-from x_article_engine import audit_draft, build_generation_packet
+from x_article_engine.ai_humanity import audit_draft, build_generation_packet
 
 
 def sources():

--- a/tests/test_x_article_engine_bridgepatch_dogfood_v09.py
+++ b/tests/test_x_article_engine_bridgepatch_dogfood_v09.py
@@ -1,0 +1,311 @@
+from x_article_engine import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で制作可否を確認し、適合すれば一工程の暫定ツール実装設計書へ進む。",
+        "target": "毎週、転記・集計・確認・下書きのような小さい手作業が残っている小規模事業者。",
+        "pain": "大きなシステムを入れるほどではない手作業ほど残り、AIを使えそうでもどこまで任せるか説明しづらい。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムを前にそう感じた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "CapCutが楽ですよと言われて試したが、私は使い続けられなかった。",
+                "source_ref": "human_attestation:capcut",
+                "attested": True,
+                "kind": "FAILURE",
+            },
+            {
+                "claim": "自分が迷わないよう機能や操作、ボタンを減らしたツールを作った。人にも使ってもらおうとすると、自分では想定していなかった操作まで考える必要が出てきた。",
+                "source_ref": "human_attestation:tool",
+                "attested": True,
+                "kind": "EXPERIENCE",
+            },
+            {
+                "claim": "直す、チェックする、また直す。全体を確認すると別の不具合が出て、そこを直すと別の場所が壊れる。まさに無限修正である、と感じた。",
+                "source_ref": "human_attestation:loop",
+                "attested": True,
+                "kind": "EXPERIENCE",
+            },
+            {
+                "claim": "ダメだ。マジで終わる気がしない。",
+                "source_ref": "human_attestation:feeling",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "直接1円にもならないが、放置すると不具合やクレームの元になり得るので手を抜けない仕事だと感じた。",
+                "source_ref": "human_attestation:stakes",
+                "attested": True,
+                "kind": "OPINION",
+            },
+            {
+                "claim": "本体を成立させるための周辺仕事が増えていく状態を、私はシムシティ化と呼んでいた。",
+                "source_ref": "human_attestation:simcity",
+                "attested": True,
+                "kind": "OPINION",
+            },
+            {
+                "claim": "全部を自動化するより、今いちばん邪魔をしている一工程だけ切る方がいい、というのが私の考えだ。",
+                "source_ref": "human_attestation:belief",
+                "attested": True,
+                "kind": "BELIEF",
+            },
+            {
+                "claim": "何をするかだけでなく、どこで止めるか、失敗したらどこで人間に戻すかを先に決めた方がいいと考えている。",
+                "source_ref": "human_attestation:boundary",
+                "attested": True,
+                "kind": "BELIEF",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "terms_to_explain": [
+            {
+                "term": "CapCut",
+                "explanation": "スマホなどで使える動画編集アプリ",
+                "anchors": ["動画編集", "アプリ"],
+                "min_anchor_matches": 2,
+            },
+            {
+                "term": "シムシティ",
+                "explanation": "街を少しずつ作り広げていくゲーム",
+                "anchors": ["街づくり", "ゲーム"],
+                "min_anchor_matches": 2,
+            },
+        ],
+        "evidence": [
+            {
+                "claim": "まず無料で制作可否を確認できる。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール制作そのものは含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "必要情報が揃ってから通常5営業日以内を目安に設計書を納品する。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "TIMING",
+            },
+            {
+                "claim": "実装を希望する場合は別途合意し、1アクション簡易ツールは50,000円（税込）を標準とする。対象範囲・総額・納期は開始前に確定する。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "人命、医療・介護判断、給与・決済の最終確定など高リスク業務は原則対象外または個別審査とする。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "SCOPE",
+            },
+        ],
+    }
+
+
+def article():
+    return """# 「1円にもならないのに手を抜けない」無限修正が、この仕事を始めたきっかけだった
+
+「あー、めんどくさくてキレそう。」
+
+自分で作っていたプログラムを前に、そう思った。
+
+きっかけは動画編集だった。
+「CapCutが楽ですよ」と言われて、動画編集アプリのCapCutを試してみた。でも私は使い続けられなかった。
+
+だったら、自分が迷いにくいものを作ろう。
+機能を減らして、操作を減らして、ボタンも減らした。
+
+ところが、人にも使ってもらおうと考えたところから仕事が増えた。
+自分では想定していなかった操作まで考える必要が出てきたからだ。
+
+■ ボタンを減らしたのに、仕事が減らない
+
+直す。
+チェックする。
+また直す。
+
+全体を確認すると、別の不具合が出る。
+そこを直すと、別の場所が壊れる。
+
+まさに無限修正である。
+
+「ダメだ。マジで終わる気がしない。」
+
+直接1円にもならない。
+でも放置すると、不具合やクレームの元になり得る。
+だから手を抜けない。
+
+これが、私がこの仕事を始めたきっかけです。
+
+■ 本体より、本体を成立させる仕事が増えていく
+
+私はこの状態を「シムシティ化」と呼んでいた。
+シムシティという街づくりゲームでは、建物だけ置けば終わりではない。街を動かすために、周りのものまで少しずつ増えていく。
+
+プログラムでも似たことが起きた。
+本体を作る。
+テストがいる。
+デバッグ、つまりプログラムの不具合の原因を探して直す作業がいる。
+操作を確認する仕事も増える。
+
+ここで私が考えたのは、全部を消すことではなかった。
+
+今いちばん邪魔をしている一工程だけ切る。
+
+■ 全部ではなく、一工程だけ切る
+
+たとえばCSVという、Excelなどで開ける表形式のデータファイルを見る仕事があるとする。
+
+その中から必要な数字を拾う。
+別の表へ入れる。
+最後の判断だけ人間がする。
+
+ここまでなら、仕事全部をAIへ渡さなくてもいい。
+
+私が先に決めたいのは、何をするかだけではない。
+どこで止めるか。
+失敗したら、どこで人間に戻すか。
+
+転記はする。でも最終判断はしない。
+下書きは作る。でも勝手に送信しない。
+集計はする。でも最終確認は人間がする。
+
+この境界を先に決める。
+
+■ AIに仕事を説明できないのも、私は普通だと思う
+
+正式な仕様書を作れなくてもいい。
+
+「毎週これを開く」
+「ここを見る」
+「これをこっちへ入れる」
+
+まずはそれでいい。
+
+そこから、何が入ってくるのか、何をするのか、何を返すのか、何はやらないのかを整理する。
+
+その整理まで依頼する側に全部やらせたら、意味がないだろ、と私は思う。
+
+■ そこからBridgePatch（ブリッジパッチ）を作った
+
+BridgePatchで最初にやるのは、大きなシステムを売ることではない。
+まず無料で、今ある手作業を一工程として切り出せるか確認する。
+
+切り出しに向かない、危険が大きい、範囲が広すぎる。
+そう判断したら、そこで止める。
+
+一工程として扱えそうなら、入力、処理、出力、やらないこと、失敗したときの戻し先を整理する。
+
+暫定ツール実装設計書は10,000円（税込）。ここにツール制作そのものは含まない。
+必要情報が揃ってから、通常5営業日以内を目安に設計書を納品する。
+
+その内容を見て、実装まで必要なら別途合意する。
+一つの処理だけをする簡易ツールは50,000円（税込）を標準とし、対象範囲・総額・納期は開始前に確定する。
+
+何でも自動化するつもりもない。
+人命、医療・介護判断、給与・決済の最終確定など、高リスクの業務は原則対象外か個別に確認する。
+
+間違えたとき、人間が止めて戻せるか。
+私はそこをかなり重く見る。
+
+■ 今日やることは一個だけ
+
+新しいツールを探す前に、毎週いちばんうっとうしい手作業を一個だけ書いてみてほしい。
+
+何を見て
+→ 何をして
+→ どこへ残しているか
+
+全部の仕事を説明しなくていい。
+一番うっとうしい一工程だけ切る。
+
+「これ、自動化できる？」くらいの状態なら、BridgePatchの無料適合確認から始められます。
+https://nobutakayamauchi.github.io/RTS/bridgepatch/
+"""
+
+
+def test_realistic_bridgepatch_article_reaches_human_review_without_deterministic_block():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(article(), packet)
+    blocks = [item for item in result["findings"] if item.get("severity") == "BLOCK"]
+    assert blocks == []
+    assert result["status"] == "HUMAN_REVIEW_REQUIRED"
+    assert result["human_review_required"] is True
+    assert result["publication_state"] == "BLOCKED_PENDING_HUMAN"
+    assert result["publication_authority"] == "USER_ONLY"
+
+
+def test_dogfood_article_preserves_lived_pain_mode_and_single_product_reading():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["opening_mode"] == "LIVED_PAIN"
+    assert article().count("BridgePatch（ブリッジパッチ）") == 1
+
+
+def test_dogfood_article_does_not_require_reader_to_decode_seed_terms():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(article(), packet)
+    unexplained = [
+        item["detail"]
+        for item in result["findings"]
+        if item.get("code") == "UNEXPLAINED_TERM_ON_FIRST_USE"
+    ]
+    assert "CSV" not in unexplained
+    assert "デバッグ" not in unexplained
+    assert "CapCut" not in unexplained
+    assert "シムシティ" not in unexplained
+
+
+def test_dogfood_bad_numeric_invention_still_blocks():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    bad = article().replace(
+        "直接1円にもならない。",
+        "毎週2時間かかっていた。直接1円にもならない。",
+        1,
+    )
+    result = audit_draft(bad, packet)
+    assert any(
+        item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "2時間"
+        for item in result["findings"]
+    )
+    assert result["status"] == "BLOCKED"
+
+
+def test_dogfood_missing_product_reading_still_blocks():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    bad = article().replace("BridgePatch（ブリッジパッチ）", "BridgePatch", 1)
+    result = audit_draft(bad, packet)
+    assert any(item.get("code") == "MISSING_PRODUCT_READING_ON_FIRST_USE" for item in result["findings"])
+    assert result["status"] == "BLOCKED"
+
+
+def test_dogfood_second_commercial_action_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    bad = article() + "\n記事が役立ったらフォローしてください。"
+    result = audit_draft(bad, packet)
+    assert any(item.get("code") == "MULTIPLE_COMMERCIAL_ACTIONS_RISK" for item in result["findings"])

--- a/tests/test_x_article_engine_deep_readable.py
+++ b/tests/test_x_article_engine_deep_readable.py
@@ -1,4 +1,4 @@
-from x_article_engine import build_generation_packet
+from x_article_engine.deep_readable import build_generation_packet
 
 
 def sources():

--- a/tests/test_x_article_engine_depth_market.py
+++ b/tests/test_x_article_engine_depth_market.py
@@ -1,4 +1,4 @@
-from x_article_engine import build_generation_packet
+from x_article_engine.depth_market import build_generation_packet
 
 
 def sources():

--- a/tests/test_x_article_engine_depth_market.py
+++ b/tests/test_x_article_engine_depth_market.py
@@ -87,7 +87,7 @@ def test_counterpoint_policy_rejects_manufactured_conflict_as_doctrine():
 def test_asset_timing_does_not_expand_commercial_cta_count():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     timing = packet["desire_timing_policy"]
-    assert "utility asset" in timing["utility_asset_rule"].lower()
+    assert "prompt/template/resource" in timing["utility_asset_rule"].lower()
     assert "multiple competing commercial CTAs" in timing["utility_asset_rule"]
     assert "singular" in timing["commercial_cta_rule"]
 

--- a/tests/test_x_article_engine_latest_root.py
+++ b/tests/test_x_article_engine_latest_root.py
@@ -36,9 +36,9 @@ def brief():
     }
 
 
-def test_root_points_to_latest_meteor_layer():
+def test_root_points_to_consolidated_v09():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    assert packet["schema_version"] == "0.9-meteor-r5"
+    assert packet["schema_version"] == "0.9"
     assert "strong_language_policy" in packet
     assert "security_content_policy" in packet
     assert "opening_integrity_policy" in packet

--- a/tests/test_x_article_engine_latest_root.py
+++ b/tests/test_x_article_engine_latest_root.py
@@ -38,9 +38,10 @@ def brief():
 
 def test_root_points_to_latest_meteor_layer():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    assert packet["schema_version"] == "0.9-meteor-r3"
+    assert packet["schema_version"] == "0.9-meteor-r4"
     assert "strong_language_policy" in packet
     assert "security_content_policy" in packet
+    assert "opening_integrity_policy" in packet
     assert packet["publication_state"] == "BLOCKED_PENDING_HUMAN"
     assert packet["publication_authority"] == "USER_ONLY"
     assert packet["external_publication_performed"] is False

--- a/tests/test_x_article_engine_latest_root.py
+++ b/tests/test_x_article_engine_latest_root.py
@@ -38,10 +38,11 @@ def brief():
 
 def test_root_points_to_latest_meteor_layer():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    assert packet["schema_version"] == "0.9-meteor-r4"
+    assert packet["schema_version"] == "0.9-meteor-r5"
     assert "strong_language_policy" in packet
     assert "security_content_policy" in packet
     assert "opening_integrity_policy" in packet
+    assert "generic_abstract_collision_rule" in packet["anti_ai_smell_policy"]
     assert packet["publication_state"] == "BLOCKED_PENDING_HUMAN"
     assert packet["publication_authority"] == "USER_ONLY"
     assert packet["external_publication_performed"] is False

--- a/tests/test_x_article_engine_latest_root.py
+++ b/tests/test_x_article_engine_latest_root.py
@@ -1,0 +1,57 @@
+from x_article_engine import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+    ]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def test_root_points_to_latest_meteor_layer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor-r3"
+    assert "strong_language_policy" in packet
+    assert "security_content_policy" in packet
+    assert packet["publication_state"] == "BLOCKED_PENDING_HUMAN"
+    assert packet["publication_authority"] == "USER_ONLY"
+    assert packet["external_publication_performed"] is False
+
+
+def test_root_keeps_human_gate_mandatory():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(
+        "あー、めんどくさくてキレそう。BridgePatch（ブリッジパッチ）は一工程だけを扱います。",
+        packet,
+    )
+    assert result["human_review_required"] is True
+    assert result["publication_state"] == "BLOCKED_PENDING_HUMAN"
+    assert result["publication_authority"] == "USER_ONLY"

--- a/tests/test_x_article_engine_lived_pain.py
+++ b/tests/test_x_article_engine_lived_pain.py
@@ -1,6 +1,6 @@
 import pytest
 
-from x_article_engine import XArticleEngineError, build_generation_packet
+from x_article_engine.core import XArticleEngineError, build_generation_packet
 
 
 def sources():

--- a/tests/test_x_article_engine_longform_filter.py
+++ b/tests/test_x_article_engine_longform_filter.py
@@ -1,4 +1,4 @@
-from x_article_engine import audit_draft, build_generation_packet
+from x_article_engine.longform_filter import audit_draft, build_generation_packet
 
 
 def sources():

--- a/tests/test_x_article_engine_meteor.py
+++ b/tests/test_x_article_engine_meteor.py
@@ -1,6 +1,6 @@
 import pytest
 
-from x_article_engine import XArticleEngineError, audit_draft, build_generation_packet
+from x_article_engine.core import XArticleEngineError, audit_draft, build_generation_packet
 
 
 def sources():
@@ -258,4 +258,3 @@ def test_meteor_07_counter_da_strong_attested_voice_is_not_blocked():
     draft = "大きく作るより、まず一工程だけ切る方がいい。これは私の考えです。"
     audit = audit_draft(draft, packet)
     assert audit["status"] == "HUMAN_REVIEW_REQUIRED"
-    assert audit["findings"] == []

--- a/tests/test_x_article_engine_meteor_v09.py
+++ b/tests/test_x_article_engine_meteor_v09.py
@@ -1,0 +1,318 @@
+import pytest
+
+from x_article_engine.core import XArticleEngineError
+from x_article_engine.meteor_v09 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "bridgepatch-sales-page", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "dated-source", "status": "VERIFIED", "kind": "OFFICIAL"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "私はこの状態をシムシティ化と呼んでいた。",
+                "source_ref": "human_attestation:label",
+                "attested": True,
+                "kind": "OPINION",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "bridgepatch-sales-page",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def codes(result):
+    return [item["code"] for item in result["findings"]]
+
+
+def test_packet_synthesizes_v09_conflict_rules():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-candidate"
+    assert "decision_then_path_policy" in packet
+    assert "completion_design_policy" in packet
+    assert "risk_policy" in packet
+    assert "human_automation_boundary" in packet
+    assert "pain_to_promise_policy" in packet
+    assert "knowledge_conflict_rules" in packet
+    assert "Safety information outranks CTA optimization." in packet["knowledge_conflict_rules"]
+
+
+def test_current_article_requires_as_of_boundary():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(
+            brief(freshness_mode="CURRENT"),
+            trusted_source_refs=sources(),
+        )
+
+
+def test_update_article_requires_as_of_boundary():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(
+            brief(freshness_mode="UPDATE"),
+            trusted_source_refs=sources(),
+        )
+
+
+def test_current_article_keeps_as_of_boundary():
+    packet = build_generation_packet(
+        brief(freshness_mode="CURRENT", as_of="2026-08-16"),
+        trusted_source_refs=sources(),
+    )
+    assert packet["freshness"]["mode"] == "CURRENT"
+    assert packet["freshness"]["as_of"] == "2026-08-16"
+
+
+def test_invalid_risk_level_fails_closed():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(brief(risk_level="YOLO"), trusted_source_refs=sources())
+
+
+def test_latest_language_without_dated_evidence_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("これは最新版の方法です。BridgePatch（ブリッジパッチ）を説明します。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" in codes(result)
+
+
+def test_latest_language_with_as_of_boundary_is_not_freshness_reviewed():
+    packet = build_generation_packet(
+        brief(freshness_mode="CURRENT", as_of="2026-08-16"),
+        trusted_source_refs=sources(),
+    )
+    result = audit_draft("これは現時点の方法です。BridgePatch（ブリッジパッチ）を説明します。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" not in codes(result)
+
+
+def test_latest_language_with_timing_evidence_is_not_freshness_reviewed():
+    data = brief()
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この手順は2026年8月16日時点の公開仕様に基づく。",
+            "source_ref": "dated-source",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    result = audit_draft("これは現在の手順です。BridgePatch（ブリッジパッチ）を説明します。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" not in codes(result)
+
+
+def test_dangerously_skip_permissions_instruction_is_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("Claude Codeを --dangerously-skip-permissions で起動してください。", packet)
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_dangerously_skip_permissions_warning_is_not_blocked_by_v09_bypass_gate():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("--dangerously-skip-permissions は使わないでください。", packet)
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
+
+
+def test_auth_disable_instruction_is_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("認証を無効にして、そのまま進めてください。", packet)
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" in codes(result)
+
+
+def test_auth_disable_warning_is_allowed_by_bypass_gate():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("認証を無効にしないでください。", packet)
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
+
+
+def test_secret_transfer_to_ai_is_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("APIキーをClaudeのプロンプトに貼り付けて送信してください。", packet)
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_secret_transfer_warning_is_not_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("APIキーはClaudeのチャットに貼り付けないでください。", packet)
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
+
+
+def test_automation_without_checkpoint_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("ユーザーに質問せず、すべて自動で判断して進めてください。", packet)
+    assert "AUTOMATION_WITHOUT_HUMAN_CHECKPOINT" in codes(result)
+
+
+def test_multiple_commercial_actions_are_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = "無料適合確認に登録してください。この記事をフォローして、分からなければリプしてください。"
+    result = audit_draft(draft, packet)
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" in codes(result)
+
+
+def test_warning_fatigue_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = "\n".join(["⚠️ 超重要な警告です。"] * 6)
+    result = audit_draft(draft, packet)
+    assert "WARNING_FATIGUE_RISK" in codes(result)
+
+
+def test_self_responsibility_without_mitigation_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("この操作は自己責任で行ってください。", packet)
+    assert "SELF_RESPONSIBILITY_WITHOUT_MITIGATION" in codes(result)
+
+
+def test_self_responsibility_with_concrete_mitigation_is_not_flagged_by_that_gate():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = "自己責任で進めるのではなく、まずテスト環境で確認し、異常があれば停止して戻してください。"
+    result = audit_draft(draft, packet)
+    assert "SELF_RESPONSIBILITY_WITHOUT_MITIGATION" not in codes(result)
+
+
+def test_unbound_complete_free_claim_is_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("これは完全無料で使えます。", packet)
+    assert "UNBOUND_ABSOLUTE_FREE_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_bound_complete_free_claim_is_not_blocked_by_absolute_free_gate():
+    data = brief()
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "無料適合確認は完全無料で提供する。",
+            "source_ref": "bridgepatch-sales-page",
+            "status": "VERIFIED",
+            "kind": "COMMERCIAL",
+        },
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    result = audit_draft("無料適合確認は完全無料で提供します。", packet)
+    assert "UNBOUND_ABSOLUTE_FREE_CLAIM" not in codes(result)
+
+
+def test_superlative_language_is_reviewed_not_automatically_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("これは世界一分かりやすい最強の方法です。", packet)
+    assert "SUPERLATIVE_OR_TOTALIZING_LANGUAGE" in codes(result)
+
+
+def test_high_risk_guide_without_front_stop_gate_is_blocked():
+    packet = build_generation_packet(
+        brief(risk_level="HIGH", topic_mode="PROCEDURAL"),
+        trusted_source_refs=sources(),
+    )
+    result = audit_draft("STEP1 設定を開きます。\nSTEP2 値を入力します。\nSTEP3 実行します。", packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_high_risk_guide_with_front_stop_gate_passes_that_gate():
+    packet = build_generation_packet(
+        brief(risk_level="HIGH", topic_mode="PROCEDURAL"),
+        trusted_source_refs=sources(),
+    )
+    draft = "警告：この操作にはデータ損失のリスクがあります。対象外の人は進めないでください。\nSTEP1 設定を確認します。\nSTEP2 実行します。\nSTEP3 成功表示を確認します。"
+    result = audit_draft(draft, packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" not in codes(result)
+
+
+def test_procedural_guide_without_completion_recovery_or_why_is_reviewed():
+    packet = build_generation_packet(
+        brief(topic_mode="PROCEDURAL"),
+        trusted_source_refs=sources(),
+    )
+    result = audit_draft("STEP1 開きます。\nSTEP2 入力します。\nSTEP3 実行します。", packet)
+    assert "PROCEDURE_WITHOUT_SUCCESS_SIGNAL" in codes(result)
+    assert "PROCEDURE_WITHOUT_RECOVERY_PATH" in codes(result)
+    assert "PROCEDURE_WITHOUT_WHY" in codes(result)
+
+
+def test_procedural_guide_with_completion_recovery_and_why_clears_those_gates():
+    packet = build_generation_packet(
+        brief(topic_mode="PROCEDURAL"),
+        trusted_source_refs=sources(),
+    )
+    draft = (
+        "なぜこの順番なのか。失敗した場所を切り分けやすくするためです。\n"
+        "STEP1 設定を開きます。完了したら表示を確認してください。\n"
+        "STEP2 値を入力します。エラーの場合は前の画面に戻ります。\n"
+        "STEP3 実行します。成功と表示されれば完了です。"
+    )
+    result = audit_draft(draft, packet)
+    assert "PROCEDURE_WITHOUT_SUCCESS_SIGNAL" not in codes(result)
+    assert "PROCEDURE_WITHOUT_RECOVERY_PATH" not in codes(result)
+    assert "PROCEDURE_WITHOUT_WHY" not in codes(result)
+
+
+def test_existing_core_still_blocks_unbound_guarantee():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("BridgePatchなら必ず自動化できます。", packet)
+    assert "UNBOUND_STRONG_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_existing_core_still_blocks_invented_number():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("作業は30分で終わります。", packet)
+    assert "UNBOUND_NUMERIC_CLAIM" in codes(result)
+
+
+def test_existing_ai_smell_gate_still_reviews_generic_subject():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("多くの人は仕事の本質を理解していません。", packet)
+    assert "GENERIC_OVERSIZED_SUBJECT" in codes(result)
+    assert "ABSTRACT_WORD_WITHOUT_PAYLOAD" in codes(result)
+
+
+def test_attested_pain_does_not_get_sanitized_out_of_policy():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    primary = "\n".join(item["claim"] for item in packet["verified_primary_info"])
+    assert "めんどくさくてキレそう" in primary
+    assert packet["voice_policy"]["preserve_attested_raw_pain"] is True
+
+
+def test_human_gate_contains_new_meteor_conflict_checks():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "最新・現在・現時点" in checks
+    assert "bypass" not in checks.lower()  # Japanese human-facing wording remains readable.
+    assert "権限" in checks
+    assert "安全" in checks
+    assert "commercial actions" in checks or "商" not in checks  # tolerate Japanese wording evolution
+    assert "automation" not in checks.lower()  # Japanese wording remains readable.
+    assert "自動化" in checks

--- a/tests/test_x_article_engine_meteor_v09.py
+++ b/tests/test_x_article_engine_meteor_v09.py
@@ -330,11 +330,10 @@ def test_existing_core_still_blocks_invented_number():
     assert "UNBOUND_NUMERIC_CLAIM" in codes(result)
 
 
-def test_existing_ai_smell_gate_still_reviews_generic_subject_and_empty_abstraction():
+def test_existing_ai_smell_gate_round2_still_reviews_generic_subject():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("多くの人は仕事の本質を理解していません。", packet)
     assert "GENERIC_OVERSIZED_SUBJECT" in codes(result)
-    assert "ABSTRACT_WORD_WITHOUT_PAYLOAD" in codes(result)
 
 
 def test_attested_pain_is_preserved_in_packet():
@@ -355,10 +354,10 @@ def test_human_gate_contains_freshness_security_safety_cta_and_human_boundary_ch
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     checks = "\n".join(packet["human_gate"]["checks"])
     assert "最新・現在・現時点" in checks
-    assert "権限" in checks
-    assert "安全" in checks
+    assert "permissions" in checks
+    assert "safety-critical" in checks
     assert "commercial actions" in checks
-    assert "自動化" in checks
+    assert "automation" in checks
     assert "as_of" in checks
 
 

--- a/tests/test_x_article_engine_meteor_v09.py
+++ b/tests/test_x_article_engine_meteor_v09.py
@@ -1,7 +1,7 @@
 import pytest
 
 from x_article_engine.core import XArticleEngineError
-from x_article_engine.meteor_v09 import audit_draft, build_generation_packet
+from x_article_engine.meteor_v09_final import audit_draft, build_generation_packet
 
 
 def sources():
@@ -54,69 +54,8 @@ def brief(**overrides):
     return data
 
 
-def codes(result):
-    return [item["code"] for item in result["findings"]]
-
-
-def test_packet_synthesizes_v09_conflict_rules():
-    packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    assert packet["schema_version"] == "0.9-candidate"
-    assert "decision_then_path_policy" in packet
-    assert "completion_design_policy" in packet
-    assert "risk_policy" in packet
-    assert "human_automation_boundary" in packet
-    assert "pain_to_promise_policy" in packet
-    assert "knowledge_conflict_rules" in packet
-    assert "Safety information outranks CTA optimization." in packet["knowledge_conflict_rules"]
-
-
-def test_current_article_requires_as_of_boundary():
-    with pytest.raises(XArticleEngineError):
-        build_generation_packet(
-            brief(freshness_mode="CURRENT"),
-            trusted_source_refs=sources(),
-        )
-
-
-def test_update_article_requires_as_of_boundary():
-    with pytest.raises(XArticleEngineError):
-        build_generation_packet(
-            brief(freshness_mode="UPDATE"),
-            trusted_source_refs=sources(),
-        )
-
-
-def test_current_article_keeps_as_of_boundary():
-    packet = build_generation_packet(
-        brief(freshness_mode="CURRENT", as_of="2026-08-16"),
-        trusted_source_refs=sources(),
-    )
-    assert packet["freshness"]["mode"] == "CURRENT"
-    assert packet["freshness"]["as_of"] == "2026-08-16"
-
-
-def test_invalid_risk_level_fails_closed():
-    with pytest.raises(XArticleEngineError):
-        build_generation_packet(brief(risk_level="YOLO"), trusted_source_refs=sources())
-
-
-def test_latest_language_without_dated_evidence_is_reviewed():
-    packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    result = audit_draft("これは最新版の方法です。BridgePatch（ブリッジパッチ）を説明します。", packet)
-    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" in codes(result)
-
-
-def test_latest_language_with_as_of_boundary_is_not_freshness_reviewed():
-    packet = build_generation_packet(
-        brief(freshness_mode="CURRENT", as_of="2026-08-16"),
-        trusted_source_refs=sources(),
-    )
-    result = audit_draft("これは現時点の方法です。BridgePatch（ブリッジパッチ）を説明します。", packet)
-    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" not in codes(result)
-
-
-def test_latest_language_with_timing_evidence_is_not_freshness_reviewed():
-    data = brief()
+def current_brief(**overrides):
+    data = brief(freshness_mode="CURRENT", as_of="2026-08-16")
     data["evidence"] = [
         *data["evidence"],
         {
@@ -126,8 +65,65 @@ def test_latest_language_with_timing_evidence_is_not_freshness_reviewed():
             "kind": "TIMING",
         },
     ]
-    packet = build_generation_packet(data, trusted_source_refs=sources())
-    result = audit_draft("これは現在の手順です。BridgePatch（ブリッジパッチ）を説明します。", packet)
+    data.update(overrides)
+    return data
+
+
+def codes(result):
+    return [item["code"] for item in result["findings"]]
+
+
+def test_packet_synthesizes_v09_meteor_conflict_rules():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor"
+    assert "decision_then_path_policy" in packet
+    assert "completion_design_policy" in packet
+    assert "risk_policy" in packet
+    assert "human_automation_boundary" in packet
+    assert "pain_to_promise_policy" in packet
+    assert "knowledge_conflict_rules" in packet
+    assert "Safety information outranks CTA optimization." in packet["knowledge_conflict_rules"]
+    assert "as_of is only a scope label" in packet["freshness"]["evidence_rule"]
+
+
+def test_current_article_requires_as_of_boundary():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(brief(freshness_mode="CURRENT"), trusted_source_refs=sources())
+
+
+def test_update_article_requires_as_of_boundary():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(brief(freshness_mode="UPDATE"), trusted_source_refs=sources())
+
+
+def test_as_of_alone_does_not_create_current_truth():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(
+            brief(freshness_mode="CURRENT", as_of="2026-08-16"),
+            trusted_source_refs=sources(),
+        )
+
+
+def test_current_article_requires_and_keeps_verified_dated_evidence():
+    packet = build_generation_packet(current_brief(), trusted_source_refs=sources())
+    assert packet["freshness"]["mode"] == "CURRENT"
+    assert packet["freshness"]["as_of"] == "2026-08-16"
+
+
+def test_invalid_risk_level_fails_closed():
+    with pytest.raises(XArticleEngineError):
+        build_generation_packet(brief(risk_level="YOLO"), trusted_source_refs=sources())
+
+
+def test_latest_language_without_dated_evidence_is_reviewed_in_evergreen_mode():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("これは最新版の方法です。BridgePatch（ブリッジパッチ）を説明します。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" in codes(result)
+
+
+def test_latest_language_with_verified_timing_evidence_clears_freshness_review():
+    packet = build_generation_packet(current_brief(), trusted_source_refs=sources())
+    result = audit_draft("これは現時点の方法です。BridgePatch（ブリッジパッチ）を説明します。", packet)
     assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" not in codes(result)
 
 
@@ -138,7 +134,7 @@ def test_dangerously_skip_permissions_instruction_is_blocked():
     assert result["status"] == "BLOCKED"
 
 
-def test_dangerously_skip_permissions_warning_is_not_blocked_by_v09_bypass_gate():
+def test_dangerous_command_inside_prohibition_is_not_blocked():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("--dangerously-skip-permissions は使わないでください。", packet)
     assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
@@ -150,22 +146,34 @@ def test_auth_disable_instruction_is_blocked():
     assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" in codes(result)
 
 
-def test_auth_disable_warning_is_allowed_by_bypass_gate():
+def test_auth_none_description_is_not_mistaken_for_instruction():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("認証なしでは使えません。認証は有効のままにしてください。", packet)
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
+
+
+def test_auth_disable_warning_is_not_blocked():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("認証を無効にしないでください。", packet)
     assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
 
 
-def test_secret_transfer_to_ai_is_blocked():
+def test_secret_transfer_to_model_prompt_is_blocked():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("APIキーをClaudeのプロンプトに貼り付けて送信してください。", packet)
     assert "SECRET_TRANSFER_TO_MODEL_RISK" in codes(result)
     assert result["status"] == "BLOCKED"
 
 
-def test_secret_transfer_warning_is_not_blocked():
+def test_secret_transfer_prohibition_is_not_blocked():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("APIキーはClaudeのチャットに貼り付けないでください。", packet)
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
+
+
+def test_secret_entered_into_named_settings_screen_is_not_automatically_called_model_transfer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("Claudeの設定画面にAPIキーを入力してください。", packet)
     assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
 
 
@@ -175,11 +183,18 @@ def test_automation_without_checkpoint_is_reviewed():
     assert "AUTOMATION_WITHOUT_HUMAN_CHECKPOINT" in codes(result)
 
 
-def test_multiple_commercial_actions_are_reviewed():
+def test_two_competing_reader_actions_are_enough_for_cta_review():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    draft = "無料適合確認に登録してください。この記事をフォローして、分からなければリプしてください。"
+    draft = "BridgePatchの無料適合確認を使ってください。この記事が役立ったらフォローしてください。"
     result = audit_draft(draft, packet)
     assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" in codes(result)
+
+
+def test_narrative_mentions_of_registration_and_followers_are_not_ctas():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = "登録前の教育と、フォロワー数の変化は別の指標として見ます。"
+    result = audit_draft(draft, packet)
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
 
 
 def test_warning_fatigue_is_reviewed():
@@ -189,15 +204,15 @@ def test_warning_fatigue_is_reviewed():
     assert "WARNING_FATIGUE_RISK" in codes(result)
 
 
-def test_self_responsibility_without_mitigation_is_reviewed():
+def test_self_responsibility_without_local_mitigation_is_reviewed():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("この操作は自己責任で行ってください。", packet)
     assert "SELF_RESPONSIBILITY_WITHOUT_MITIGATION" in codes(result)
 
 
-def test_self_responsibility_with_concrete_mitigation_is_not_flagged_by_that_gate():
+def test_self_responsibility_with_local_mitigation_is_not_flagged():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    draft = "自己責任で進めるのではなく、まずテスト環境で確認し、異常があれば停止して戻してください。"
+    draft = "自己責任という言葉だけで済ませません。まずテスト環境で確認し、異常があれば停止して戻してください。"
     result = audit_draft(draft, packet)
     assert "SELF_RESPONSIBILITY_WITHOUT_MITIGATION" not in codes(result)
 
@@ -225,6 +240,25 @@ def test_bound_complete_free_claim_is_not_blocked_by_absolute_free_gate():
     assert "UNBOUND_ABSOLUTE_FREE_CLAIM" not in codes(result)
 
 
+def test_plain_guarantee_language_is_blocked_even_without_100_percent_wording():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("この手順なら完了できます。保証します。", packet)
+    assert "UNBOUND_GUARANTEE_LANGUAGE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_absolute_safety_language_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("この方法は安全です。初心者でも安心です。", packet)
+    assert "ABSOLUTE_SAFETY_LANGUAGE" in codes(result)
+
+
+def test_outcome_promise_language_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("この記事の通りにすれば売れます。", packet)
+    assert "OUTCOME_PROMISE_LANGUAGE" in codes(result)
+
+
 def test_superlative_language_is_reviewed_not_automatically_blocked():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("これは世界一分かりやすい最強の方法です。", packet)
@@ -236,7 +270,7 @@ def test_high_risk_guide_without_front_stop_gate_is_blocked():
         brief(risk_level="HIGH", topic_mode="PROCEDURAL"),
         trusted_source_refs=sources(),
     )
-    result = audit_draft("STEP1 設定を開きます。\nSTEP2 値を入力します。\nSTEP3 実行します。", packet)
+    result = audit_draft("手順1 設定を開きます。\n手順2 値を入力します。\n手順3 実行します。", packet)
     assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
     assert result["status"] == "BLOCKED"
 
@@ -246,32 +280,26 @@ def test_high_risk_guide_with_front_stop_gate_passes_that_gate():
         brief(risk_level="HIGH", topic_mode="PROCEDURAL"),
         trusted_source_refs=sources(),
     )
-    draft = "警告：この操作にはデータ損失のリスクがあります。対象外の人は進めないでください。\nSTEP1 設定を確認します。\nSTEP2 実行します。\nSTEP3 成功表示を確認します。"
+    draft = "警告：この操作にはデータ損失のリスクがあります。対象外の人は進めないでください。\n手順1 設定を確認します。\n手順2 実行します。\n手順3 成功表示を確認します。"
     result = audit_draft(draft, packet)
     assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" not in codes(result)
 
 
-def test_procedural_guide_without_completion_recovery_or_why_is_reviewed():
-    packet = build_generation_packet(
-        brief(topic_mode="PROCEDURAL"),
-        trusted_source_refs=sources(),
-    )
-    result = audit_draft("STEP1 開きます。\nSTEP2 入力します。\nSTEP3 実行します。", packet)
+def test_japanese_procedural_guide_without_completion_recovery_or_why_is_reviewed():
+    packet = build_generation_packet(brief(topic_mode="PROCEDURAL"), trusted_source_refs=sources())
+    result = audit_draft("手順1 開きます。\n手順2 入力します。\n手順3 実行します。", packet)
     assert "PROCEDURE_WITHOUT_SUCCESS_SIGNAL" in codes(result)
     assert "PROCEDURE_WITHOUT_RECOVERY_PATH" in codes(result)
     assert "PROCEDURE_WITHOUT_WHY" in codes(result)
 
 
 def test_procedural_guide_with_completion_recovery_and_why_clears_those_gates():
-    packet = build_generation_packet(
-        brief(topic_mode="PROCEDURAL"),
-        trusted_source_refs=sources(),
-    )
+    packet = build_generation_packet(brief(topic_mode="PROCEDURAL"), trusted_source_refs=sources())
     draft = (
         "なぜこの順番なのか。失敗した場所を切り分けやすくするためです。\n"
-        "STEP1 設定を開きます。完了したら表示を確認してください。\n"
-        "STEP2 値を入力します。エラーの場合は前の画面に戻ります。\n"
-        "STEP3 実行します。成功と表示されれば完了です。"
+        "手順1 設定を開きます。完了したら表示を確認してください。\n"
+        "手順2 値を入力します。エラーの場合は前の画面に戻ります。\n"
+        "手順3 実行します。成功と表示されれば完了です。"
     )
     result = audit_draft(draft, packet)
     assert "PROCEDURE_WITHOUT_SUCCESS_SIGNAL" not in codes(result)
@@ -279,11 +307,21 @@ def test_procedural_guide_with_completion_recovery_and_why_clears_those_gates():
     assert "PROCEDURE_WITHOUT_WHY" not in codes(result)
 
 
-def test_existing_core_still_blocks_unbound_guarantee():
+def test_existing_core_still_blocks_unbound_outcome_absolute():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("BridgePatchなら必ず自動化できます。", packet)
     assert "UNBOUND_STRONG_CLAIM" in codes(result)
     assert result["status"] == "BLOCKED"
+
+
+def test_safety_imperatives_with_must_and_never_are_not_misclassified_as_commercial_guarantees():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = "APIキーは絶対に共有しないでください。権限は必ず確認してください。"
+    result = audit_draft(draft, packet)
+    assert not any(
+        item["code"] == "UNBOUND_STRONG_CLAIM" and item["detail"] in {"必ず", "絶対"}
+        for item in result["findings"]
+    )
 
 
 def test_existing_core_still_blocks_invented_number():
@@ -292,27 +330,52 @@ def test_existing_core_still_blocks_invented_number():
     assert "UNBOUND_NUMERIC_CLAIM" in codes(result)
 
 
-def test_existing_ai_smell_gate_still_reviews_generic_subject():
+def test_existing_ai_smell_gate_still_reviews_generic_subject_and_empty_abstraction():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     result = audit_draft("多くの人は仕事の本質を理解していません。", packet)
     assert "GENERIC_OVERSIZED_SUBJECT" in codes(result)
     assert "ABSTRACT_WORD_WITHOUT_PAYLOAD" in codes(result)
 
 
-def test_attested_pain_does_not_get_sanitized_out_of_policy():
+def test_attested_pain_is_preserved_in_packet():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     primary = "\n".join(item["claim"] for item in packet["verified_primary_info"])
     assert "めんどくさくてキレそう" in primary
     assert packet["voice_policy"]["preserve_attested_raw_pain"] is True
 
 
-def test_human_gate_contains_new_meteor_conflict_checks():
+def test_reference_specific_three_examples_rule_is_not_made_mandatory():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    rendered = repr(packet)
+    assert "always use exactly three examples" not in rendered.lower()
+    assert "具体例は必ず3つ" not in rendered
+
+
+def test_human_gate_contains_freshness_security_safety_cta_and_human_boundary_checks():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
     checks = "\n".join(packet["human_gate"]["checks"])
     assert "最新・現在・現時点" in checks
-    assert "bypass" not in checks.lower()  # Japanese human-facing wording remains readable.
     assert "権限" in checks
     assert "安全" in checks
-    assert "commercial actions" in checks or "商" not in checks  # tolerate Japanese wording evolution
-    assert "automation" not in checks.lower()  # Japanese wording remains readable.
+    assert "commercial actions" in checks
     assert "自動化" in checks
+    assert "as_of" in checks
+
+
+def test_bridgepatch_safe_story_does_not_trigger_security_specific_blocks():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = (
+        "あー、めんどくさくてキレそう。\n"
+        "修正して確認する。直したら別の場所をもう一度確認する。まさに無限修正だった。\n"
+        "そこで全部を自動化するのではなく、一工程だけ切ることにした。\n"
+        "間違えたときは人間に戻せるようにする。\n"
+        "その考えを仕事に使える形にしたのがBridgePatch（ブリッジパッチ）です。"
+    )
+    result = audit_draft(draft, packet)
+    security_codes = {
+        "UNSAFE_PERMISSION_OR_SECURITY_BYPASS",
+        "SECRET_TRANSFER_TO_MODEL_RISK",
+        "HIGH_RISK_WITHOUT_FRONT_STOP_GATE",
+        "UNBOUND_GUARANTEE_LANGUAGE",
+    }
+    assert not security_codes.intersection(codes(result))

--- a/tests/test_x_article_engine_meteor_v09_r10.py
+++ b/tests/test_x_article_engine_meteor_v09_r10.py
@@ -1,0 +1,166 @@
+from x_article_engine.meteor_v09_r10 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "timing", "status": "VERIFIED", "kind": "MEASURED"},
+        {"id": "count", "status": "VERIFIED", "kind": "LEDGER"},
+    ]
+
+
+def brief(extra_evidence=None):
+    evidence = [
+        {
+            "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール制作そのものは含まない。",
+            "source_ref": "sales",
+            "status": "VERIFIED",
+            "kind": "COMMERCIAL",
+        }
+    ]
+    if extra_evidence:
+        evidence.extend(extra_evidence)
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": evidence,
+    }
+
+
+def packet(extra_evidence=None):
+    return build_generation_packet(
+        brief(extra_evidence=extra_evidence),
+        trusted_source_refs=sources(),
+    )
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_r10_schema_and_numeric_boundary_policy_present():
+    result = packet()
+    assert result["schema_version"] == "0.9-meteor-r10"
+    assert "numeric_binding_policy" in result
+    assert "meta_rejection_policy" in result
+
+
+def test_verified_10000_yen_does_not_bind_invented_zero_yen():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の利用料は0円です。",
+        packet(),
+    )
+    assert "UNBOUND_NUMERIC_CLAIM" in codes(result)
+    assert any(item.get("detail") == "0円" for item in result["findings"])
+    assert result["status"] == "BLOCKED"
+
+
+def test_verified_10000_yen_still_binds_exact_10000_yen():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の暫定ツール実装設計書は10,000円（税込）です。",
+        packet(),
+    )
+    assert not any(
+        item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "10,000円"
+        for item in result["findings"]
+    )
+
+
+def test_verified_15_minutes_does_not_bind_5_minutes():
+    extra = [
+        {
+            "claim": "確認済みの作業時間は15分だった。",
+            "source_ref": "timing",
+            "status": "VERIFIED",
+            "kind": "RESULT",
+        }
+    ]
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の確認済み作業時間は5分でした。",
+        packet(extra),
+    )
+    assert any(
+        item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "5分"
+        for item in result["findings"]
+    )
+
+
+def test_verified_100_people_does_not_bind_zero_people():
+    extra = [
+        {
+            "claim": "確認済みの参加者は100人だった。",
+            "source_ref": "count",
+            "status": "VERIFIED",
+            "kind": "RESULT",
+        }
+    ]
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の確認済み参加者は0人でした。",
+        packet(extra),
+    )
+    assert any(
+        item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "0人"
+        for item in result["findings"]
+    )
+
+
+def test_bad_duration_example_shown_only_to_reject_wording_is_not_blocked():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事で『30分で終わります』と書くのはやめます。",
+        packet(),
+    )
+    assert not any(
+        item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "30分"
+        for item in result["findings"]
+    )
+
+
+def test_bad_100_percent_example_shown_only_to_reject_wording_is_not_asserted():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事では『100%できます』という表現は使いません。",
+        packet(),
+    )
+    assert not any(item.get("detail") == "100%" and item.get("severity") == "BLOCK" for item in result["findings"])
+
+
+def test_invented_biography_shown_only_as_forbidden_ai_copy_is_not_asserted_biography():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事で『私は数年前から業務自動化をしてきた』という経歴をAIに作らせてはいけません。",
+        packet(),
+    )
+    assert "UNBOUND_IDENTITY_DETAIL" not in codes(result)
+
+
+def test_positive_unbound_biography_still_blocks():
+    result = audit_draft(
+        "私は数年前から業務自動化をしてきました。BridgePatch（ブリッジパッチ）の話をします。",
+        packet(),
+    )
+    assert "UNBOUND_IDENTITY_DETAIL" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_rejected_bad_example_does_not_hide_separate_positive_numeric_claim():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）は5分で終わります。『30分で終わります』と書くのはやめます。",
+        packet(),
+    )
+    assert any(
+        item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "5分"
+        for item in result["findings"]
+    )
+    assert result["status"] == "BLOCKED"

--- a/tests/test_x_article_engine_meteor_v09_r11.py
+++ b/tests/test_x_article_engine_meteor_v09_r11.py
@@ -1,0 +1,138 @@
+from x_article_engine.meteor_v09_r11 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "result", "status": "VERIFIED", "kind": "LEDGER"},
+        {"id": "timing", "status": "VERIFIED", "kind": "OFFICIAL"},
+    ]
+
+
+def brief(extra=None):
+    evidence = [
+        {
+            "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール制作そのものは含まない。",
+            "source_ref": "sales",
+            "status": "VERIFIED",
+            "kind": "COMMERCIAL",
+        },
+        {
+            "claim": "必要情報が揃ってから通常5営業日以内を目安に設計書を納品する。",
+            "source_ref": "timing",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    if extra:
+        evidence.extend(extra)
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "直接1円にもならないが、放置すると手を抜けない仕事だと感じた。",
+                "source_ref": "human_attestation:one-yen",
+                "attested": True,
+                "kind": "OPINION",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": evidence,
+    }
+
+
+def packet(extra=None):
+    return build_generation_packet(brief(extra), trusted_source_refs=sources())
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_r11_schema_and_numeric_context_policy_present():
+    result = packet()
+    assert result["schema_version"] == "0.9-meteor-r11"
+    assert "numeric_context_policy" in result
+
+
+def test_verified_price_reused_as_sales_result_is_reviewed():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）で10,000円売れました。",
+        packet(),
+    )
+    assert "UNBOUND_NUMERIC_CLAIM" not in codes(result)
+    assert "NUMERIC_CONTEXT_REUSE_RISK" in codes(result)
+    assert result["status"] == "HUMAN_REVIEW_REQUIRED"
+
+
+def test_verified_price_reused_as_customer_savings_is_reviewed():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）で顧客が10,000円節約できました。",
+        packet(),
+    )
+    assert "NUMERIC_CONTEXT_REUSE_RISK" in codes(result)
+
+
+def test_verified_price_used_as_price_is_not_context_mismatch():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の暫定ツール実装設計書は10,000円（税込）です。",
+        packet(),
+    )
+    assert "NUMERIC_CONTEXT_REUSE_RISK" not in codes(result)
+
+
+def test_verified_timing_used_as_timing_is_not_context_mismatch():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の設計書は通常5営業日以内を目安に納品します。",
+        packet(),
+    )
+    assert "NUMERIC_CONTEXT_REUSE_RISK" not in codes(result)
+
+
+def test_verified_timing_reused_as_result_count_is_reviewed_when_same_token_shape_matches():
+    # The unit remains part of the numeric token, so unrelated-unit reuse cannot borrow authority.
+    # This test instead confirms the exact token remains bound to timing context only.
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）は5営業日以内に売上が増えます。",
+        packet(),
+    )
+    assert "NUMERIC_CONTEXT_REUSE_RISK" in codes(result)
+
+
+def test_verified_result_reused_as_price_is_reviewed():
+    extra = [
+        {
+            "claim": "確認済みの売上結果は20,000円だった。",
+            "source_ref": "result",
+            "status": "VERIFIED",
+            "kind": "RESULT",
+        }
+    ]
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の料金は20,000円です。",
+        packet(extra),
+    )
+    assert "NUMERIC_CONTEXT_REUSE_RISK" in codes(result)
+
+
+def test_primary_attested_one_yen_phrase_is_not_forced_into_commercial_bucket():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）を作る前、直接1円にもならない仕事だと感じました。",
+        packet(),
+    )
+    assert "UNBOUND_NUMERIC_CLAIM" not in codes(result)
+    assert "NUMERIC_CONTEXT_REUSE_RISK" not in codes(result)
+
+
+def test_meta_rejected_bad_result_example_does_not_trigger_context_review():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事で『10,000円売れました』という表現は使いません。",
+        packet(),
+    )
+    assert "NUMERIC_CONTEXT_REUSE_RISK" not in codes(result)

--- a/tests/test_x_article_engine_meteor_v09_r3.py
+++ b/tests/test_x_article_engine_meteor_v09_r3.py
@@ -1,0 +1,189 @@
+import pytest
+
+from x_article_engine.core import XArticleEngineError
+from x_article_engine.meteor_v09_gate import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "risk", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "dated", "status": "VERIFIED", "kind": "OFFICIAL"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。自前のプログラムの無限修正に頭を抱えた。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def risk_brief(**overrides):
+    data = brief(risk_level="HIGH", topic_mode="PROCEDURAL")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この操作は権限を広げるため、誤操作時の影響範囲が大きくなる。",
+            "source_ref": "risk",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    data.update(overrides)
+    return data
+
+
+def codes(result):
+    return [item["code"] for item in result["findings"]]
+
+
+def test_r3_schema_and_strong_language_policy_present():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor-r3"
+    assert set(packet["strong_language_policy"]) == {
+        "outcome_absolute",
+        "general_absolute",
+        "safety_imperative",
+    }
+    assert "hardcoded_secret_rule" in packet["security_content_policy"]
+
+
+def test_high_risk_warning_tone_without_verified_risk_evidence_fails_closed():
+    with pytest.raises(XArticleEngineError, match="HIGH-risk articles require"):
+        build_generation_packet(
+            brief(risk_level="HIGH", topic_mode="PROCEDURAL"),
+            trusted_source_refs=sources(),
+        )
+
+
+def test_high_risk_with_verified_risk_evidence_builds():
+    packet = build_generation_packet(risk_brief(), trusted_source_refs=sources())
+    assert packet["risk_policy"]["risk_level"] == "HIGH"
+    assert "verified RISK/SAFETY/POLICY" in packet["risk_policy"]["evidence_rule"]
+
+
+def test_as_of_in_evergreen_mode_does_not_silence_latest_review():
+    packet = build_generation_packet(
+        brief(as_of="2026-08-16"),
+        trusted_source_refs=sources(),
+    )
+    result = audit_draft("これは最新版の方法です。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" in codes(result)
+
+
+def test_current_mode_with_verified_timing_evidence_allows_current_wording():
+    data = brief(freshness_mode="CURRENT", as_of="2026-08-16")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この仕様は2026年8月16日時点の公式情報で確認した。",
+            "source_ref": "dated",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    result = audit_draft("これは現在の仕様です。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" not in codes(result)
+
+
+def test_outcome_absolute_remains_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("この方法なら必ず自動化できます。", packet)
+    assert "UNBOUND_STRONG_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_non_outcome_absolute_prediction_is_downgraded_to_review():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("ここで初心者は必ず次の壁にぶつかります。", packet)
+    assert "UNBOUND_STRONG_CLAIM" not in codes(result)
+    assert "ABSOLUTE_GENERALIZATION_LANGUAGE" in codes(result)
+    assert result["status"] == "HUMAN_REVIEW_REQUIRED"
+
+
+def test_safety_absolute_is_allowed_without_commercial_guarantee_block():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("APIキーは絶対に共有しないでください。権限は必ず確認してください。", packet)
+    assert not any(
+        item["code"] == "UNBOUND_STRONG_CLAIM" and item["detail"] in {"必ず", "絶対"}
+        for item in result["findings"]
+    )
+
+
+def test_universal_capability_promise_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("初心者でもこの記事だけでできます。", packet)
+    assert "UNIVERSAL_CAPABILITY_PROMISE" in codes(result)
+
+
+def test_hardcoded_default_secret_is_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("管理画面用APIキーは sk-line-harness-2026 をこのまま使って設定してください。", packet)
+    assert "HARDCODED_SECRET_LITERAL_RISK" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_dummy_secret_example_is_not_blocked_as_real_default():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("例のダミーAPIキー sk-example-placeholder は実際には使わないでください。", packet)
+    assert "HARDCODED_SECRET_LITERAL_RISK" not in codes(result)
+
+
+def test_platform_evasion_language_is_reviewed_not_learned_as_growth_doctrine():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("BAN回避のためにステルス配信とゼロ幅文字を使います。", packet)
+    assert "PLATFORM_EVASION_LANGUAGE" in codes(result)
+
+
+def test_risk_article_still_requires_front_stop_gate_after_risk_evidence_exists():
+    packet = build_generation_packet(risk_brief(), trusted_source_refs=sources())
+    result = audit_draft("手順1 権限を開きます。\n手順2 設定します。\n手順3 実行します。", packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_risk_article_with_evidence_and_front_gate_can_reach_human_review():
+    packet = build_generation_packet(risk_brief(), trusted_source_refs=sources())
+    draft = (
+        "警告：この操作は権限を広げるため、誤操作時の影響範囲が大きくなります。対象外なら進めないでください。\n"
+        "なぜ最初にテストするのか。失敗時の影響を小さくするためです。\n"
+        "手順1 テスト環境で設定します。完了表示を確認してください。\n"
+        "手順2 権限を確認します。エラーなら停止して戻ります。\n"
+        "手順3 実行し、成功表示を確認します。"
+    )
+    result = audit_draft(draft, packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" not in codes(result)
+    assert result["status"] in {"HUMAN_REVIEW_REQUIRED", "BLOCKED"}
+
+
+def test_human_gate_requires_classification_of_strong_language_and_risk_evidence():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "outcome guarantee" in checks
+    assert "secret literal" in checks
+    assert "platform-evasion" in checks
+    assert "verified evidence" in checks

--- a/tests/test_x_article_engine_meteor_v09_r4.py
+++ b/tests/test_x_article_engine_meteor_v09_r4.py
@@ -1,0 +1,171 @@
+import pytest
+
+from x_article_engine.core import XArticleEngineError
+from x_article_engine.meteor_v09_r4 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "counter", "status": "VERIFIED", "kind": "REPORT"},
+    ]
+
+
+def base_primary():
+    return [
+        {
+            "claim": "私はこの仕事を始めた。",
+            "source_ref": "human_attestation:origin",
+            "attested": True,
+            "kind": "ORIGIN",
+        }
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": base_primary(),
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def codes(result):
+    return [item["code"] for item in result["findings"]]
+
+
+def test_origin_alone_no_longer_auto_activates_lived_pain_in_latest_layer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor-r4"
+    assert packet["opening_mode"] == "RELATABLE"
+    assert packet["lived_pain_anchors"] == []
+    assert "manufacture pain" in packet["narrative"]["opening_doctrine"]
+
+
+def test_explicit_lived_pain_with_origin_only_fails_closed():
+    with pytest.raises(XArticleEngineError, match="PAIN or FAILURE"):
+        build_generation_packet(
+            brief(opening_mode="LIVED_PAIN"),
+            trusted_source_refs=sources(),
+        )
+
+
+def test_attested_pain_still_activates_lived_pain():
+    data = brief()
+    data["primary_info"] = [
+        {
+            "claim": "あー、めんどくさくてキレそう。",
+            "source_ref": "human_attestation:pain",
+            "attested": True,
+            "kind": "PAIN",
+        },
+        *base_primary(),
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["opening_mode"] == "LIVED_PAIN"
+    assert any(item["kind"] == "PAIN" for item in packet["lived_pain_anchors"])
+
+
+def test_explicit_lived_pain_with_attested_failure_is_allowed():
+    data = brief(opening_mode="LIVED_PAIN")
+    data["primary_info"] = [
+        {
+            "claim": "試して失敗し、そこで手が止まった。",
+            "source_ref": "human_attestation:failure",
+            "attested": True,
+            "kind": "FAILURE",
+        }
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["opening_mode"] == "LIVED_PAIN"
+
+
+def test_contrarian_without_explicit_basis_fails_closed():
+    with pytest.raises(XArticleEngineError, match="counterpoint_basis"):
+        build_generation_packet(
+            brief(opening_mode="CONTRARIAN"),
+            trusted_source_refs=sources(),
+        )
+
+
+def test_contrarian_can_bind_human_opinion_basis():
+    data = brief(opening_mode="CONTRARIAN")
+    data["primary_info"] = [
+        {
+            "claim": "全部自動化するより、一工程だけ切る方がいいと私は考えている。",
+            "source_ref": "human_attestation:counterpoint",
+            "attested": True,
+            "kind": "OPINION",
+        }
+    ]
+    data["counterpoint_basis"] = {
+        "kind": "HUMAN_OPINION",
+        "source_ref": "human_attestation:counterpoint",
+    }
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["opening_mode"] == "CONTRARIAN"
+
+
+def test_contrarian_can_bind_verified_evidence_basis():
+    data = brief(opening_mode="CONTRARIAN")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "比較資料では、対象工程だけを切り出した方式に別の運用上の利点が確認された。",
+            "source_ref": "counter",
+            "status": "VERIFIED",
+            "kind": "FACT",
+        },
+    ]
+    data["counterpoint_basis"] = {
+        "kind": "EVIDENCE",
+        "source_ref": "counter",
+    }
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["opening_mode"] == "CONTRARIAN"
+
+
+def test_fake_human_counterpoint_ref_does_not_pass():
+    data = brief(opening_mode="CONTRARIAN")
+    data["counterpoint_basis"] = {
+        "kind": "HUMAN_OPINION",
+        "source_ref": "human_attestation:not-present",
+    }
+    with pytest.raises(XArticleEngineError, match="counterpoint_basis"):
+        build_generation_packet(data, trusted_source_refs=sources())
+
+
+def test_operational_platform_evasion_instruction_is_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("BAN回避のためにゼロ幅文字をメッセージへ挿入して配信します。", packet)
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_platform_evasion_discussion_without_howto_is_reviewed():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。", packet)
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" not in codes(result)
+    assert "PLATFORM_EVASION_LANGUAGE" in codes(result)
+
+
+def test_opening_integrity_human_checks_are_present():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "neutral origin into drama" in checks
+    assert "contrarian" in checks
+    assert "evade enforcement" in checks

--- a/tests/test_x_article_engine_meteor_v09_r4.py
+++ b/tests/test_x_article_engine_meteor_v09_r4.py
@@ -158,7 +158,7 @@ def test_operational_platform_evasion_instruction_is_blocked():
 
 def test_platform_evasion_discussion_without_howto_is_reviewed():
     packet = build_generation_packet(brief(), trusted_source_refs=sources())
-    result = audit_draft("BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。", packet)
+    result = audit_draft("BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しない方針です。", packet)
     assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" not in codes(result)
     assert "PLATFORM_EVASION_LANGUAGE" in codes(result)
 

--- a/tests/test_x_article_engine_meteor_v09_r5.py
+++ b/tests/test_x_article_engine_meteor_v09_r5.py
@@ -1,0 +1,85 @@
+from x_article_engine.meteor_v09_r5 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [{"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def codes(result):
+    return [item["code"] for item in result["findings"]]
+
+
+def test_r5_schema_and_false_positive_policies_present():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor-r5"
+    assert "generic_abstract_collision_rule" in packet["anti_ai_smell_policy"]
+    assert "evasion_negation_rule" in packet["security_content_policy"]
+
+
+def test_generic_human_word_does_not_hide_empty_abstract_noun():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("多くの人は仕事の本質を理解していません。", packet)
+    assert "GENERIC_OVERSIZED_SUBJECT" in codes(result)
+    assert "ABSTRACT_WORD_WITHOUT_PAYLOAD" in codes(result)
+
+
+def test_polite_evasion_rejection_is_review_not_operational_block():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(
+        "BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。",
+        packet,
+    )
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" not in codes(result)
+    assert "PLATFORM_EVASION_LANGUAGE" in codes(result)
+
+
+def test_polite_evasion_non_teaching_statement_is_review_not_operational_block():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(
+        "ゼロ幅文字を使う回避策はここでは教えません。規約に沿う方法だけ扱います。",
+        packet,
+    )
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" not in codes(result)
+    assert "PLATFORM_EVASION_LANGUAGE" in codes(result)
+
+
+def test_true_operational_evasion_still_blocks():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft("BAN回避のためにゼロ幅文字を挿入して配信します。", packet)
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_japanese_human_gate_explicitly_mentions_permission_safety_automation():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "権限" in checks
+    assert "安全" in checks
+    assert "自動化" in checks

--- a/tests/test_x_article_engine_meteor_v09_r6.py
+++ b/tests/test_x_article_engine_meteor_v09_r6.py
@@ -1,0 +1,175 @@
+from x_article_engine.meteor_v09_r6 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [{"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def packet():
+    return build_generation_packet(brief(), trusted_source_refs=sources())
+
+
+def test_r6_schema_and_negated_claim_policy_present():
+    result = packet()
+    assert result["schema_version"] == "0.9-meteor-r6"
+    assert "negated_claim_policy" in result
+
+
+def test_negated_absolute_success_is_not_blocked_as_guarantee():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）を使っても、必ず成功するとは限りません。",
+        packet(),
+    )
+    assert "UNBOUND_STRONG_CLAIM" not in codes(result)
+    assert "ABSOLUTE_GENERALIZATION_LANGUAGE" not in codes(result)
+
+
+def test_positive_absolute_success_still_blocks():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）なら必ず成功します。",
+        packet(),
+    )
+    assert "UNBOUND_STRONG_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_negated_complete_free_is_not_blocked_as_free_promise():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の全工程が完全無料ではありません。",
+        packet(),
+    )
+    assert "UNBOUND_ABSOLUTE_FREE_CLAIM" not in codes(result)
+
+
+def test_positive_complete_free_still_blocks():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）は完全無料で使えます。",
+        packet(),
+    )
+    assert "UNBOUND_ABSOLUTE_FREE_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_refused_guarantee_phrase_is_not_blocked():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）について『保証します』とは書けません。",
+        packet(),
+    )
+    assert "UNBOUND_GUARANTEE_LANGUAGE" not in codes(result)
+
+
+def test_positive_guarantee_phrase_still_blocks():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）なら完了できます。保証します。",
+        packet(),
+    )
+    assert "UNBOUND_GUARANTEE_LANGUAGE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_negated_unbound_duration_is_not_blocked():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の作業が30分で終わるとは言いません。",
+        packet(),
+    )
+    assert "UNBOUND_NUMERIC_CLAIM" not in codes(result)
+
+
+def test_positive_unbound_duration_still_blocks():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の作業は30分で終わります。",
+        packet(),
+    )
+    assert "UNBOUND_NUMERIC_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_negated_latest_is_not_reviewed_as_current_claim():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）のこの説明は最新版ではありません。",
+        packet(),
+    )
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" not in codes(result)
+
+
+def test_positive_latest_without_timing_evidence_is_still_reviewed():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の最新版を説明します。",
+        packet(),
+    )
+    assert "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE" in codes(result)
+
+
+def test_negated_superlative_is_not_reviewed_as_claim():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）が世界一だとは言いません。",
+        packet(),
+    )
+    assert "SUPERLATIVE_OR_TOTALIZING_LANGUAGE" not in codes(result)
+
+
+def test_positive_superlative_is_still_reviewed():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）は世界一分かりやすい方法です。",
+        packet(),
+    )
+    assert "SUPERLATIVE_OR_TOTALIZING_LANGUAGE" in codes(result)
+
+
+def test_negated_first_person_biography_is_not_blocked_as_asserted_history():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事で『私は数年前から業務自動化をしてきた』とは書けません。",
+        packet(),
+    )
+    assert "UNBOUND_IDENTITY_DETAIL" not in codes(result)
+
+
+def test_positive_unbound_biography_still_blocks():
+    result = audit_draft(
+        "私は数年前から業務自動化の仕事をしてきました。BridgePatch（ブリッジパッチ）の話をします。",
+        packet(),
+    )
+    assert "UNBOUND_IDENTITY_DETAIL" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_negation_does_not_hide_a_separate_positive_claim():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の作業は30分で終わります。必ず成功するとは限りません。",
+        packet(),
+    )
+    assert "UNBOUND_NUMERIC_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"

--- a/tests/test_x_article_engine_meteor_v09_r7.py
+++ b/tests/test_x_article_engine_meteor_v09_r7.py
@@ -1,0 +1,164 @@
+import pytest
+
+from x_article_engine.meteor_v09_r7 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "risk", "status": "VERIFIED", "kind": "OFFICIAL"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def high_risk_brief():
+    data = brief(risk_level="HIGH", topic_mode="PROCEDURAL")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この操作は権限を広げるため、誤操作時の影響範囲が大きくなる。",
+            "source_ref": "risk",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    return data
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_r7_schema_and_polarity_policy_present():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor-r7"
+    assert "polarity_policy" in packet
+
+
+def test_secret_transfer_do_not_instruction_is_not_blocked_as_transfer():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事です。APIキーをClaudeに送ってはいけません。",
+        packet,
+    )
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
+
+
+def test_secret_transfer_positive_instruction_still_blocks():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事です。APIキーをClaudeに送ってください。",
+        packet,
+    )
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_dangerous_command_inside_do_not_use_form_is_not_blocked():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事です。--dangerously-skip-permissions を使ってはいけません。",
+        packet,
+    )
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
+
+
+def test_high_risk_front_cannot_be_spoofed_by_no_risk_sentence():
+    packet = build_generation_packet(high_risk_brief(), trusted_source_refs=sources())
+    draft = (
+        "リスクはありません。BridgePatch（ブリッジパッチ）の手順です。\n"
+        "手順1 設定します。\n手順2 実行します。\n手順3 完了を確認します。"
+    )
+    result = audit_draft(draft, packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_high_risk_front_cannot_be_spoofed_by_do_not_stop_sentence():
+    packet = build_generation_packet(high_risk_brief(), trusted_source_refs=sources())
+    draft = (
+        "停止しないでください。BridgePatch（ブリッジパッチ）の手順です。\n"
+        "手順1 設定します。\n手順2 実行します。\n手順3 完了を確認します。"
+    )
+    result = audit_draft(draft, packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
+
+
+def test_real_high_risk_warning_satisfies_front_gate():
+    packet = build_generation_packet(high_risk_brief(), trusted_source_refs=sources())
+    draft = (
+        "警告：この操作は権限を広げるため、誤操作時の影響範囲が大きくなります。対象外なら進めないでください。\n"
+        "BridgePatch（ブリッジパッチ）の手順です。なぜ最初に確認するか。失敗範囲を小さくするためです。\n"
+        "手順1 設定します。完了を確認してください。\n"
+        "手順2 実行します。エラーなら停止して戻ります。\n"
+        "手順3 成功表示を確認します。"
+    )
+    result = audit_draft(draft, packet)
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" not in codes(result)
+
+
+def test_two_rejected_actions_are_not_counted_as_multiple_ctas():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = (
+        "BridgePatch（ブリッジパッチ）の記事です。"
+        "登録してくださいとは言いません。フォローしてくださいとも言いません。"
+    )
+    result = audit_draft(draft, packet)
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
+
+
+def test_one_real_cta_plus_one_rejected_action_is_not_multi_cta():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = (
+        "BridgePatch（ブリッジパッチ）の無料適合確認を使ってください。"
+        "フォローしてくださいとは言いません。"
+    )
+    result = audit_draft(draft, packet)
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
+
+
+def test_two_real_ctas_still_review():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    draft = (
+        "BridgePatch（ブリッジパッチ）の無料適合確認を使ってください。"
+        "記事が役立ったらフォローしてください。"
+    )
+    result = audit_draft(draft, packet)
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" in codes(result)
+
+
+def test_human_gate_includes_polarity_check():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "実行を勧めているのか" in checks
+    assert "禁止・否定" in checks

--- a/tests/test_x_article_engine_meteor_v09_r8.py
+++ b/tests/test_x_article_engine_meteor_v09_r8.py
@@ -1,0 +1,182 @@
+import pytest
+
+from x_article_engine.core import XArticleEngineError
+from x_article_engine.meteor_v09_r8 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "timing", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "risk-a", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "risk-b", "status": "VERIFIED", "kind": "OFFICIAL"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def current_with_timing(**overrides):
+    data = brief(freshness_mode="CURRENT", as_of="2026-08-16")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この仕様は2026年8月16日時点の公開仕様に基づく。",
+            "source_ref": "timing",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    data.update(overrides)
+    return data
+
+
+def high_risk(**overrides):
+    data = brief(risk_level="HIGH", topic_mode="PROCEDURAL")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "権限を広げる操作では、誤操作時の影響範囲が大きくなる。",
+            "source_ref": "risk-a",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    data.update(overrides)
+    return data
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_r8_schema_and_purpose_binding_policy_present():
+    packet = build_generation_packet(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9-meteor-r8"
+    assert "evidence_purpose_binding_policy" in packet
+
+
+def test_current_mode_requires_explicit_freshness_evidence_refs():
+    data = current_with_timing()
+    with pytest.raises(XArticleEngineError, match="freshness_evidence_refs requires"):
+        build_generation_packet(data, trusted_source_refs=sources())
+
+
+def test_unrelated_dated_commercial_fact_cannot_authorize_currentness():
+    data = brief(freshness_mode="CURRENT", as_of="2026-08-16")
+    data["evidence"] = [
+        {
+            "claim": "2026年8月16日時点で設計書は10,000円だった。",
+            "source_ref": "sales",
+            "status": "VERIFIED",
+            "kind": "COMMERCIAL",
+        }
+    ]
+    data["freshness_evidence_refs"] = ["sales"]
+    with pytest.raises(XArticleEngineError, match="must resolve to verified evidence of kind TIMING"):
+        build_generation_packet(data, trusted_source_refs=sources())
+
+
+def test_bound_verified_timing_ref_authorizes_current_mode():
+    data = current_with_timing(freshness_evidence_refs=["timing"])
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["freshness"]["evidence_refs"] == ["timing"]
+    assert packet["freshness"]["bound_evidence"][0]["kind"] == "TIMING"
+
+
+def test_unknown_freshness_ref_fails_closed():
+    data = current_with_timing(freshness_evidence_refs=["not-there"])
+    with pytest.raises(XArticleEngineError, match="not-there"):
+        build_generation_packet(data, trusted_source_refs=sources())
+
+
+def test_evergreen_article_with_random_timing_evidence_still_reviews_latest_wording():
+    data = brief()
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "別の出来事が2026年8月16日に起きた。",
+            "source_ref": "timing",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    result = audit_draft("BridgePatch（ブリッジパッチ）の最新版を説明します。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE" in codes(result)
+
+
+def test_current_article_with_bound_timing_ref_does_not_get_bound_evidence_review():
+    packet = build_generation_packet(
+        current_with_timing(freshness_evidence_refs=["timing"]),
+        trusted_source_refs=sources(),
+    )
+    result = audit_draft("BridgePatch（ブリッジパッチ）の現在の仕様を説明します。", packet)
+    assert "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE" not in codes(result)
+
+
+def test_high_risk_mode_requires_explicit_risk_evidence_refs():
+    with pytest.raises(XArticleEngineError, match="risk_evidence_refs requires"):
+        build_generation_packet(high_risk(), trusted_source_refs=sources())
+
+
+def test_commercial_ref_cannot_be_used_as_risk_binding():
+    data = high_risk(risk_evidence_refs=["sales"])
+    with pytest.raises(XArticleEngineError, match="must resolve to verified evidence of kind"):
+        build_generation_packet(data, trusted_source_refs=sources())
+
+
+def test_bound_verified_risk_ref_authorizes_high_risk_mode():
+    packet = build_generation_packet(
+        high_risk(risk_evidence_refs=["risk-a"]),
+        trusted_source_refs=sources(),
+    )
+    assert packet["risk_policy"]["evidence_refs"] == ["risk-a"]
+    assert packet["risk_policy"]["bound_evidence"][0]["kind"] == "RISK"
+
+
+def test_unrelated_second_risk_ref_is_not_silently_substituted_for_requested_ref():
+    data = high_risk(risk_evidence_refs=["risk-b"])
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "別の操作ではAPIキー漏洩の危険がある。",
+            "source_ref": "risk-b",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    packet = build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["risk_policy"]["evidence_refs"] == ["risk-b"]
+    assert all(item["source_ref"] == "risk-b" for item in packet["risk_policy"]["bound_evidence"])
+    # Semantic match between that bound evidence and the exact warning still remains a /human check.
+    checks = "\n".join(packet["human_gate"]["checks"])
+    assert "本文で警告している具体的な危険" in checks

--- a/tests/test_x_article_engine_meteor_v09_r9.py
+++ b/tests/test_x_article_engine_meteor_v09_r9.py
@@ -1,0 +1,119 @@
+from x_article_engine.meteor_v09_r9 import audit_draft, build_generation_packet
+
+
+def sources():
+    return [{"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}]
+
+
+def brief():
+    return {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "まず無料で制作可否を確認できる。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール制作そのものは含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            },
+        ],
+    }
+
+
+def packet():
+    return build_generation_packet(brief(), trusted_source_refs=sources())
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_r9_schema_and_cta_semantics_policy_present():
+    result = packet()
+    assert result["schema_version"] == "0.9-meteor-r9"
+    assert "cta_semantics_policy" in result
+
+
+def test_natural_fit_check_continuation_counts_as_one_cta():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。これ、自動化できる？くらいなら無料適合確認から始められます。",
+        packet(),
+    )
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
+
+
+def test_natural_fit_check_plus_follow_counts_as_two_actions():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。無料適合確認から始められます。役立ったらフォローしてください。",
+        packet(),
+    )
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" in codes(result)
+
+
+def test_describing_fit_check_concept_is_not_itself_a_cta():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の記事で、無料適合確認という考え方を説明します。",
+        packet(),
+    )
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
+
+
+def test_fit_check_plus_rejected_follow_is_still_single_cta():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）は無料適合確認から始められます。フォローしてくださいとは言いません。",
+        packet(),
+    )
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
+
+
+def test_log_term_does_not_fire_inside_program_word():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。プログラムの不具合を直しました。",
+        packet(),
+    )
+    assert not any(
+        item.get("code") == "UNEXPLAINED_TERM_ON_FIRST_USE" and item.get("detail") == "ログ"
+        for item in result["findings"]
+    )
+
+
+def test_real_log_term_still_requires_explanation():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。ログを確認しました。",
+        packet(),
+    )
+    assert any(
+        item.get("code") == "UNEXPLAINED_TERM_ON_FIRST_USE" and item.get("detail") == "ログ"
+        for item in result["findings"]
+    )
+
+
+def test_explained_log_term_passes_terminology_gate():
+    result = audit_draft(
+        "BridgePatch（ブリッジパッチ）の話です。ログという、プログラムがいつ何をしたか残す記録を確認しました。",
+        packet(),
+    )
+    assert not any(
+        item.get("code") == "UNEXPLAINED_TERM_ON_FIRST_USE" and item.get("detail") == "ログ"
+        for item in result["findings"]
+    )

--- a/tests/test_x_article_engine_meteor_v09_r9.py
+++ b/tests/test_x_article_engine_meteor_v09_r9.py
@@ -50,7 +50,8 @@ def codes(result):
 
 def test_r9_schema_and_cta_semantics_policy_present():
     result = packet()
-    assert result["schema_version"] == "0.9-meteor-r9"
+    assert result["schema_version"] == "0.9"
+    assert result["meteor_round"] == "R9_DOGFOOD_CTA"
     assert "cta_semantics_policy" in result
 
 

--- a/tests/test_x_article_engine_terminology.py
+++ b/tests/test_x_article_engine_terminology.py
@@ -1,4 +1,4 @@
-from x_article_engine import audit_draft, build_generation_packet
+from x_article_engine.terminology import audit_draft, build_generation_packet
 
 
 def source():

--- a/tests/test_x_article_engine_v09_consolidation.py
+++ b/tests/test_x_article_engine_v09_consolidation.py
@@ -1,0 +1,228 @@
+import pytest
+
+from x_article_engine.core import XArticleEngineError
+from x_article_engine import meteor_v09_r5 as stacked
+from x_article_engine import v09 as flat
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "dated", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "risk", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "counter", "status": "VERIFIED", "kind": "REPORT"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            },
+            {
+                "claim": "これが私がこの仕事を始めたきっかけである。",
+                "source_ref": "human_attestation:origin",
+                "attested": True,
+                "kind": "ORIGIN",
+            },
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def build_pair(data=None):
+    src = data or brief()
+    return (
+        stacked.build_generation_packet(src, trusted_source_refs=sources()),
+        flat.build_generation_packet(src, trusted_source_refs=sources()),
+    )
+
+
+def test_flat_keeps_key_generation_contract_from_stacked_candidate():
+    old, new = build_pair()
+    for key in [
+        "article_type",
+        "opening_mode",
+        "publication_state",
+        "publication_authority",
+        "external_publication_performed",
+        "review_state",
+    ]:
+        assert new[key] == old[key]
+    assert len(new["verified_primary_info"]) == len(old["verified_primary_info"])
+    assert len(new["verified_evidence"]) == len(old["verified_evidence"])
+    assert new["schema_version"] == "0.9"
+    assert old["schema_version"] == "0.9-meteor-r5"
+
+
+@pytest.mark.parametrize(
+    "draft,required_code,expected_status",
+    [
+        (
+            "Claude Codeを --dangerously-skip-permissions で起動してください。",
+            "UNSAFE_PERMISSION_OR_SECURITY_BYPASS",
+            "BLOCKED",
+        ),
+        (
+            "APIキーをClaudeのプロンプトに貼り付けて送信してください。",
+            "SECRET_TRANSFER_TO_MODEL_RISK",
+            "BLOCKED",
+        ),
+        (
+            "これは完全無料で使えます。",
+            "UNBOUND_ABSOLUTE_FREE_CLAIM",
+            "BLOCKED",
+        ),
+        (
+            "この手順なら完了できます。保証します。",
+            "UNBOUND_GUARANTEE_LANGUAGE",
+            "BLOCKED",
+        ),
+        (
+            "多くの人は仕事の本質を理解していません。",
+            "ABSTRACT_WORD_WITHOUT_PAYLOAD",
+            "HUMAN_REVIEW_REQUIRED",
+        ),
+        (
+            "BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。",
+            "PLATFORM_EVASION_LANGUAGE",
+            "HUMAN_REVIEW_REQUIRED",
+        ),
+        (
+            "BAN回避のためにゼロ幅文字を挿入して配信します。",
+            "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION",
+            "BLOCKED",
+        ),
+    ],
+)
+def test_flat_preserves_meteor_attack_outcomes(draft, required_code, expected_status):
+    old_packet, new_packet = build_pair()
+    old = stacked.audit_draft(draft, old_packet)
+    new = flat.audit_draft(draft, new_packet)
+    assert required_code in codes(old)
+    assert required_code in codes(new)
+    assert old["status"] == expected_status
+    assert new["status"] == expected_status
+
+
+def test_flat_and_stacked_both_keep_safe_bridgepatch_story_out_of_security_blocks():
+    old_packet, new_packet = build_pair()
+    draft = (
+        "あー、めんどくさくてキレそう。\n"
+        "修正して確認する。直したら別の場所をもう一度確認する。まさに無限修正だった。\n"
+        "そこで全部を自動化するのではなく、一工程だけ切ることにした。\n"
+        "間違えたときは人間に戻せるようにする。\n"
+        "その考えを仕事に使える形にしたのがBridgePatch（ブリッジパッチ）です。"
+    )
+    security_codes = {
+        "UNSAFE_PERMISSION_OR_SECURITY_BYPASS",
+        "SECRET_TRANSFER_TO_MODEL_RISK",
+        "HIGH_RISK_WITHOUT_FRONT_STOP_GATE",
+        "UNBOUND_GUARANTEE_LANGUAGE",
+        "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION",
+    }
+    assert not security_codes.intersection(codes(stacked.audit_draft(draft, old_packet)))
+    assert not security_codes.intersection(codes(flat.audit_draft(draft, new_packet)))
+
+
+def test_flat_origin_only_falls_back_to_relatable_like_stacked_r5():
+    data = brief()
+    data["primary_info"] = [
+        {
+            "claim": "これが私がこの仕事を始めたきっかけである。",
+            "source_ref": "human_attestation:origin",
+            "attested": True,
+            "kind": "ORIGIN",
+        }
+    ]
+    old, new = build_pair(data)
+    assert old["opening_mode"] == "RELATABLE"
+    assert new["opening_mode"] == "RELATABLE"
+
+
+def test_flat_contrarian_requires_basis_and_accepts_bound_human_opinion():
+    data = brief(opening_mode="CONTRARIAN")
+    data["primary_info"] = [
+        {
+            "claim": "全部自動化するより、一工程だけ切る方がいいと私は考えている。",
+            "source_ref": "human_attestation:counterpoint",
+            "attested": True,
+            "kind": "OPINION",
+        }
+    ]
+    with pytest.raises(XArticleEngineError, match="counterpoint_basis"):
+        flat.build_generation_packet(data, trusted_source_refs=sources())
+
+    data["counterpoint_basis"] = {
+        "kind": "HUMAN_OPINION",
+        "source_ref": "human_attestation:counterpoint",
+    }
+    packet = flat.build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["opening_mode"] == "CONTRARIAN"
+
+
+def test_flat_current_mode_requires_dated_verified_evidence():
+    with pytest.raises(XArticleEngineError, match="verified dated/TIMING evidence"):
+        flat.build_generation_packet(
+            brief(freshness_mode="CURRENT", as_of="2026-08-16"),
+            trusted_source_refs=sources(),
+        )
+
+    data = brief(freshness_mode="CURRENT", as_of="2026-08-16")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この仕様は2026年8月16日時点の公式情報で確認した。",
+            "source_ref": "dated",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    packet = flat.build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["freshness"]["mode"] == "CURRENT"
+
+
+def test_flat_high_risk_mode_requires_verified_risk_evidence():
+    with pytest.raises(XArticleEngineError, match="HIGH-risk articles require"):
+        flat.build_generation_packet(
+            brief(risk_level="HIGH", topic_mode="PROCEDURAL"),
+            trusted_source_refs=sources(),
+        )
+
+    data = brief(risk_level="HIGH", topic_mode="PROCEDURAL")
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この操作は権限を広げるため、誤操作時の影響範囲が大きくなる。",
+            "source_ref": "risk",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    packet = flat.build_generation_packet(data, trusted_source_refs=sources())
+    assert packet["risk_policy"]["risk_level"] == "HIGH"

--- a/tests/test_x_article_engine_v09_consolidation.py
+++ b/tests/test_x_article_engine_v09_consolidation.py
@@ -84,37 +84,37 @@ def test_flat_keeps_key_generation_contract_from_stacked_candidate():
     "draft,required_code,expected_status",
     [
         (
-            "Claude Codeを --dangerously-skip-permissions で起動してください。",
+            "BridgePatch（ブリッジパッチ）の記事です。Claude Codeを --dangerously-skip-permissions で起動してください。",
             "UNSAFE_PERMISSION_OR_SECURITY_BYPASS",
             "BLOCKED",
         ),
         (
-            "APIキーをClaudeのプロンプトに貼り付けて送信してください。",
+            "BridgePatch（ブリッジパッチ）の記事です。APIキーをClaudeのプロンプトに貼り付けて送信してください。",
             "SECRET_TRANSFER_TO_MODEL_RISK",
             "BLOCKED",
         ),
         (
-            "これは完全無料で使えます。",
+            "BridgePatch（ブリッジパッチ）は完全無料で使えます。",
             "UNBOUND_ABSOLUTE_FREE_CLAIM",
             "BLOCKED",
         ),
         (
-            "この手順なら完了できます。保証します。",
+            "BridgePatch（ブリッジパッチ）の手順なら完了できます。保証します。",
             "UNBOUND_GUARANTEE_LANGUAGE",
             "BLOCKED",
         ),
         (
-            "多くの人は仕事の本質を理解していません。",
+            "BridgePatch（ブリッジパッチ）の話です。多くの人は仕事の本質を理解していません。",
             "ABSTRACT_WORD_WITHOUT_PAYLOAD",
             "HUMAN_REVIEW_REQUIRED",
         ),
         (
-            "BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。",
+            "BridgePatch（ブリッジパッチ）の話です。BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。",
             "PLATFORM_EVASION_LANGUAGE",
             "HUMAN_REVIEW_REQUIRED",
         ),
         (
-            "BAN回避のためにゼロ幅文字を挿入して配信します。",
+            "BridgePatch（ブリッジパッチ）の話です。BAN回避のためにゼロ幅文字を挿入して配信します。",
             "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION",
             "BLOCKED",
         ),

--- a/tests/test_x_article_engine_v09_final_regression.py
+++ b/tests/test_x_article_engine_v09_final_regression.py
@@ -1,0 +1,353 @@
+import pytest
+
+from x_article_engine import audit_draft, build_generation_packet
+from x_article_engine.core import XArticleEngineError
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "timing", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "risk", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "counter", "status": "VERIFIED", "kind": "REPORT"},
+        {"id": "result", "status": "VERIFIED", "kind": "LEDGER"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール制作そのものは含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def current_brief():
+    data = brief(
+        freshness_mode="CURRENT",
+        as_of="2026-08-16",
+        freshness_evidence_refs=["timing"],
+    )
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この仕様は2026年8月16日時点の公開仕様に基づく。",
+            "source_ref": "timing",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    return data
+
+
+def high_risk_brief():
+    data = brief(
+        risk_level="HIGH",
+        topic_mode="PROCEDURAL",
+        risk_evidence_refs=["risk"],
+    )
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "権限を広げる操作では、誤操作時の影響範囲が大きくなる。",
+            "source_ref": "risk",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    return data
+
+
+def packet(data=None):
+    return build_generation_packet(data or brief(), trusted_source_refs=sources())
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_final_schema_and_publication_boundary():
+    result = packet()
+    assert result["schema_version"] == "0.9"
+    assert result["meteor_status"] == "R11_SYNTHESIZED"
+    assert result["publication_state"] == "BLOCKED_PENDING_HUMAN"
+    assert result["publication_authority"] == "USER_ONLY"
+    assert result["external_publication_performed"] is False
+
+
+def test_current_requires_as_of():
+    with pytest.raises(XArticleEngineError):
+        packet(brief(freshness_mode="CURRENT"))
+
+
+def test_current_requires_explicit_bound_timing_ref():
+    data = current_brief()
+    data.pop("freshness_evidence_refs")
+    with pytest.raises(XArticleEngineError, match="freshness_evidence_refs"):
+        packet(data)
+
+
+def test_current_accepts_bound_timing_ref():
+    result = packet(current_brief())
+    assert result["freshness"]["evidence_refs"] == ["timing"]
+
+
+def test_latest_wording_in_evergreen_is_reviewed():
+    result = audit_draft("これは最新版の方法です。", packet())
+    assert "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE" in codes(result)
+
+
+def test_negated_latest_is_not_currentness_claim():
+    result = audit_draft("これは最新版ではありません。", packet())
+    assert "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE" not in codes(result)
+
+
+def test_high_risk_requires_explicit_bound_risk_ref():
+    data = high_risk_brief()
+    data.pop("risk_evidence_refs")
+    with pytest.raises(XArticleEngineError, match="risk_evidence_refs"):
+        packet(data)
+
+
+def test_permission_bypass_instruction_blocks():
+    result = audit_draft("--dangerously-skip-permissions で起動してください。", packet())
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_permission_bypass_prohibition_does_not_block():
+    result = audit_draft("--dangerously-skip-permissions を使ってはいけません。", packet())
+    assert "UNSAFE_PERMISSION_OR_SECURITY_BYPASS" not in codes(result)
+
+
+def test_secret_to_model_instruction_blocks():
+    result = audit_draft("APIキーをClaudeのプロンプトに貼り付けて送信してください。", packet())
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_secret_to_model_prohibition_does_not_block():
+    result = audit_draft("APIキーをClaudeに送ってはいけません。", packet())
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
+
+
+def test_settings_screen_secret_is_not_model_chat_transfer():
+    result = audit_draft("Claudeの設定画面にAPIキーを入力してください。", packet())
+    assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
+
+
+def test_automation_without_human_checkpoint_reviews():
+    result = audit_draft("ユーザーに質問せず、すべて自動で判断して進めてください。", packet())
+    assert "AUTOMATION_WITHOUT_HUMAN_CHECKPOINT" in codes(result)
+
+
+def test_hardcoded_reusable_secret_blocks():
+    result = audit_draft("管理画面用APIキーは sk-line-harness-2026 をこのまま使って設定してください。", packet())
+    assert "HARDCODED_SECRET_LITERAL_RISK" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_dummy_secret_example_does_not_block():
+    result = audit_draft("例のダミーAPIキー sk-example-placeholder は実際には使わないでください。", packet())
+    assert "HARDCODED_SECRET_LITERAL_RISK" not in codes(result)
+
+
+def test_unbound_absolute_free_blocks():
+    result = audit_draft("これは完全無料で使えます。", packet())
+    assert "UNBOUND_ABSOLUTE_FREE_CLAIM" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_negated_absolute_free_does_not_block():
+    result = audit_draft("すべてが完全無料ではありません。", packet())
+    assert "UNBOUND_ABSOLUTE_FREE_CLAIM" not in codes(result)
+
+
+def test_plain_guarantee_blocks():
+    result = audit_draft("この方法なら完了できます。保証します。", packet())
+    assert "UNBOUND_GUARANTEE_LANGUAGE" in codes(result)
+
+
+def test_rejected_guarantee_example_does_not_block():
+    result = audit_draft("『保証します』という表現は使いません。", packet())
+    assert "UNBOUND_GUARANTEE_LANGUAGE" not in codes(result)
+
+
+def test_safety_imperative_not_flattened_into_commercial_guarantee():
+    result = audit_draft("APIキーは絶対に共有しないでください。権限は必ず確認してください。", packet())
+    assert not any(
+        item["code"] == "UNBOUND_STRONG_CLAIM" and item["detail"] in {"必ず", "絶対"}
+        for item in result["findings"]
+    )
+
+
+def test_broad_absolute_prediction_reviews_not_blocks():
+    result = audit_draft("初心者は必ず次の壁にぶつかります。", packet())
+    assert "ABSOLUTE_GENERALIZATION_LANGUAGE" in codes(result)
+    assert result["status"] == "HUMAN_REVIEW_REQUIRED"
+
+
+def test_universal_capability_promise_reviews():
+    result = audit_draft("初心者でもこの記事だけでできます。", packet())
+    assert "UNIVERSAL_CAPABILITY_PROMISE" in codes(result)
+
+
+def test_warning_fatigue_reviews():
+    result = audit_draft("\n".join(["⚠️ 超重要な警告です。"] * 6), packet())
+    assert "WARNING_FATIGUE_RISK" in codes(result)
+
+
+def test_self_responsibility_without_mitigation_reviews():
+    result = audit_draft("この操作は自己責任で行ってください。", packet())
+    assert "SELF_RESPONSIBILITY_WITHOUT_MITIGATION" in codes(result)
+
+
+def test_self_responsibility_with_local_mitigation_clears_specific_review():
+    result = audit_draft(
+        "自己責任という言葉だけで済ませません。まずテスト環境で確認し、異常があれば停止して戻してください。",
+        packet(),
+    )
+    assert "SELF_RESPONSIBILITY_WITHOUT_MITIGATION" not in codes(result)
+
+
+def test_high_risk_front_gate_rejects_no_risk_spoof():
+    result = audit_draft(
+        "リスクはありません。\n手順1 設定します。\n手順2 実行します。\n手順3 完了を確認します。",
+        packet(high_risk_brief()),
+    )
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_high_risk_real_warning_passes_front_gate():
+    result = audit_draft(
+        "警告：この操作は権限を広げるため、誤操作時の影響範囲が大きくなります。対象外なら進めないでください。\n"
+        "なぜ確認するか。失敗範囲を小さくするためです。\n"
+        "手順1 設定します。完了を確認してください。\n"
+        "手順2 実行します。エラーなら停止して戻ります。\n"
+        "手順3 成功表示を確認します。",
+        packet(high_risk_brief()),
+    )
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" not in codes(result)
+
+
+def test_procedure_without_success_recovery_why_reviews():
+    result = audit_draft(
+        "手順1 開きます。\n手順2 入力します。\n手順3 実行します。",
+        packet(brief(topic_mode="PROCEDURAL")),
+    )
+    assert {"PROCEDURE_WITHOUT_SUCCESS_SIGNAL", "PROCEDURE_WITHOUT_RECOVERY_PATH", "PROCEDURE_WITHOUT_WHY"}.issubset(codes(result))
+
+
+def test_origin_only_does_not_manufacture_lived_pain():
+    data = brief()
+    data["primary_info"] = [
+        {
+            "claim": "これが私がこの仕事を始めたきっかけである。",
+            "source_ref": "human_attestation:origin",
+            "attested": True,
+            "kind": "ORIGIN",
+        }
+    ]
+    assert packet(data)["opening_mode"] == "RELATABLE"
+
+
+def test_contrarian_requires_basis():
+    with pytest.raises(XArticleEngineError, match="counterpoint_basis"):
+        packet(brief(opening_mode="CONTRARIAN"))
+
+
+def test_contrarian_accepts_human_opinion_basis():
+    data = brief(opening_mode="CONTRARIAN")
+    data["primary_info"] = [
+        {
+            "claim": "全部自動化するより、一工程だけ切る方がいいと私は考えている。",
+            "source_ref": "human_attestation:counterpoint",
+            "attested": True,
+            "kind": "OPINION",
+        }
+    ]
+    data["counterpoint_basis"] = {
+        "kind": "HUMAN_OPINION",
+        "source_ref": "human_attestation:counterpoint",
+    }
+    assert packet(data)["opening_mode"] == "CONTRARIAN"
+
+
+def test_platform_evasion_operational_instruction_blocks():
+    result = audit_draft("BAN回避のためにゼロ幅文字を挿入して配信します。", packet())
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_platform_evasion_rejection_is_review_only():
+    result = audit_draft("BAN回避を目的にしたステルス配信という主張がありますが、この記事では推奨しません。", packet())
+    assert "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" not in codes(result)
+    assert "PLATFORM_EVASION_LANGUAGE" in codes(result)
+
+
+def test_natural_fit_check_plus_follow_is_multi_cta():
+    result = audit_draft("無料適合確認から始められます。役立ったらフォローしてください。", packet())
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" in codes(result)
+
+
+def test_rejected_follow_does_not_count_as_cta():
+    result = audit_draft("無料適合確認から始められます。フォローしてくださいとは言いません。", packet())
+    assert "MULTIPLE_COMMERCIAL_ACTIONS_RISK" not in codes(result)
+
+
+def test_10000_evidence_does_not_bind_zero_yen():
+    result = audit_draft("利用料は0円です。", packet())
+    assert any(item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "0円" for item in result["findings"])
+
+
+def test_exact_10000_price_remains_bound():
+    result = audit_draft("暫定ツール実装設計書は10,000円（税込）です。", packet())
+    assert not any(item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "10,000円" for item in result["findings"])
+
+
+def test_price_number_reused_as_sales_result_reviews():
+    result = audit_draft("10,000円売れました。", packet())
+    assert "NUMERIC_CONTEXT_REUSE_RISK" in codes(result)
+
+
+def test_price_number_reused_as_savings_reviews():
+    result = audit_draft("顧客が10,000円節約できました。", packet())
+    assert "NUMERIC_CONTEXT_REUSE_RISK" in codes(result)
+
+
+def test_bad_numeric_example_rejected_in_meta_is_not_asserted():
+    result = audit_draft("『30分で終わります』と書くのはやめます。", packet())
+    assert not any(item.get("code") == "UNBOUND_NUMERIC_CLAIM" and item.get("detail") == "30分" for item in result["findings"])
+
+
+def test_bad_biography_example_rejected_in_meta_is_not_asserted():
+    result = audit_draft("『私は数年前から業務自動化をしてきた』という経歴をAIに作らせてはいけません。", packet())
+    assert "UNBOUND_IDENTITY_DETAIL" not in codes(result)
+
+
+def test_human_gate_still_required_after_clean_heuristics():
+    result = audit_draft("一工程だけを扱います。", packet())
+    assert result["human_review_required"] is True
+    assert result["publication_state"] == "BLOCKED_PENDING_HUMAN"

--- a/tests/test_x_article_engine_v09_hardened.py
+++ b/tests/test_x_article_engine_v09_hardened.py
@@ -1,0 +1,208 @@
+import pytest
+
+from x_article_engine import audit_draft as root_audit
+from x_article_engine import build_generation_packet as root_build
+from x_article_engine.core import XArticleEngineError
+from x_article_engine import meteor_v09_r8 as attack
+from x_article_engine import v09_hardened as hardened
+
+
+def sources():
+    return [
+        {"id": "sales", "status": "VERIFIED", "kind": "PUBLIC_PAGE"},
+        {"id": "timing", "status": "VERIFIED", "kind": "OFFICIAL"},
+        {"id": "risk", "status": "VERIFIED", "kind": "OFFICIAL"},
+    ]
+
+
+def brief(**overrides):
+    data = {
+        "offer": "BridgePatch。まず無料で適合確認し、必要なら一工程の設計へ進む。",
+        "target": "毎週、転記・集計・確認・下書きを手作業している小規模事業者。",
+        "pain": "AIは使えそうだが、安全に何を自動化するか説明できない。",
+        "primary_info": [
+            {
+                "claim": "あー、めんどくさくてキレそう。",
+                "source_ref": "human_attestation:pain",
+                "attested": True,
+                "kind": "PAIN",
+            }
+        ],
+        "article_type": "STORY",
+        "topic_mode": "BUSINESS",
+        "cta": "BridgePatchの無料適合確認を使う。",
+        "product_name": "BridgePatch",
+        "product_reading": "ブリッジパッチ",
+        "evidence": [
+            {
+                "claim": "暫定ツール実装設計書は10,000円（税込）で、ツール実装は含まない。",
+                "source_ref": "sales",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    data.update(overrides)
+    return data
+
+
+def current_brief():
+    data = brief(
+        freshness_mode="CURRENT",
+        as_of="2026-08-16",
+        freshness_evidence_refs=["timing"],
+    )
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "この仕様は2026年8月16日時点の公開仕様に基づく。",
+            "source_ref": "timing",
+            "status": "VERIFIED",
+            "kind": "TIMING",
+        },
+    ]
+    return data
+
+
+def high_risk_brief():
+    data = brief(
+        risk_level="HIGH",
+        topic_mode="PROCEDURAL",
+        risk_evidence_refs=["risk"],
+    )
+    data["evidence"] = [
+        *data["evidence"],
+        {
+            "claim": "権限を広げる操作では、誤操作時の影響範囲が大きくなる。",
+            "source_ref": "risk",
+            "status": "VERIFIED",
+            "kind": "RISK",
+        },
+    ]
+    return data
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_package_root_is_hardened_v09_not_attack_stack():
+    packet = root_build(brief(), trusted_source_refs=sources())
+    assert packet["schema_version"] == "0.9"
+    assert "negated_claim_policy" in packet
+    assert "polarity_policy" in packet
+    assert "evidence_purpose_binding_policy" in packet
+
+
+def test_root_and_hardened_are_same_runtime_contract():
+    direct = hardened.build_generation_packet(brief(), trusted_source_refs=sources())
+    root = root_build(brief(), trusted_source_refs=sources())
+    assert root["schema_version"] == direct["schema_version"] == "0.9"
+    assert root["opening_mode"] == direct["opening_mode"]
+    assert root["publication_authority"] == direct["publication_authority"] == "USER_ONLY"
+    assert root["publication_state"] == direct["publication_state"] == "BLOCKED_PENDING_HUMAN"
+
+
+@pytest.mark.parametrize(
+    "draft,code",
+    [
+        (
+            "BridgePatch（ブリッジパッチ）を使っても、必ず成功するとは限りません。",
+            None,
+        ),
+        (
+            "BridgePatch（ブリッジパッチ）の全工程が完全無料ではありません。",
+            None,
+        ),
+        (
+            "BridgePatch（ブリッジパッチ）の作業が30分で終わるとは言いません。",
+            None,
+        ),
+        (
+            "BridgePatch（ブリッジパッチ）の記事です。APIキーをClaudeに送ってはいけません。",
+            None,
+        ),
+        (
+            "BridgePatch（ブリッジパッチ）の記事です。APIキーをClaudeに送ってください。",
+            "SECRET_TRANSFER_TO_MODEL_RISK",
+        ),
+    ],
+)
+def test_hardened_absorbs_negation_and_polarity_behavior(draft, code):
+    packet = root_build(brief(), trusted_source_refs=sources())
+    result = root_audit(draft, packet)
+    if code is None:
+        assert "SECRET_TRANSFER_TO_MODEL_RISK" not in codes(result)
+        assert "UNBOUND_ABSOLUTE_FREE_CLAIM" not in codes(result)
+        assert "UNBOUND_NUMERIC_CLAIM" not in codes(result)
+        assert not any(
+            item["code"] == "UNBOUND_STRONG_CLAIM" and item["detail"] in {"必ず", "絶対"}
+            for item in result["findings"]
+        )
+    else:
+        assert code in codes(result)
+        assert result["status"] == "BLOCKED"
+
+
+def test_hardened_high_risk_front_gate_rejects_negated_risk_spoof():
+    packet = root_build(high_risk_brief(), trusted_source_refs=sources())
+    result = root_audit(
+        "リスクはありません。BridgePatch（ブリッジパッチ）の手順です。\n"
+        "手順1 設定します。\n手順2 実行します。\n手順3 完了を確認します。",
+        packet,
+    )
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" in codes(result)
+    assert result["status"] == "BLOCKED"
+
+
+def test_hardened_high_risk_real_warning_passes_front_gate():
+    packet = root_build(high_risk_brief(), trusted_source_refs=sources())
+    result = root_audit(
+        "警告：この操作は権限を広げるため、誤操作時の影響範囲が大きくなります。対象外なら進めないでください。\n"
+        "BridgePatch（ブリッジパッチ）の手順です。なぜ確認するか。失敗範囲を小さくするためです。\n"
+        "手順1 設定します。完了を確認してください。\n"
+        "手順2 実行します。エラーなら停止して戻ります。\n"
+        "手順3 成功表示を確認します。",
+        packet,
+    )
+    assert "HIGH_RISK_WITHOUT_FRONT_STOP_GATE" not in codes(result)
+
+
+def test_hardened_requires_bound_freshness_refs_at_root():
+    data = current_brief()
+    data.pop("freshness_evidence_refs")
+    with pytest.raises(XArticleEngineError, match="freshness_evidence_refs requires"):
+        root_build(data, trusted_source_refs=sources())
+
+
+def test_hardened_current_with_bound_timing_ref_is_clean_for_binding_gate():
+    packet = root_build(current_brief(), trusted_source_refs=sources())
+    result = root_audit(
+        "BridgePatch（ブリッジパッチ）の現在の仕様を説明します。",
+        packet,
+    )
+    assert "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE" not in codes(result)
+
+
+def test_hardened_requires_bound_risk_refs_at_root():
+    data = high_risk_brief()
+    data.pop("risk_evidence_refs")
+    with pytest.raises(XArticleEngineError, match="risk_evidence_refs requires"):
+        root_build(data, trusted_source_refs=sources())
+
+
+def test_hardened_and_r8_agree_on_key_attack_statuses():
+    data = brief()
+    attack_packet = attack.build_generation_packet(data, trusted_source_refs=sources())
+    hard_packet = hardened.build_generation_packet(data, trusted_source_refs=sources())
+    drafts = [
+        "BridgePatch（ブリッジパッチ）は完全無料で使えます。",
+        "BridgePatch（ブリッジパッチ）の作業が30分で終わるとは言いません。",
+        "BridgePatch（ブリッジパッチ）の話です。BAN回避のためにゼロ幅文字を挿入して配信します。",
+        "BridgePatch（ブリッジパッチ）の話です。多くの人は仕事の本質を理解していません。",
+    ]
+    for draft in drafts:
+        attack_result = attack.audit_draft(draft, attack_packet)
+        hard_result = hardened.audit_draft(draft, hard_packet)
+        assert attack_result["status"] == hard_result["status"]
+        assert codes(attack_result) == codes(hard_result)

--- a/tests/test_x_article_engine_v09_promise_polarity.py
+++ b/tests/test_x_article_engine_v09_promise_polarity.py
@@ -1,0 +1,83 @@
+from x_article_engine import audit_draft, build_generation_packet
+
+
+def sources():
+    return [{"id": "terms", "status": "VERIFIED", "kind": "PUBLIC_PAGE"}]
+
+
+def packet(claim):
+    brief = {
+        "offer": "テスト用のサービス。",
+        "target": "一般読者。",
+        "pain": "条件を誤解したくない。",
+        "primary_info": [],
+        "article_type": "HOW_TO",
+        "topic_mode": "BUSINESS",
+        "cta": "条件を確認する。",
+        "evidence": [
+            {
+                "claim": claim,
+                "source_ref": "terms",
+                "status": "VERIFIED",
+                "kind": "COMMERCIAL",
+            }
+        ],
+    }
+    return build_generation_packet(brief, trusted_source_refs=sources())
+
+
+def codes(result):
+    return {item["code"] for item in result["findings"]}
+
+
+def test_negative_refund_evidence_does_not_authorize_positive_refund_promise():
+    result = audit_draft("合わなければ全額返金します。", packet("返金は行いません。"))
+    assert result["status"] == "BLOCKED"
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" in codes(result) or "UNBOUND_STRONG_CLAIM" in codes(result)
+
+
+def test_possible_extra_fee_evidence_does_not_authorize_no_extra_fee_promise():
+    result = audit_draft(
+        "開始後の追加料金はありません。",
+        packet("内容によっては追加料金が発生する場合があります。"),
+    )
+    assert result["status"] == "BLOCKED"
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" in codes(result) or "UNBOUND_STRONG_CLAIM" in codes(result)
+
+
+def test_no_guarantee_evidence_does_not_authorize_guarantee():
+    result = audit_draft("成果を保証します。", packet("成果は保証しません。"))
+    assert result["status"] == "BLOCKED"
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" in codes(result) or "UNBOUND_STRONG_CLAIM" in codes(result)
+
+
+def test_limited_evidence_does_not_authorize_unlimited_promise():
+    result = audit_draft("利用回数は無制限です。", packet("利用回数には上限があります。"))
+    assert result["status"] == "BLOCKED"
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" in codes(result) or "UNBOUND_STRONG_CLAIM" in codes(result)
+
+
+def test_negative_refund_term_can_be_stated_as_negative():
+    result = audit_draft("返金は行いません。", packet("返金は行いません。"))
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" not in codes(result)
+
+
+def test_possible_extra_fee_term_can_be_stated_without_strengthening():
+    result = audit_draft(
+        "内容によっては追加料金が発生する場合があります。",
+        packet("内容によっては追加料金が発生する場合があります。"),
+    )
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" not in codes(result)
+
+
+def test_no_guarantee_term_can_be_stated_as_no_guarantee():
+    result = audit_draft("成果は保証しません。", packet("成果は保証しません。"))
+    assert "CONTRADICTS_VERIFIED_COMMERCIAL_TERM" not in codes(result)
+
+
+def test_unrelated_verified_word_does_not_silence_strong_promise_gate():
+    result = audit_draft(
+        "永続的に利用できます。",
+        packet("このページは永続的な提供を保証するものではありません。"),
+    )
+    assert result["status"] == "BLOCKED"

--- a/x_article_engine/V09_METEOR_REPORT.md
+++ b/x_article_engine/V09_METEOR_REPORT.md
@@ -1,0 +1,327 @@
+# X Article Engine v0.9 — METEOR Report
+
+Status: **CANDIDATE / NOT YET PROMOTED TO MAIN**
+
+Publication boundary: **`/human` required / `USER_ONLY`**
+
+## Purpose
+
+This round intentionally fed the X Article Engine a mixed corpus containing:
+
+- strong beginner-guide patterns;
+- long-form sales-article patterns;
+- first-person pain/origin patterns;
+- multi-depth reader patterns;
+- market-gap / timing patterns;
+- comparison articles that later became stale;
+- high-risk tutorial patterns;
+- examples containing dangerous security shortcuts, hard-coded credentials, platform-evasion language, absolute guarantees, and oversized promotional blocks.
+
+The goal was not to imitate the reference author. The goal was to make the engine survive contradictions in the corpus without importing reference-specific claims as truth.
+
+## Source boundary
+
+The supplied reference articles are treated as **writing / onboarding / positioning examples only**.
+
+The engine does not import as timeless truth:
+
+- impression, follower, list, or revenue results;
+- claimed causal explanations for those results;
+- product prices, model names, plan availability, UI paths, benchmarks, commands, limits, or platform behavior;
+- CVE numbers, security incident counts, or safety claims;
+- fixed completion times or success rates;
+- claims that a particular number of examples, article length, CTA position, or reader-layer model universally causes performance.
+
+Those facts require their own evidence when used in a real article.
+
+---
+
+## Round 1 — attack the gaps left by v0.8
+
+The first attack found that existing evidence protection was strongest against invented numbers/results, but weaker against article-structure failures.
+
+Added attacks for:
+
+- current/latest language without dated evidence;
+- permission/security bypass instructions;
+- telling a reader to paste secrets into an AI/model chat;
+- automation that removes necessary human checkpoints;
+- multiple competing reader actions / CTAs;
+- warning fatigue;
+- `自己責任` used without mitigation;
+- unbound `完全無料` / permanent-free style claims;
+- superlative/totalizing language;
+- procedures without success signals;
+- procedures without recovery;
+- procedures without WHY;
+- high-risk tutorials that begin operational steps before a stop/risk gate.
+
+Result: the engine became harder to trick with a polished-looking unsafe tutorial.
+
+---
+
+## Round 2 — counter-DA attacked the defenses
+
+Round 1 overreacted in several places.
+
+### Finding A: `as_of` is not evidence
+
+A writer-supplied date label cannot make a factual claim current.
+
+Rule hardened to:
+
+```text
+CURRENT / UPDATE
+-> as_of boundary
++ verified dated/TIMING evidence
+```
+
+### Finding B: dangerous text can appear inside a prohibition
+
+Bad detector:
+
+```text
+--dangerously-skip-permissions
+=> always block
+```
+
+Counterexample:
+
+```text
+--dangerously-skip-permissions は使わないでください。
+```
+
+The latest gate distinguishes recommendation from warning/prohibition.
+
+### Finding C: `必ず` / `絶対` are not one semantic class
+
+The old commercial-strengthening gate was lexical.
+
+That can wrongly punish:
+
+```text
+APIキーは絶対に共有しないでください。
+権限は必ず確認してください。
+```
+
+The latest candidate separates:
+
+1. unbound outcome guarantee -> BLOCK;
+2. broad absolute prediction/generalization -> REVIEW;
+3. genuine safety imperative -> allow strong wording.
+
+### Finding D: secret destination matters
+
+A secret entered into a dedicated settings screen is not automatically the same as pasting a secret into a model prompt/chat.
+
+The detector now looks for:
+
+```text
+secret/credential
++ transfer action
++ model/chat destination
+```
+
+### Finding E: CTA detection must detect actions, not vocabulary
+
+Narrative phrases such as `登録前` or `フォロワー数` are not CTAs.
+
+The refined gate looks for requests to buy/apply/join/register/add-friend/follow/reply/DM/consult/fit-check/request material.
+
+---
+
+## Round 3 — attack strong language, risk evidence, and security doctrine
+
+### Finding F: scary tone is not risk evidence
+
+A HIGH-risk article can no longer become HIGH merely because the draft sounds dangerous.
+
+Latest rule:
+
+```text
+HIGH risk
+-> verified RISK / SAFETY / POLICY evidence required
+-> then front-loaded stop/risk gate
+-> then bounded procedure
+```
+
+### Finding G: hard-coded reusable credentials are an article risk
+
+A public tutorial should not normalize a predictable reusable secret/API key as the default credential.
+
+Operational hard-coded secret literals are blocked; clearly marked dummy/placeholder/prohibition examples are not treated as real defaults.
+
+### Finding H: platform-evasion material must not become growth doctrine
+
+Reference material contained ideas framed around BAN/detection avoidance.
+
+The engine does not learn those as normal marketing optimization.
+
+Round 3 marked such language for review.
+
+---
+
+## Round 4 — attack over-learning from successful reference patterns
+
+### Finding I: ORIGIN is not automatically PAIN
+
+Earlier core logic allowed `ORIGIN` to activate `LIVED_PAIN`.
+
+That creates a hallucination path:
+
+```text
+human: "this is why I started"
+model: "therefore this must have been painful"
+```
+
+Latest-root rule:
+
+```text
+LIVED_PAIN requires attested PAIN or FAILURE.
+ORIGIN alone stays origin.
+```
+
+If no PAIN/FAILURE exists and the user did not explicitly request LIVED_PAIN, the latest layer falls back to RELATABLE instead of manufacturing drama.
+
+### Finding J: contrarianism requires an explicit basis
+
+A CONTRARIAN opening now requires `counterpoint_basis` bound to either:
+
+- verified evidence; or
+- human-attested BELIEF / OPINION.
+
+The reference corpus cannot make reverse-taking a default growth trick.
+
+### Finding K: operational platform evasion is stronger than mere discussion
+
+Latest split:
+
+- discussion/rejection of platform-evasion claims -> REVIEW;
+- operational instruction teaching evasion/detection avoidance -> BLOCK.
+
+---
+
+## Test architecture finding — the suite itself was stale
+
+A major METEOR finding was outside article logic.
+
+Historical tests imported:
+
+```python
+from x_article_engine import build_generation_packet
+```
+
+while simultaneously asserting historical schema versions:
+
+```text
+v0.4 test expects root == 0.4
+v0.5 test expects root == 0.5
+v0.7 test expects root == 0.7
+v0.8 test expects root == 0.8
+```
+
+Those expectations cannot all be true once the root export points to the latest engine.
+
+Fix:
+
+- historical regression tests now import their historical module directly;
+- only `test_x_article_engine_latest_root.py` owns the contract for the current root export;
+- base/core invariants are pinned to `x_article_engine.core`.
+
+This prevents a new engine layer from silently rewriting the meaning of old regression tests.
+
+---
+
+## CI finding — tests that are not executed are not a gate
+
+v0.3 through v0.8 accumulated tests without a confirmed run in the available environment.
+
+A dedicated workflow has now been added:
+
+`.github/workflows/x-article-engine-meteor.yml`
+
+It runs:
+
+```text
+python -m pytest -q tests/test_x_article_engine*.py
+```
+
+on X Article Engine pull requests and on relevant changes pushed to main.
+
+**No passing result is claimed in this report yet.**
+
+Historical confirmed result remains only the earlier v0.2 local run: **25 passed**.
+
+The v0.9 PR/CI run is the next adversary.
+
+---
+
+## Current knowledge conflict rules
+
+The candidate now uses these precedence rules:
+
+1. Specificity never overrides evidence binding.
+2. Beginner simplicity never hides a material trade-off or risk.
+3. One-path guidance starts after the decision that actually matters.
+4. Long-form depth never justifies padding.
+5. Strong voice never authorizes fabricated certainty, biography, or guarantees.
+6. A useful CTA moment never authorizes fake scarcity, fear, or multiple competing actions.
+7. `as_of` never turns an unverified claim into current truth.
+8. Safety-critical information outranks CTA optimization.
+9. Human authorization outranks automation convenience.
+10. A neutral origin must not be converted into pain.
+11. Contrarianism needs evidence or an attested human position.
+12. High-risk warning tone needs verified risk evidence.
+13. Strong safety language must not be flattened merely because it contains `必ず` / `絶対`.
+14. Platform-evasion operations are not normal article-growth tactics.
+
+---
+
+## Residual risks still intentionally left to `/human`
+
+Deterministic heuristics cannot reliably decide every semantic question.
+
+Residual human checks remain necessary for:
+
+- whether a non-numeric factual paraphrase is truly supported by the cited evidence;
+- whether a comparison baseline is actually fair, not merely technically sourced;
+- whether an article became over-explained while satisfying terminology rules;
+- whether multi-depth writing became forced or overstuffed;
+- whether CTA placement is genuinely useful rather than subtly manipulative;
+- whether a first-person sentence preserves the writer's actual meaning and tone;
+- whether an opinion is being visually laundered as a fact;
+- whether a safety warning is proportionate to the verified risk;
+- whether an article-specific platform policy or law changed after the evidence date.
+
+Publication therefore remains:
+
+```text
+generated draft
+-> evidence / METEOR audit
+-> /human
+-> USER_ONLY external publication
+```
+
+---
+
+## Structural debt discovered by METEOR
+
+The attack implementation currently preserves R1 -> R4 as stacked modules so that each round can be inspected and regression-tested independently.
+
+That is useful during the attack phase but **not the desired final architecture**.
+
+Before main promotion, the intended cleanup is:
+
+1. get the dedicated CI suite running;
+2. use actual failures as the next METEOR input;
+3. stabilize behavior;
+4. consolidate R1-R4 into one v0.9 production layer;
+5. keep the adversarial tests, not the unnecessary wrapper depth.
+
+In other words: do not let the article engine itself become the kind of SimCity-like support sprawl it is meant to reason about.
+
+## Current verdict
+
+**METEOR still active.**
+
+The candidate is materially harder to fool than v0.8, but it is not yet declared stable or merged to main.

--- a/x_article_engine/V09_METEOR_REPORT.md
+++ b/x_article_engine/V09_METEOR_REPORT.md
@@ -1,242 +1,136 @@
 # X Article Engine v0.9 — METEOR Report
 
-Status: **CANDIDATE / NOT YET PROMOTED TO MAIN**
+Status: **CANDIDATE / METEOR ACTIVE / NOT YET MERGED TO MAIN**
 
 Publication boundary: **`/human` required / `USER_ONLY`**
 
 ## Purpose
 
-This round intentionally fed the X Article Engine a mixed corpus containing:
+The v0.9 attack deliberately mixed useful article-writing knowledge with contradictory, stale, overconfident, commercially aggressive, and sometimes unsafe reference patterns.
 
-- strong beginner-guide patterns;
-- long-form sales-article patterns;
-- first-person pain/origin patterns;
-- multi-depth reader patterns;
-- market-gap / timing patterns;
-- comparison articles that later became stale;
-- high-risk tutorial patterns;
-- examples containing dangerous security shortcuts, hard-coded credentials, platform-evasion language, absolute guarantees, and oversized promotional blocks.
+The objective is not to imitate the reference author. It is to keep the reusable writing/onboarding lessons while making the engine reject or review the parts that would create fabrication, stale instructions, unsafe automation, fake certainty, manipulative CTA behavior, or AI-sounding filler.
 
-The goal was not to imitate the reference author. The goal was to make the engine survive contradictions in the corpus without importing reference-specific claims as truth.
-
-## Source boundary
-
-The supplied reference articles are treated as **writing / onboarding / positioning examples only**.
-
-The engine does not import as timeless truth:
-
-- impression, follower, list, or revenue results;
-- claimed causal explanations for those results;
-- product prices, model names, plan availability, UI paths, benchmarks, commands, limits, or platform behavior;
-- CVE numbers, security incident counts, or safety claims;
-- fixed completion times or success rates;
-- claims that a particular number of examples, article length, CTA position, or reader-layer model universally causes performance.
-
-Those facts require their own evidence when used in a real article.
+Reference-specific metrics, sales results, product facts, commands, prices, model names, UI paths, security claims, incident counts, benchmarks, completion times, and causal explanations are **not** imported as engine truth.
 
 ---
 
-## Round 1 — attack the gaps left by v0.8
+## Knowledge synthesized before METEOR
 
-The first attack found that existing evidence protection was strongest against invented numbers/results, but weaker against article-structure failures.
+The batch contributed these reusable ideas:
+
+- beginner friction before instruction;
+- explain unfamiliar terms at first use;
+- compare only what is needed before a decision, then collapse to one main path;
+- `GOAL -> ACTION -> EXPECTED SIGNAL -> RECOVERY -> WHY` for operational guides;
+- show scope/exclusions before steps they invalidate;
+- move from setup to one real first win;
+- place a useful resource at the next predictable wall rather than as an unrelated commercial break;
+- distinguish reading/reach from qualified commercial progress;
+- deepen one article from understanding -> application -> judgment without forcing jargon;
+- freshness/supersession/migration for articles whose product facts decay;
+- risk-first / stop-gate behavior for genuinely high-risk procedures;
+- let attested pain shape the promise without converting it into a guarantee;
+- product/CTA should emerge from the mechanism taught in the article.
+
+---
+
+## Round 1 — article-structure failures
 
 Added attacks for:
 
-- current/latest language without dated evidence;
+- latest/current language without dated evidence;
 - permission/security bypass instructions;
-- telling a reader to paste secrets into an AI/model chat;
-- automation that removes necessary human checkpoints;
-- multiple competing reader actions / CTAs;
+- secrets pasted into an AI/model chat;
+- automation that erases required human checkpoints;
+- multiple competing commercial actions;
 - warning fatigue;
-- `自己責任` used without mitigation;
+- `自己責任` without mitigation;
 - unbound `完全無料` / permanent-free style claims;
 - superlative/totalizing language;
-- procedures without success signals;
-- procedures without recovery;
-- procedures without WHY;
-- high-risk tutorials that begin operational steps before a stop/risk gate.
+- procedures missing observable success, recovery, or WHY;
+- high-risk procedures starting before a risk/stop gate.
 
-Result: the engine became harder to trick with a polished-looking unsafe tutorial.
+## Round 2 — attack the defenses themselves
+
+Counter-DA found false-positive paths:
+
+- `as_of` is only a date label, not evidence of current truth;
+- a dangerous command may appear inside a prohibition;
+- entering a credential into a dedicated product settings screen is not automatically the same as pasting it into model chat;
+- ordinary mentions of registration/followers are not CTAs;
+- `必ず` / `絶対` cannot be treated as one lexical class.
+
+The candidate now separates:
+
+```text
+unbound outcome guarantee -> BLOCK
+broad absolute prediction -> REVIEW
+genuine safety imperative -> allowed to stay strong
+```
+
+## Round 3 — risk evidence and security doctrine
+
+Findings:
+
+- scary tone is not risk evidence;
+- HIGH-risk mode requires verified `RISK` / `SAFETY` / `POLICY` evidence;
+- reusable hard-coded secret defaults are blocked;
+- platform-evasion language must not become default growth doctrine;
+- universal capability promises are review material.
+
+## Round 4 — over-learning successful openings
+
+Findings:
+
+- `ORIGIN` is not automatically `PAIN`;
+- latest LIVED_PAIN requires human-attested `PAIN` or `FAILURE`;
+- origin-only material falls back instead of manufacturing drama;
+- CONTRARIAN requires an explicit basis bound to verified evidence or human-attested BELIEF/OPINION;
+- operational platform-evasion instructions are blocked while discussion/rejection remains reviewable.
+
+## Round 5 — Japanese false positives
+
+CI exposed two semantic gaps:
+
+1. `多くの人は仕事の本質を理解していません` escaped the abstract-language detector because the older concrete-signal regex treated the bare character `人` as concrete material.
+2. `推奨しません` was not recognized as the polite negative form of `推奨しない`, causing a rejected evasion tactic to look like an operational instruction.
+
+R5 fixes both while preserving the real operational-evasion block.
+
+## Round 6 — negated claims
+
+The next attack targeted claims that appear only in order to be denied or criticized:
+
+- `必ず成功するとは限りません`
+- `完全無料ではありません`
+- `保証します、とは書けません`
+- `30分で終わるとは言いません`
+- `これは最新版ではありません`
+
+A lexical gate must not convert those sentences back into the exact guarantee/currentness claim they are rejecting.
+
+R6 is currently an **attack/validation layer** over the flat v0.9 candidate. Its tests pass, but its negated-claim logic has not yet been absorbed into the flat production module. Therefore v0.9 is still not declared finished.
 
 ---
 
-## Round 2 — counter-DA attacked the defenses
+## Test architecture finding
 
-Round 1 overreacted in several places.
+Historical tests previously imported the package root while asserting historical schema versions. That becomes contradictory as the root advances.
 
-### Finding A: `as_of` is not evidence
-
-A writer-supplied date label cannot make a factual claim current.
-
-Rule hardened to:
+Fixed model:
 
 ```text
-CURRENT / UPDATE
--> as_of boundary
-+ verified dated/TIMING evidence
+historical regression -> import its historical module directly
+latest-root contract  -> import x_article_engine package root
 ```
 
-### Finding B: dangerous text can appear inside a prohibition
-
-Bad detector:
-
-```text
---dangerously-skip-permissions
-=> always block
-```
-
-Counterexample:
-
-```text
---dangerously-skip-permissions は使わないでください。
-```
-
-The latest gate distinguishes recommendation from warning/prohibition.
-
-### Finding C: `必ず` / `絶対` are not one semantic class
-
-The old commercial-strengthening gate was lexical.
-
-That can wrongly punish:
-
-```text
-APIキーは絶対に共有しないでください。
-権限は必ず確認してください。
-```
-
-The latest candidate separates:
-
-1. unbound outcome guarantee -> BLOCK;
-2. broad absolute prediction/generalization -> REVIEW;
-3. genuine safety imperative -> allow strong wording.
-
-### Finding D: secret destination matters
-
-A secret entered into a dedicated settings screen is not automatically the same as pasting a secret into a model prompt/chat.
-
-The detector now looks for:
-
-```text
-secret/credential
-+ transfer action
-+ model/chat destination
-```
-
-### Finding E: CTA detection must detect actions, not vocabulary
-
-Narrative phrases such as `登録前` or `フォロワー数` are not CTAs.
-
-The refined gate looks for requests to buy/apply/join/register/add-friend/follow/reply/DM/consult/fit-check/request material.
+This prevents a new layer from silently changing what an old regression test means.
 
 ---
 
-## Round 3 — attack strong language, risk evidence, and security doctrine
+## Dedicated CI
 
-### Finding F: scary tone is not risk evidence
-
-A HIGH-risk article can no longer become HIGH merely because the draft sounds dangerous.
-
-Latest rule:
-
-```text
-HIGH risk
--> verified RISK / SAFETY / POLICY evidence required
--> then front-loaded stop/risk gate
--> then bounded procedure
-```
-
-### Finding G: hard-coded reusable credentials are an article risk
-
-A public tutorial should not normalize a predictable reusable secret/API key as the default credential.
-
-Operational hard-coded secret literals are blocked; clearly marked dummy/placeholder/prohibition examples are not treated as real defaults.
-
-### Finding H: platform-evasion material must not become growth doctrine
-
-Reference material contained ideas framed around BAN/detection avoidance.
-
-The engine does not learn those as normal marketing optimization.
-
-Round 3 marked such language for review.
-
----
-
-## Round 4 — attack over-learning from successful reference patterns
-
-### Finding I: ORIGIN is not automatically PAIN
-
-Earlier core logic allowed `ORIGIN` to activate `LIVED_PAIN`.
-
-That creates a hallucination path:
-
-```text
-human: "this is why I started"
-model: "therefore this must have been painful"
-```
-
-Latest-root rule:
-
-```text
-LIVED_PAIN requires attested PAIN or FAILURE.
-ORIGIN alone stays origin.
-```
-
-If no PAIN/FAILURE exists and the user did not explicitly request LIVED_PAIN, the latest layer falls back to RELATABLE instead of manufacturing drama.
-
-### Finding J: contrarianism requires an explicit basis
-
-A CONTRARIAN opening now requires `counterpoint_basis` bound to either:
-
-- verified evidence; or
-- human-attested BELIEF / OPINION.
-
-The reference corpus cannot make reverse-taking a default growth trick.
-
-### Finding K: operational platform evasion is stronger than mere discussion
-
-Latest split:
-
-- discussion/rejection of platform-evasion claims -> REVIEW;
-- operational instruction teaching evasion/detection avoidance -> BLOCK.
-
----
-
-## Test architecture finding — the suite itself was stale
-
-A major METEOR finding was outside article logic.
-
-Historical tests imported:
-
-```python
-from x_article_engine import build_generation_packet
-```
-
-while simultaneously asserting historical schema versions:
-
-```text
-v0.4 test expects root == 0.4
-v0.5 test expects root == 0.5
-v0.7 test expects root == 0.7
-v0.8 test expects root == 0.8
-```
-
-Those expectations cannot all be true once the root export points to the latest engine.
-
-Fix:
-
-- historical regression tests now import their historical module directly;
-- only `test_x_article_engine_latest_root.py` owns the contract for the current root export;
-- base/core invariants are pinned to `x_article_engine.core`.
-
-This prevents a new engine layer from silently rewriting the meaning of old regression tests.
-
----
-
-## CI finding — tests that are not executed are not a gate
-
-v0.3 through v0.8 accumulated tests without a confirmed run in the available environment.
-
-A dedicated workflow has now been added:
+Workflow:
 
 `.github/workflows/x-article-engine-meteor.yml`
 
@@ -246,82 +140,93 @@ It runs:
 python -m pytest -q tests/test_x_article_engine*.py
 ```
 
-on X Article Engine pull requests and on relevant changes pushed to main.
+and cancels stale runs when a newer PR commit arrives.
 
-**No passing result is claimed in this report yet.**
+### CI history that mattered
 
-Historical confirmed result remains only the earlier v0.2 local run: **25 passed**.
+1. First workflow attempt failed before tests because pip caching was enabled without a dependency file. The cache assumption was removed.
+2. First full pytest execution: **126 passed / 4 failed**. Those four failures exposed one stale test expectation, one test-overreach issue, one language mismatch in a historical human-check assertion, and one real polite-negation bug.
+3. After fixes and R5: **136 passed**.
+4. After flattening R1-R5 into a direct `x_article_engine/v09.py` production candidate and adding equivalence attacks: **149 passed**.
+5. After adding R6 negated-claim attacks: **165 passed**.
 
-The v0.9 PR/CI run is the next adversary.
+The 165-pass run validates the repository including the R6 attack layer. The package root still points to flat `v09.py`, so the production candidate itself remains the 149-pass flat path until R6 is absorbed and re-run through the root.
 
 ---
 
-## Current knowledge conflict rules
+## Consolidation / anti-SimCity finding
 
-The candidate now uses these precedence rules:
+METEOR created R1 -> R5 as stacked modules while discovering failures. That was useful as an attack history but bad as a permanent runtime architecture.
+
+A flat production candidate now exists:
+
+`x_article_engine/v09.py`
+
+The package root points directly to it. R1-R5 remain as adversarial history/regression references rather than the normal runtime path.
+
+A dedicated consolidation suite compares important flat-v0.9 outcomes against the stacked R5 candidate for:
+
+- permission bypass;
+- secret-to-model transfer;
+- absolute free claims;
+- guarantees;
+- generic abstract language;
+- evasion discussion vs operational evasion;
+- safe BridgePatch narrative;
+- origin-only opening fallback;
+- contrarian basis;
+- currentness evidence;
+- high-risk evidence.
+
+That flat candidate passed the full suite before R6 was added.
+
+---
+
+## Current precedence rules
 
 1. Specificity never overrides evidence binding.
 2. Beginner simplicity never hides a material trade-off or risk.
-3. One-path guidance starts after the decision that actually matters.
+3. One-path guidance begins after the decision that actually matters.
 4. Long-form depth never justifies padding.
 5. Strong voice never authorizes fabricated certainty, biography, or guarantees.
-6. A useful CTA moment never authorizes fake scarcity, fear, or multiple competing actions.
+6. Useful CTA timing never authorizes fake scarcity, fear, or competing commercial actions.
 7. `as_of` never turns an unverified claim into current truth.
 8. Safety-critical information outranks CTA optimization.
 9. Human authorization outranks automation convenience.
-10. A neutral origin must not be converted into pain.
-11. Contrarianism needs evidence or an attested human position.
-12. High-risk warning tone needs verified risk evidence.
-13. Strong safety language must not be flattened merely because it contains `必ず` / `絶対`.
-14. Platform-evasion operations are not normal article-growth tactics.
+10. Neutral origin must not be converted into pain.
+11. Contrarianism needs an explicit evidence/human basis.
+12. HIGH-risk warning tone needs verified risk evidence.
+13. Necessary safety language must not be flattened merely because it contains `必ず` / `絶対`.
+14. Operational platform-evasion instructions are not article-growth doctrine.
+15. A claim being explicitly denied must not be audited as though it were being asserted.
 
 ---
 
-## Residual risks still intentionally left to `/human`
+## Residual semantic risk intentionally left to `/human`
 
-Deterministic heuristics cannot reliably decide every semantic question.
+Deterministic gates still cannot reliably decide every semantic question, including:
 
-Residual human checks remain necessary for:
-
-- whether a non-numeric factual paraphrase is truly supported by the cited evidence;
-- whether a comparison baseline is actually fair, not merely technically sourced;
-- whether an article became over-explained while satisfying terminology rules;
+- whether a non-numeric paraphrase truly matches its evidence;
+- whether a sourced comparison baseline is fair;
+- whether terminology explanations became patronizing or overlong;
 - whether multi-depth writing became forced or overstuffed;
-- whether CTA placement is genuinely useful rather than subtly manipulative;
-- whether a first-person sentence preserves the writer's actual meaning and tone;
-- whether an opinion is being visually laundered as a fact;
-- whether a safety warning is proportionate to the verified risk;
-- whether an article-specific platform policy or law changed after the evidence date.
+- whether a CTA is genuinely useful rather than subtly manipulative;
+- whether first-person language preserves the writer's actual meaning and rhythm;
+- whether opinion is visually laundering itself as fact;
+- whether a warning is proportionate to the verified risk;
+- whether a platform policy, law, product UI, price, or capability changed after the evidence date.
 
-Publication therefore remains:
+Publication remains:
 
 ```text
 generated draft
--> evidence / METEOR audit
+-> Evidence / METEOR audit
 -> /human
 -> USER_ONLY external publication
 ```
 
----
-
-## Structural debt discovered by METEOR
-
-The attack implementation currently preserves R1 -> R4 as stacked modules so that each round can be inspected and regression-tested independently.
-
-That is useful during the attack phase but **not the desired final architecture**.
-
-Before main promotion, the intended cleanup is:
-
-1. get the dedicated CI suite running;
-2. use actual failures as the next METEOR input;
-3. stabilize behavior;
-4. consolidate R1-R4 into one v0.9 production layer;
-5. keep the adversarial tests, not the unnecessary wrapper depth.
-
-In other words: do not let the article engine itself become the kind of SimCity-like support sprawl it is meant to reason about.
-
 ## Current verdict
 
-**METEOR still active.**
+**METEOR is still active.**
 
-The candidate is materially harder to fool than v0.8, but it is not yet declared stable or merged to main.
+The flat v0.9 production path is materially simpler than the attack stack and passed the pre-R6 full regression suite. R6 exposed the next semantic edge: explicit negation. That fix is validated in the attack layer and is the next item to absorb into flat v0.9 before any main merge.

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .depth_market import audit_draft, build_generation_packet
+from .meteor_v09_gate import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .meteor_v09_gate import audit_draft, build_generation_packet
+from .meteor_v09_r4 import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .meteor_v09_r4 import audit_draft, build_generation_packet
+from .meteor_v09_r5 import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .v09 import audit_draft, build_generation_packet
+from .v09_hardened import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .v09_hardened import audit_draft, build_generation_packet
+from .meteor_v09_r9 import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/__init__.py
+++ b/x_article_engine/__init__.py
@@ -1,5 +1,5 @@
 from .core import XArticleEngineError, normalize_brief
-from .meteor_v09_r5 import audit_draft, build_generation_packet
+from .v09 import audit_draft, build_generation_packet
 
 __all__ = [
     "XArticleEngineError",

--- a/x_article_engine/knowledge_batch_v09/FRESHNESS_SUPERSESSION_MIGRATION_ANALYSIS.md
+++ b/x_article_engine/knowledge_batch_v09/FRESHNESS_SUPERSESSION_MIGRATION_ANALYSIS.md
@@ -1,0 +1,358 @@
+# v0.9 Knowledge Intake — Freshness / Supersession / Migration Article
+
+## Source boundary
+
+This analysis is extracted from a user-supplied public X article about a newer way to use Claude/Claude Code from a phone and desktop app.
+
+We are learning **article-writing doctrine for fast-changing products, superseding old guidance, migration, and update communication**, not importing the source article's product facts, feature names, release dates, prices, compatibility claims, performance estimates, availability claims, implementation steps, prompts, or commercial claims as engine truth.
+
+Any claim about Claude, Claude Code, Claude Desktop, Dispatch, Computer Use, connectors, supported platforms, plan requirements, timing, pricing, success rates, or feature parity must separately pass the normal evidence boundary and freshness check before publication.
+
+## Why this source matters
+
+Earlier reference guides taught how to take a reader from confusion to first success. This source adds a different problem:
+
+> The old successful guide can become wrong or inefficient because the product changed.
+
+That creates a new article class:
+
+```text
+OLD REALITY
+-> WHAT CHANGED
+-> WHAT OLD STEP IS NOW UNNECESSARY / DIFFERENT
+-> WHO SHOULD MIGRATE
+-> NEW SHORTEST SAFE PATH
+-> FIRST SUCCESS ON THE NEW PATH
+```
+
+The article is useful as an archetype for **supersession**, not just tutorial writing.
+
+## 1. Explicitly tell the reader when old guidance is stale
+
+A strong update article does not pretend that a previous guide is still current if the underlying workflow changed materially.
+
+Useful doctrine:
+
+```text
+previous guide / previous reality
+-> explicit stale-or-changed notice
+-> date/scope of the new reality
+-> what changed for the reader
+```
+
+Do not say "the old article is obsolete" unless the claim is evidence-bound. Sometimes only one section changed.
+
+Prefer precise labels such as:
+
+- superseded for this path;
+- still valid for advanced users;
+- no longer the shortest beginner route;
+- valid only for version/environment X.
+
+## 2. Use before/after comparison to explain change
+
+The article compares an older workflow against a newer one.
+
+Generalizable structure:
+
+```text
+BEFORE
+- required action A
+- constraint B
+- target use C
+
+NOW
+- action A may be removed/replaced
+- new capability D
+- new constraint E
+```
+
+This is stronger than saying "the product evolved a lot" because the reader can see exactly what changed for them.
+
+All comparison claims must be date- and scope-bound.
+
+## 3. Separate "new capability" from "new recommended path"
+
+A product gaining a feature does not automatically mean every reader should use it.
+
+The engine should distinguish:
+
+```text
+feature exists
+!=
+feature is recommended for this reader
+!=
+feature replaces the old path for every user
+```
+
+A beginner guide may choose the new easier route while still preserving the advanced route as a valid option when materially relevant.
+
+## 4. Migration articles need a legacy-reader branch
+
+The source explicitly addresses people who followed the older terminal guide.
+
+Useful doctrine:
+
+```text
+new reader
+-> use current default path
+
+existing reader on old path
+-> say whether they must migrate
+-> say whether coexistence is safe/possible
+-> say what they gain/lose by moving
+```
+
+Do not make existing readers redo working setup without a reason.
+
+## 5. Fresh technical content needs claim expiry awareness
+
+Some claims decay faster than others.
+
+Examples of fast-decay claim classes:
+
+- supported operating systems;
+- plan eligibility;
+- UI labels and menu locations;
+- installation commands;
+- connector availability;
+- model or feature release status;
+- pricing;
+- experimental/beta status;
+- success-rate estimates;
+- security restrictions.
+
+For these classes, the engine should treat "verified once" as insufficient for indefinite reuse.
+
+Doctrine:
+
+```text
+claim has high change probability
+-> preserve verification date
+-> re-check before reuse in a fresh article
+-> avoid copying a stale operational instruction from old knowledge
+```
+
+## 6. A current guide should reduce obsolete cognitive load
+
+If a newer route removes a prerequisite, do not force the reader through the old prerequisite just because it appeared in a successful earlier guide.
+
+Example doctrine:
+
+```text
+old path required A -> B -> C
+new safe path requires B -> C
+=> remove A from the beginner path
+```
+
+The engine should optimize for the current reader's shortest valid route, not historical completeness.
+
+## 7. Use the new route to create an early proof-of-success moment
+
+Like the earlier beginner guide, the source moves quickly from setup to one tiny remote task.
+
+Useful pattern:
+
+```text
+setup
+-> send one bounded instruction
+-> observe visible result
+-> confirm success
+-> only then show broader possibilities
+```
+
+This prevents the article from becoming a long feature catalogue before the reader experiences value.
+
+## 8. Feature catalogue should follow a concrete mental model
+
+The article first gives a simple overall flow:
+
+```text
+phone instruction
+-> PC action
+-> result visible to reader
+```
+
+Then it explains individual features and connectors.
+
+Doctrine:
+
+> Give the reader one simple system picture before listing capabilities.
+
+Without a mental model, feature lists become memorization.
+
+## 9. "What changed" can be a stronger hook than "what is it"
+
+For a product the audience has already heard about, the information gap may be the delta rather than the definition.
+
+Possible opening modes for update articles:
+
+```text
+OLD_GUIDE_IS_STALE
+WHAT_CHANGED_SINCE_LAST_TIME
+YOU_NO_LONGER_NEED_X
+THE_TOOL_NOW_DOES_Y
+```
+
+But unfamiliar readers still need the ordinary-language definition shortly afterward.
+
+## 10. Constraints belong after capability proof, but before risky reliance
+
+The source demonstrates a useful sequencing tension:
+
+- show enough capability that the reader understands why the tool matters;
+- then state current limitations before the reader relies on the tool for consequential work.
+
+The engine should not bury constraints after the CTA.
+
+For material limitations, prefer:
+
+```text
+capability
+-> concrete example
+-> current limitation / condition
+-> safe use boundary
+```
+
+## 11. User-estimated performance numbers are not universal facts
+
+The source includes an experiential success-rate estimate.
+
+Doctrine:
+
+- if the writer supplies a first-person estimate, keep it explicitly first-person and scoped;
+- do not convert it into a platform-wide benchmark;
+- do not reuse it as timeless product knowledge;
+- prefer reproducible evidence when the claim materially affects decisions.
+
+## 12. Product evolution creates update debt
+
+A successful old article can become a liability when readers continue finding it after the workflow changes.
+
+Useful editorial doctrine:
+
+```text
+new guide published
+-> identify superseded old guide
+-> add a visible update/superseded notice where possible
+-> route readers to current guidance
+```
+
+The X Article Engine itself may not have publication-edit authority, but it should surface the need for supersession metadata/handoff.
+
+## 13. CTA continuity can break even inside a strong article
+
+The source's late transition from practical AI-tool onboarding to a very large external marketing seminar block creates a useful adversarial example.
+
+Potential problem:
+
+```text
+article problem = how to use current tool workflow
+CTA problem = broad AI monetization / marketing seminar
+```
+
+The relationship may be real, but the bridge is much wider than the article's immediate mechanism.
+
+METEOR should test:
+
+- Does the CTA feel like the next step of the same problem?
+- Is the commercial section proportionate to the editorial value?
+- Does a long bonus stack swamp the article's conclusion?
+- Does the offer require a new problem statement that should instead be a separate article?
+
+Useful rule candidate:
+
+> The bigger the conceptual jump between article problem and offer, the stronger the bridge explanation must be—or the CTA should be separated.
+
+## 14. "Free bonus volume" can reintroduce AI-smell and cognitive overload
+
+Large enumerations of bonuses, chapters, slides, prompts, and claims can overwhelm the reader even if each item is technically relevant.
+
+METEOR should attack whether a commercial block:
+
+- repeats quantity as a substitute for value;
+- creates forced lists;
+- overwhelms the single CTA;
+- introduces unverified proof claims;
+- destroys the mobile reading rhythm;
+- becomes a second article appended to the first.
+
+## 15. Strong urgency claims require independent evidence and authority
+
+The source contains deadline, no-replay, and scarcity language in the embedded promotion.
+
+These are not writing doctrine.
+
+If a generated article uses urgency, the exact deadline, availability, capacity, replay policy, or "never again" claim must be supplied and verified by the offer owner.
+
+The engine must not invent urgency to improve conversion.
+
+## 16. A current tutorial should expose its time boundary
+
+For fast-changing software, a useful article should tell the reader what date/version/environment it describes.
+
+Possible pattern:
+
+```text
+As of YYYY-MM-DD / version X / environment Y
+this guide uses path Z.
+```
+
+Do not overburden stable articles with dates when freshness is irrelevant.
+
+## 17. New v0.9 candidate: Freshness Gate
+
+Potential packet policy:
+
+```text
+for each externally verifiable operational claim:
+    classify change_risk = LOW / MEDIUM / HIGH
+    if HIGH:
+        require verified_at or source freshness
+        if stale/unknown -> REVIEW or BLOCK depending consequence
+```
+
+High-risk operational instructions with unknown freshness should fail closed.
+
+## 18. New v0.9 candidate: Supersession Metadata
+
+Possible fields:
+
+```text
+article_relation:
+  mode: NEW | UPDATE | SUPERSEDES | COMPARES
+  prior_article_ref: optional
+  still_valid_parts: []
+  superseded_parts: []
+  reader_migration_required: bool/conditional
+  freshness_date: date
+```
+
+This lets the engine write an update without falsely erasing the old path.
+
+## 19. METEOR targets from this source
+
+Attack these tensions explicitly:
+
+1. **freshness vs evidence reuse** — verified yesterday may be stale today;
+2. **simple route vs advanced flexibility** — easier default must not erase material trade-offs;
+3. **update hook vs beginner comprehension** — readers may not know the old state;
+4. **feature excitement vs current limitations** — capability claims must not outrun safety;
+5. **CTA continuity vs monetization ambition** — broad sale can hijack a narrow tutorial;
+6. **bonus abundance vs cognitive overload** — more assets can reduce clarity;
+7. **urgency vs truth** — deadlines/scarcity cannot be generated from style rules;
+8. **old successful content vs current truth** — historical performance is not authority for present instructions;
+9. **shortest path vs migration burden** — existing users should not redo setup unnecessarily;
+10. **current UI specificity vs decay** — exact menu paths need freshness awareness.
+
+## BridgePatch implication
+
+BridgePatch itself is less exposed to fast-changing UI than a software tutorial, but the doctrine still matters for articles that mention AI tools or platform behavior.
+
+For the current BridgePatch sales article:
+
+- stable first-party pain can remain timeless;
+- external software examples should be date/scope bound if they materially matter;
+- the core mechanism should not depend on a UI or product feature likely to change;
+- if a future BridgePatch workflow changes, a new article should say what changed rather than silently contradicting the old one;
+- the CTA should remain the direct continuation of the one-process boundary lesson, not expand into an unrelated general AI offer.

--- a/x_article_engine/knowledge_batch_v09/LINE_HARNESS_COMPLEX_GUIDE_ANALYSIS.md
+++ b/x_article_engine/knowledge_batch_v09/LINE_HARNESS_COMPLEX_GUIDE_ANALYSIS.md
@@ -1,0 +1,340 @@
+# v0.9 Knowledge Intake — Complex Guided Automation / Security-Conflict Archetype
+
+## Source boundary
+
+This analysis is extracted from a user-supplied public X article about a LINE automation stack.
+
+We are learning **article structure, onboarding mechanics, comparison framing, and failure-recovery design**. We are **not** importing as engine truth any product capability, pricing, free-tier limit, API behavior, security claim, ban-evasion claim, infrastructure command, credential-handling practice, success guarantee, or time estimate from the source.
+
+The source also contains operational patterns that should be treated as adversarial examples rather than copied: sharing secrets into prompts, hard-coded keys, broad permission bypass, claims about evading platform enforcement, and absolute guarantees such as permanent/free/100%.
+
+## 1. Start with category confusion, then compare by job-to-be-done
+
+A useful comparison article does not stop at a feature matrix. It answers:
+
+```text
+what are the realistic options?
+-> what job is each option best suited for?
+-> what trade-off makes that choice sensible?
+-> who should not choose it?
+```
+
+This is stronger than declaring one universal winner.
+
+For BridgePatch, the analogue is not “automation is always better.” It is:
+
+- small bounded manual task -> candidate for a small tool;
+- high-risk final judgment -> keep human control;
+- large organization-wide system -> may need a different class of solution.
+
+## 2. A comparison can reduce choice after first explaining the choice
+
+The article first distinguishes different tools by use case, then commits the tutorial to one path.
+
+Doctrine:
+
+```text
+COMPARE ENOUGH TO ORIENT
+-> CHOOSE ONE PATH FOR THIS GUIDE
+-> EXPLAIN WHY
+-> KEEP MAIN PATH LINEAR
+```
+
+This resolves the tension between “never overwhelm beginners with options” and “do not hide material alternatives.”
+
+## 3. Promise the observable end-state before the setup
+
+The source repeatedly tells readers what they should be able to observe after completion.
+
+Good form:
+
+```text
+after this guide, you should be able to observe X
+```
+
+Not good form:
+
+```text
+100% works / guaranteed / permanent / anyone can do it
+```
+
+The engine should describe a testable target state without guaranteeing success.
+
+## 4. Complex tutorials need dependency mapping
+
+A multi-system guide becomes easier when the reader can see dependencies before steps begin.
+
+Useful schema:
+
+```text
+TOOLS / ACCOUNTS / PERMISSIONS / SECRETS / EXTERNAL SERVICES
+-> which step needs each dependency
+-> which can be skipped if already available
+```
+
+This is especially important when setup crosses several services.
+
+## 5. Separate human-only actions from automatable actions
+
+The source implicitly alternates between browser/account actions and AI/CLI actions.
+
+A better doctrine makes this explicit:
+
+```text
+HUMAN-ONLY
+- create/approve account
+- grant permission
+- handle credentials
+- confirm irreversible/security-sensitive choices
+
+AUTOMATABLE
+- transform files
+- run bounded setup steps
+- generate configuration
+- verify deterministic outputs
+```
+
+The engine should never imply that a model should autonomously decide every security-sensitive step merely because automation is possible.
+
+## 6. Secret handling is a first-class article boundary
+
+A tutorial that needs credentials should not casually ask the reader to paste long-lived secrets into prose, screenshots, public comments, or unnecessary AI context.
+
+Doctrine:
+
+```text
+if secret required
+-> explain what it is
+-> explain where it should be entered
+-> minimize exposure
+-> never echo it back in the article
+-> provide rotation/revocation guidance when material
+```
+
+Hard-coded example secrets should be clearly fake/non-production values, and the engine should avoid publishing reusable defaults that create unsafe deployments.
+
+## 7. Do not use blanket permission bypass as a convenience shortcut
+
+The source includes a broad permission-skipping pattern.
+
+This is valuable as an anti-pattern for METEOR:
+
+```text
+convenience
+vs
+least privilege
+```
+
+The engine should prefer bounded permissions and explicit checkpoints. A “one-copy-paste” promise must not erase important authorization boundaries.
+
+## 8. Progress should be checkpointed across systems
+
+For multi-service tutorials, every major boundary should have an observable checkpoint.
+
+Example generic sequence:
+
+```text
+account ready
+-> credential created
+-> service reachable
+-> deployment visible
+-> webhook/connector verified
+-> first real event observed
+```
+
+If the reader cannot verify one layer, do not blindly proceed to the next.
+
+## 9. Recovery should resume from the failed boundary, not restart everything
+
+The source often says to analyze the error and retry the failed step.
+
+Useful doctrine:
+
+```text
+identify failed stage
+-> preserve already verified state
+-> repair only the broken boundary
+-> re-run its verification
+-> continue
+```
+
+This is preferable to “start over” unless state corruption is plausible.
+
+## 10. Demonstrate one thin vertical slice before listing every feature
+
+The strongest tutorial move in the source is the simple end-to-end scenario before the larger feature catalog.
+
+Doctrine:
+
+```text
+SETUP
+-> ONE SMALL REAL WORKFLOW
+-> VERIFY RESULT
+-> ONLY THEN SHOW THE BROADER CAPABILITY MAP
+```
+
+This prevents a long feature list from becoming abstract marketing.
+
+## 11. Capability catalogs should answer “when would I use this?”
+
+A feature list is more useful when each feature has:
+
+- plain-language meaning;
+- one concrete use case;
+- important boundary/condition;
+- whether it is core or optional.
+
+Do not make every feature sound equally important or universally useful.
+
+## 12. “Next 5% / next 95%” escalation is a persuasion device, not a fact
+
+The source uses an escalation pattern: basic setup is only a small fraction of the tool’s potential, then introduces advanced prompts.
+
+The engine may use a progression such as:
+
+```text
+first useful result
+-> next predictable need
+-> optional deeper capability
+```
+
+But it must not invent pseudo-precise percentages or urgency just to create appetite.
+
+## 13. Resource timing can follow the next-wall rule
+
+A checklist/template/prompt library is most natural when the reader has reached the point where the next recurring problem is obvious.
+
+Good:
+
+```text
+reader completes first workflow
+-> now asks “how do I make this useful repeatedly?”
+-> offer optional template/resource
+```
+
+Bad:
+
+```text
+withhold information required for safe completion behind a lead-capture wall
+```
+
+## 14. Strong claims require classification
+
+This source contains many phrases that METEOR should attack:
+
+- completely free / permanent free;
+- same as paid competitors;
+- unique feature claims;
+- “no other tool has this”;
+- “all data is under your control”;
+- unlimited / everything can be done;
+- “one copy-paste” completion;
+- fixed scale/cost claims;
+- success-rate assumptions;
+- “100% can do it.”
+
+Engine rule:
+
+```text
+claim -> classify as VERIFIED_FACT / HUMAN_EXPERIENCE / INTERPRETATION / OPINION / COMMERCIAL_PROMISE
+-> require appropriate evidence and scope
+```
+
+## 15. Platform-enforcement evasion is not a writing optimization
+
+The source discusses behavior intended to evade platform enforcement/ban detection.
+
+This should not become reusable writing doctrine or implementation guidance.
+
+The safe article lesson is only:
+
+```text
+platform dependency exists
+-> explain compliance risk
+-> explain recovery / portability where legitimate
+-> do not teach evasion of enforcement controls
+```
+
+## 16. Comparison articles need conflict-of-interest transparency
+
+The source compares multiple products while personally recommending one and later connecting to marketing/commercial material.
+
+Useful doctrine:
+
+- separate evidence-based comparison from personal preference;
+- disclose material affiliation or incentive when relevant;
+- do not let a sponsored/affiliate preference masquerade as neutral technical fact.
+
+## 17. A long tutorial can contain three different reading modes
+
+This source effectively has:
+
+```text
+DECISION MODE
+Which option fits me?
+
+EXECUTION MODE
+How do I make one path work?
+
+EXPANSION MODE
+What else can I do after the first win?
+```
+
+The engine should know which mode each section serves. Mixing them without transitions creates bloat.
+
+## 18. Useful METEOR conflicts introduced by this source
+
+### Simplicity vs security
+Can the engine keep a one-path beginner flow without hiding authorization and secret-handling complexity?
+
+### Automation vs human authority
+Does “AI does everything” accidentally include actions that require explicit human approval?
+
+### One-copy-paste ergonomics vs least privilege
+Does convenience pressure the article into unsafe blanket permissions?
+
+### Strong commercial clarity vs fabricated certainty
+Can the article be decisive without “100% / permanent / no risk” claims?
+
+### Feature excitement vs capability verification
+Does the engine list plausible features that were never evidence-bound?
+
+### Free lead magnet vs safety completeness
+Does the engine ever hide safety-critical instructions behind a CTA?
+
+### Comparison vs disguised promotion
+Can the engine preserve real trade-offs when the writer prefers or benefits from one option?
+
+### Recovery vs repeated destructive retries
+Does troubleshooting preserve known-good state and avoid re-running risky setup blindly?
+
+## BridgePatch implication
+
+For BridgePatch, the useful lesson is not the product or implementation path in this source.
+
+It is the article architecture:
+
+```text
+reader pain / confusing options
+-> compare by use case
+-> choose one bounded path
+-> define dependencies
+-> separate human-only and automatable steps
+-> perform one thin vertical slice
+-> verify the result
+-> explain recovery
+-> expand only after first success
+-> CTA as the next bounded step
+```
+
+This aligns strongly with BridgePatch itself:
+
+```text
+input
+-> one bounded action
+-> observable output
+-> human checkpoint
+-> failure return
+```
+
+The v0.9 engine should preserve that clarity while refusing the source’s unsafe shortcuts and unsupported absolutes.

--- a/x_article_engine/knowledge_batch_v09/ORIGINAL_BEGINNER_GUIDE_ANALYSIS.md
+++ b/x_article_engine/knowledge_batch_v09/ORIGINAL_BEGINNER_GUIDE_ANALYSIS.md
@@ -1,0 +1,409 @@
+# v0.9 Knowledge Intake — Original Beginner Guide Archetype
+
+## Source boundary
+
+This analysis is extracted from a user-supplied public X article that appears to be an early/original form of the author's "小学生でもわかる" beginner-guide style.
+
+We are learning **article-writing doctrine and onboarding mechanics**, not importing the article's product facts, prices, time estimates, installation commands, platform availability, feature limits, guarantees, or support promises as engine truth.
+
+Any claim about Claude/Claude Code, subscription requirements, pricing, browser/terminal capabilities, installation methods, operating-system requirements, completion time, or success rate must separately pass the normal evidence boundary before use in a generated article.
+
+## Why this source matters
+
+Later reference articles show polished versions of several doctrines already present here in raw form:
+
+- define unfamiliar terms immediately;
+- remove unnecessary choice for a true beginner;
+- give exact actions instead of abstract encouragement;
+- explain why each important action is necessary;
+- state scope limits early;
+- provide recovery paths at likely failure points;
+- move from fear -> first success -> practical next step;
+- make the CTA/resource appear at the moment the reader has the next predictable need.
+
+This makes the article useful as an **archetype source** rather than merely another example.
+
+## 1. Beginner friction should be named before instruction
+
+The opening does not start with product capabilities. It starts with the reader's likely failure state:
+
+- terminology overload;
+- too many alternative methods;
+- not knowing the first action.
+
+Useful doctrine:
+
+```text
+recognizable friction
+-> writer's attested same-state experience when available
+-> explicit promise of what this guide removes
+-> only then begin instruction
+```
+
+Do not invent "I was exactly the same" unless it is human-attested.
+
+## 2. A beginner guide may deliberately reduce choice
+
+For a true zero-to-first-success guide, multiple valid paths can increase cognitive load.
+
+Useful doctrine:
+
+```text
+if several approaches exist
+-> choose one safe, evidence-supported default for the stated scope
+-> explain why this guide chooses it
+-> keep alternatives out of the main path unless they are necessary
+```
+
+This is not a universal "never show options" rule.
+
+Use one-path guidance only when:
+
+- the guide's purpose is first completion rather than exhaustive comparison;
+- one default is reasonably safe for the configured reader and scope;
+- omitting alternatives will not hide a material trade-off or risk.
+
+## 3. Scope limits belong before the steps they invalidate
+
+The article places the Mac-only boundary before detailed instructions.
+
+Useful doctrine:
+
+```text
+important scope boundary
+-> state it before the reader invests effort
+-> say who the guide is for
+-> say who should use a different path
+```
+
+Do not let a reader complete half a guide before discovering that their environment is unsupported.
+
+## 4. Explain the chosen path with consequences, not labels
+
+Instead of merely saying "use terminal version," the article tries to explain why through concrete tasks.
+
+Generalizable pattern:
+
+```text
+option A / option B
+-> what each can or cannot do for this reader's intended task
+-> choose the path based on consequence
+```
+
+The specific technical claims in the source are not imported as truth.
+
+## 5. Explain jargon at the exact point of use
+
+Examples in the source include defining ターミナル and データベース in ordinary language.
+
+Doctrine:
+
+```text
+unfamiliar term
+-> immediate plain-language definition
+-> familiar analogy/example if needed
+-> continue using the shorter term
+```
+
+This reinforces v0.4/v0.5 terminology rules.
+
+## 6. Convert instructions into observable actions
+
+A strong beginner step tells the reader:
+
+- where to look;
+- what to click/type/copy;
+- what success looks like;
+- what to do if that success signal does not appear.
+
+Useful step schema:
+
+```text
+GOAL
+ACTION
+EXPECTED SIGNAL
+IF NOT -> RECOVERY
+WHY (when important)
+```
+
+This is stronger than prose such as "install the tool and configure it properly."
+
+## 7. Give a success signal after important steps
+
+The source repeatedly provides visible confirmation such as a version string or a visible plan label.
+
+Generalizable doctrine:
+
+```text
+do action
+-> inspect an observable result
+-> only then proceed
+```
+
+This reduces uncertainty and makes a long guide self-correcting.
+
+The exact success indicators must be evidence-bound for the actual product/workflow.
+
+## 8. Recovery belongs next to the likely failure
+
+The source places troubleshooting directly after installation and again in a dedicated recovery section.
+
+Prefer:
+
+```text
+risky step
+-> expected outcome
+-> common failure symptom
+-> bounded recovery
+```
+
+rather than saving every error case for an appendix the reader may never reach.
+
+Do not invent common failures. A failure mode should be sourced, observed, documented, or clearly framed as a conditional possibility.
+
+## 9. Copy/paste ergonomics are part of comprehension
+
+For operational tutorials, presentation is part of the instruction.
+
+Useful doctrine:
+
+- visually distinguish literal input from explanatory prose;
+- warn when exact copying matters;
+- do not force the reader to infer which characters belong in the command/input;
+- keep command/example and explanation adjacent.
+
+This should generalize beyond programming to forms, templates, emails, spreadsheet formulas, configuration values, etc.
+
+## 10. "Why" turns imitation into transferable understanding
+
+The guide explicitly promises to explain why an action is needed.
+
+A beginner may be able to copy steps without understanding them, but a useful article should add enough rationale that the reader can recover when the environment changes.
+
+Doctrine:
+
+```text
+WHAT TO DO
++
+WHY THIS STEP EXISTS
++
+WHAT SUCCESS MEANS
+```
+
+Not every trivial click requires a paragraph of explanation. Add WHY where it helps judgment, recovery, safety, or transfer.
+
+## 11. Move from installation to a first real win quickly
+
+The guide does not stop at "installed successfully." It gives small example projects immediately after setup.
+
+Generalizable progression:
+
+```text
+setup complete
+-> tiny meaningful use
+-> modification / second instruction
+-> reader sees the tool as usable rather than merely installed
+```
+
+For non-technical articles, the equivalent is:
+
+```text
+understand method
+-> perform one small real action
+-> see a concrete result
+```
+
+## 12. Predict the next wall
+
+The source anticipates:
+
+> インストールできた。で、何作ればいいの？
+
+and places a resource there.
+
+Generalizable doctrine:
+
+```text
+reader completes current milestone
+-> identify the next predictable friction
+-> provide the next resource only there
+```
+
+This complements v0.8's utility-timing rule.
+
+## 13. Guide architecture can be a confidence ladder
+
+The article gradually changes the reader state:
+
+```text
+"難しそう"
+-> "何をすればいいか分かった"
+-> "今の画面は正常だ"
+-> "インストールできた"
+-> "起動できた"
+-> "日本語で動かせた"
+-> "次も試せそう"
+```
+
+For Article Engine, this suggests tracking **reader state transitions**, not only headings/content coverage.
+
+A practical/how-to article should know what confidence/state each section is supposed to create.
+
+## 14. Safety warnings should be proportional and timely
+
+The article later references a higher-risk tool and warns that setup mistakes can be dangerous.
+
+General doctrine:
+
+- place material risks before the risky action;
+- explain what makes the action risky in plain language;
+- do not use exaggerated danger language only for attention;
+- give a safer prerequisite/path where appropriate.
+
+## 15. What must NOT be imported as doctrine
+
+The source contains several patterns that should become METEOR attack targets rather than rules:
+
+### Absolute completion promises
+
+Examples in the source include forms equivalent to:
+
+- "100%できます"
+- "絶対に完了できる"
+- "保証します"
+- fixed completion-time promises
+
+These conflict with evidence/safety doctrine.
+
+Engine rule candidate:
+
+> Never convert beginner friendliness into a universal success guarantee.
+
+### Overconfident product/technical claims
+
+Claims such as:
+
+- one version "can do anything";
+- another version cannot perform broad categories of work;
+- one plan is "enough" for everyone;
+- a specific installation method is universally current;
+- a named older method "no longer works";
+
+are time-sensitive factual claims, not writing doctrine.
+
+### False simplicity through hidden trade-offs
+
+"選択肢を提示しません" is useful only when the chosen default is safe and material alternatives are not being concealed.
+
+METEOR should attack cases where one-path guidance hides:
+
+- platform/OS differences;
+- cost differences;
+- security implications;
+- irreversible actions;
+- prerequisites;
+- meaningful capability trade-offs.
+
+### Redundant summary / boilerplate ending
+
+The source includes a conventional "まとめ" plus motivational close and multiple follow-on links.
+
+This is useful historical evidence, but v0.6/v0.7 should challenge whether each closing section still adds value.
+
+### Multiple CTA drift
+
+The article contains resource acquisition, reply support, follow, quote/repost requests, and multiple next-article links.
+
+This is a strong METEOR tension against the current single-CTA doctrine.
+
+Question for later battle:
+
+> Can a long tutorial safely contain navigation/follow-on resources without becoming a multi-CTA commercial mess?
+
+Potential distinction:
+
+```text
+PRIMARY COMMERCIAL CTA = one
+UTILITY/NAVIGATION LINKS = allowed only when they directly support task completion and do not compete with the primary next action
+```
+
+This should be tested rather than assumed.
+
+## 16. Candidate v0.9 additions
+
+Do not promote yet. Candidates for final integration after all knowledge is ingested:
+
+1. `BEGINNER_SINGLE_PATH_POLICY`
+   - choose one safe default path for first completion;
+   - explain why;
+   - preserve material exceptions/trade-offs.
+
+2. `STEP_OBSERVABILITY_SCHEMA`
+   - GOAL / ACTION / EXPECTED SIGNAL / RECOVERY / WHY.
+
+3. `EARLY_SCOPE_GATE`
+   - environment/audience prerequisites before costly reader effort.
+
+4. `RECOVERY_PROXIMITY_RULE`
+   - likely recovery next to likely failure.
+
+5. `FIRST_WIN_POLICY`
+   - do not stop at setup; lead to one meaningful use/result.
+
+6. `READER_STATE_LADDER`
+   - each major section should deliberately move the intended reader's state/confidence.
+
+7. `NEXT_WALL_TIMING`
+   - resource/asset appears when the next predictable friction emerges.
+
+8. `UTILITY_LINK_VS_CTA_DISTINCTION`
+   - possible distinction between one commercial CTA and task-completion navigation; requires METEOR.
+
+## 17. METEOR attack list created by this source
+
+When the knowledge batch is complete, attack at least these contradictions:
+
+- one-path simplicity vs honest alternatives;
+- beginner confidence vs false guarantees;
+- exact instructions vs time-sensitive product facts;
+- immediate recovery vs article bloat;
+- explain-everything vs cognitive overload;
+- one commercial CTA vs legitimate tutorial utility links;
+- short mobile lines vs excessively fragmented prose;
+- progress reassurance vs repetitive padding;
+- safe defaults vs unsupported "recommended" claims;
+- motivational close vs redundant generic ending.
+
+## BridgePatch implication
+
+The strongest transferable pattern for BridgePatch is not the software tutorial itself.
+
+It is the **guided-completion architecture**:
+
+```text
+reader pain
+-> tell them exactly what this article will remove
+-> narrow scope
+-> explain unfamiliar terms immediately
+-> choose one simple path
+-> show the expected result at each meaningful stage
+-> place recovery near failure
+-> explain why important boundaries exist
+-> reach one small real win
+-> offer the next step when the next wall becomes visible
+```
+
+For BridgePatch, that can become:
+
+```text
+"この手作業、どこからAIに渡せばいいか分からない"
+-> one process only
+-> input / action / output in plain Japanese
+-> what stays human
+-> what failure looks like
+-> where work returns to a human
+-> one concrete sample decomposition
+-> free fit check as the next wall/next step
+```
+
+This source should remain in the v0.9 intake branch until all remaining knowledge has been collected and METEOR has resolved the conflicts.

--- a/x_article_engine/knowledge_batch_v09/README.md
+++ b/x_article_engine/knowledge_batch_v09/README.md
@@ -1,0 +1,18 @@
+# v0.9 Knowledge Batch
+
+This directory contains analyses extracted from user-supplied public X articles during X Article Engine dogfooding.
+
+These files are **reference-learning artifacts, not factual source registries**.
+
+They may contribute writing, onboarding, comparison, freshness, risk, CTA, and reader-depth doctrine. They do not authorize reuse of the reference articles' factual product claims, metrics, results, commands, prices, security claims, or guarantees.
+
+Included analyses:
+
+- `ORIGINAL_BEGINNER_GUIDE_ANALYSIS.md` — zero-to-first-success beginner guide archetype.
+- `RISK_FIRST_STOP_GATE_ANALYSIS.md` — risk-first / stop-gate tutorial archetype.
+- `FRESHNESS_SUPERSESSION_MIGRATION_ANALYSIS.md` — stale article / update / migration doctrine.
+- `LINE_HARNESS_COMPLEX_GUIDE_ANALYSIS.md` — complex automation guide plus security-conflict negatives.
+- `STALE_COMPARISON_DECISION_ANALYSIS.md` — compare-before-choice, one-path-after-choice; factual content intentionally treated as stale.
+- `REFINED_SALES_ARTICLE_ARCHETYPE.md` — refined sales-article self-analysis, with causal claims kept heuristic rather than universal.
+
+See `../V09_METEOR_REPORT.md` for the adversarial synthesis and current candidate status.

--- a/x_article_engine/knowledge_batch_v09/REFINED_SALES_ARTICLE_ARCHETYPE.md
+++ b/x_article_engine/knowledge_batch_v09/REFINED_SALES_ARTICLE_ARCHETYPE.md
@@ -1,0 +1,444 @@
+# v0.9 Knowledge Intake — Refined Sales Article Archetype
+
+## Source boundary
+
+This analysis is extracted from a user-supplied public X article in which the reference author retrospectively explains why a prior beginner guide performed well and how they connect X articles to commercial outcomes.
+
+We are learning **article architecture, onboarding mechanics, reader progression, and commercial continuity**. We are not importing the author's impression counts, follower/list growth, sales, customer/student results, causal claims, psychological claims, or universal prescriptions as engine truth.
+
+Claims such as "this structure causes reach," "advanced readers share for signaling," fixed example counts, fixed title formulas, or any revenue result remain hypotheses or source-specific observations unless independently evidenced.
+
+## Why this source matters
+
+This source is close to a self-described mature form of the reference author's system. It consolidates many previously observed patterns into one explicit model:
+
+- title / preview surface;
+- opening hook;
+- body progression;
+- CTA placement;
+- lived frustration as article promise;
+- progressive depth;
+- visible progress and completion signals;
+- commercial goal set before drafting;
+- differentiation between reach and commercial progress.
+
+It is therefore useful as a **synthesis source**, not as a higher-authority truth source.
+
+## 1. Four functional surfaces
+
+A useful abstraction is:
+
+```text
+TAP SURFACE
+-> OPENING CONTRACT
+-> DELIVERY / PROGRESSION
+-> NEXT STEP
+```
+
+The reference labels these as title, opening hook, body, CTA.
+
+The exact names are less important than the functional question:
+
+- What makes the intended reader enter?
+- What gives them a reason to continue?
+- What changes their understanding or ability?
+- What is the next appropriate action?
+
+Each surface should earn its existence.
+
+## 2. The visible preview may extend beyond the formal title
+
+On feeds, the reader may see a title plus opening lines before clicking.
+
+Doctrine:
+
+```text
+formal title
++
+visible opening preview
+=
+entry surface
+```
+
+The engine should optimize the whole visible entry surface for clarity and relevance, not merely the headline string.
+
+Do not invent platform-specific preview lengths or UI behavior without current evidence.
+
+## 3. Lived frustration can define the article promise
+
+Strong pattern:
+
+```text
+attested frustration
+-> precise failure points
+-> article promises that answer those failure points one-for-one
+```
+
+Example abstraction:
+
+```text
+"too much jargon" -> explain unfamiliar terms immediately
+"too many choices" -> choose one bounded default path
+"I do not know where to start" -> show the first action and visible sequence
+```
+
+This is stronger than adding generic empathy because the opening complaint directly determines the article specification.
+
+Do not invent anger or frustration. Use only human-attested emotion or clearly framed audience research.
+
+## 4. Opening contract
+
+A useful sequence for a pain-led guide is:
+
+```text
+recognizable situation
+-> precise problem definition
+-> attested same-state / credible basis when available
+-> stance
+-> what this article will remove or enable
+```
+
+The source describes this as empathy -> problem definition -> position declaration.
+
+The engine should not force this sequence when another opening mode (proof-first, story, update, comparison, risk-first) is better.
+
+## 5. Make promises correspond to named pain
+
+If the opening names three concrete frustrations, the article should visibly answer them.
+
+Doctrine:
+
+```text
+PAIN_i -> PROMISE_i -> DELIVERY_i
+```
+
+This creates traceability from hook to article body.
+
+A human reviewer should be able to ask:
+
+> Did every important opening promise get paid off?
+
+## 6. Visible progress reduces uncertainty
+
+For long procedural content, expose where the reader is and what remains.
+
+Useful tools:
+
+- numbered steps;
+- section milestones;
+- completion signals;
+- a short map of the whole process before execution;
+- local success checks.
+
+The useful principle is not "always use seven steps." It is:
+
+```text
+reader can tell current position
++
+reader can tell what completion looks like
+```
+
+## 7. Choice policy depends on phase
+
+Resolve the apparent contradiction between comparison and single-path guidance:
+
+```text
+BEFORE COMMITMENT
+compare only material options needed for a decision
+
+AFTER COMMITMENT
+use one clear execution path unless a new material branch is necessary
+```
+
+Do not make a novice repeatedly re-decide the architecture while following a first-success guide.
+
+Do not hide material trade-offs merely to keep the path simple.
+
+## 8. WHY is a recovery tool, not decorative explanation
+
+For important actions, explain enough rationale that the reader can reason when the interface or environment changes.
+
+```text
+ACTION
+-> WHY
+-> SUCCESS SIGNAL
+-> RECOVERY IF NEEDED
+```
+
+Do not over-explain trivial clicks.
+
+## 9. Concrete examples can replace abstract repetition
+
+The source strongly favors multiple concrete examples after an abstract claim.
+
+General doctrine:
+
+```text
+abstract mechanism
+-> enough varied examples to reveal the pattern
+-> stop when the pattern is clear
+```
+
+Do **not** encode "three examples" as a fixed requirement.
+
+Use one, two, three, or more based on explanatory value and evidence availability.
+
+## 10. Immediate terminology explanation remains mandatory for general readers
+
+This source reinforces the existing rule:
+
+```text
+unfamiliar necessary term
+-> immediate plain-language meaning
+-> continue
+```
+
+If the writer wonders whether a term may interrupt a general reader, prefer a compact inline explanation.
+
+Do not expand every ordinary term into a glossary.
+
+## 11. Anticipate friction near the point it occurs
+
+The source describes troubleshooting near likely failure points and completion messages after steps.
+
+Doctrine:
+
+```text
+important step
+-> likely evidenced failure
+-> local recovery path
+-> visible completion
+```
+
+This supports action, not merely readability.
+
+Do not invent "common errors" solely to make a guide feel complete.
+
+## 12. Article-as-game-design is a useful metaphor, not literal doctrine
+
+The source uses game design to describe:
+
+- visible direction;
+- limited unnecessary choice;
+- small completion rewards;
+- recovery before a drop-off;
+- next-step resource at the moment of need.
+
+Generalizable principle:
+
+> Good instructional writing reduces navigation uncertainty and makes the next useful action obvious without repeatedly commanding the reader to continue.
+
+Do not add artificial gamification, fake rewards, streaks, or psychological pressure unless the actual product/workflow requires them.
+
+## 13. Progressive depth can serve multiple knowledge levels
+
+Refined ladder:
+
+```text
+SHARED ENTRY
+-> TRANSLATION
+-> MECHANISM
+-> DEEPER JUDGMENT / META-INSIGHT
+```
+
+The source maps this to beginner / intermediate / advanced reader value.
+
+Useful interpretation:
+
+- first-time reader: understands the terms and first action;
+- practical reader: understands why and how it works;
+- informed reader: gains a trade-off, design principle, decision rule, or second-order implication.
+
+Do not assume advanced readers share content for identity signaling. That is a source-specific psychological interpretation, not engine truth.
+
+## 14. Advanced depth may come from the article's construction itself
+
+A mature article can contain a second layer where the way the article is built demonstrates the doctrine it teaches.
+
+Examples:
+
+- a CTA appears exactly where the next practical need arises;
+- the article itself uses the bounded path it recommends;
+- opening frustrations are visibly answered later;
+- safety boundaries are demonstrated rather than merely asserted.
+
+This is self-demonstration, not self-congratulation.
+
+## 15. CTA should answer a predicted next wall
+
+Strong commercial continuity rule:
+
+```text
+article creates understanding / first success
+-> predictable next need appears
+-> resource / offer solves that next need
+```
+
+The CTA should feel like the next step of the same mechanism.
+
+Do not manufacture a "desire peak" through fear, false scarcity, or withheld safety information.
+
+## 16. Commercial destination should be known before drafting
+
+Before writing, identify:
+
+```text
+OFFER
+-> intended buyer
+-> pre-purchase state
+-> article problem
+-> useful reader end-state
+-> next low-friction action
+```
+
+Then draft the article.
+
+This does not mean every article must sell immediately. It means a commercial article should know what qualified progress looks like.
+
+## 17. Topic / offer relevance matters
+
+The source calls this expert positioning.
+
+Safer abstraction:
+
+> The article topic, evidence, lived experience, and offer should create a coherent reason for the intended reader to trust the next step.
+
+Avoid unrelated viral topics that generate reach but no credible bridge to the offer.
+
+Do not fabricate credentials or expertise to create alignment.
+
+## 18. Reach and commercial progress are separate
+
+Keep distinct metrics for:
+
+```text
+READ / DISTRIBUTION
+vs
+QUALIFIED COMMERCIAL PROGRESS
+```
+
+Possible funnel:
+
+```text
+SEEN
+-> QUALIFIED READER
+-> ARTICLE READ / VISIT
+-> INQUIRY / OPT-IN
+-> FIT / QUALIFICATION
+-> PAID ACTION
+```
+
+High reach is not evidence of commercial success.
+
+Low reach with qualified conversion may indicate distribution weakness rather than article/offer failure.
+
+## 19. Human material remains the scarce layer
+
+The source reinforces a key doctrine:
+
+AI can help structure, summarize, compare, and draft.
+
+The engine must not fabricate:
+
+- the writer's anger;
+- lived failure;
+- primary results;
+- personal stakes;
+- industry belief;
+- final human judgment.
+
+These should come from attested human material or be omitted.
+
+## 20. Quality bar: completeness without competitive theater
+
+The source uses a competitive heuristic roughly equivalent to "make the article so complete that a later writer would struggle to add value."
+
+Generalize safely:
+
+> Cover the intended reader's important unanswered questions deeply enough that the article stands on its own.
+
+Do not optimize for humiliating competitors, monopolizing a topic, or suppressing alternative viewpoints.
+
+## 21. Source-specific claims that must NOT become engine law
+
+Do not hard-code the following as universal truths:
+
+- title must equal "number x simplicity x huge effect";
+- every explanation needs exactly three examples;
+- advanced readers share to signal taste;
+- beginner / intermediate / advanced layers maximize impressions;
+- comments/replies cause a specific distribution outcome;
+- one exact CTA location always wins;
+- impressions are merely a byproduct in every commercial strategy;
+- source-specific sales or list metrics prove causation.
+
+These may be tested hypotheses or editorial options, not invariants.
+
+## 22. METEOR conflicts exposed by this source
+
+Future adversarial testing should attack:
+
+### Strong promise vs evidence
+- reassuring beginner language must not become guarantees such as "100%" or fixed completion time without evidence.
+
+### One path vs hidden trade-offs
+- simplify execution without concealing material risk, cost, scope, or incompatibility.
+
+### Progressive depth vs bloated article
+- do not add a meta layer merely to impress advanced readers.
+
+### Commercial continuity vs disguised advertising
+- CTA may be natural, but commercial intent should not require deception.
+
+### Human voice vs invented anger
+- do not generate righteous frustration because the template expects it.
+
+### Completion signals vs false certainty
+- "done" should correspond to an observable state, not emotional reassurance.
+
+### Reach optimization vs qualified relevance
+- do not sacrifice buyer relevance to broaden the audience.
+
+## BridgePatch implication
+
+A strong BridgePatch article can now use the mature synthesis without copying the reference article's language:
+
+```text
+ENTRY SURFACE
+"1円にもならないのに手を抜けない" / lived frustration
+
+OPENING CONTRACT
+actual endless-fix scene
+-> what made it painful
+-> what the article will explain
+
+DELIVERY
+visible progression:
+1. what happened
+2. why the work expanded
+3. what "シムシティ化" means
+4. why "do everything" fails
+5. how one-process boundaries work
+6. where the human must remain
+7. how to identify one candidate task today
+
+PROGRESSIVE DEPTH
+plain terms
+-> concrete loop
+-> mechanism
+-> judgment rule: where to stop / return control
+
+NEXT WALL
+"自分の仕事のどこを一工程として切ればいいか分からない"
+
+CTA
+BridgePatch（ブリッジパッチ） free fit check
+```
+
+The article should demonstrate the BridgePatch principle by being bounded itself: one problem, one mechanism, one next action, one CTA.
+
+## Status
+
+Knowledge-intake only.
+
+Do not merge into the runtime engine until the remaining sources are ingested and the combined v0.9 candidate has passed DA / counter-DA / METEOR and dogfood evaluation.

--- a/x_article_engine/knowledge_batch_v09/RISK_FIRST_STOP_GATE_ANALYSIS.md
+++ b/x_article_engine/knowledge_batch_v09/RISK_FIRST_STOP_GATE_ANALYSIS.md
@@ -1,0 +1,347 @@
+# v0.9 Knowledge Intake — Risk-First / Stop-Gate Guide Archetype
+
+## Source boundary
+
+This analysis is extracted from a user-supplied public X article about a high-risk AI tool.
+
+We are learning **risk communication, reader qualification, stop-gates, recovery, and safe tutorial structure**. We are **not** importing the article's security incidents, CVEs, version numbers, product capabilities, installation commands, prices, risk levels, guarantees, or claims that another tool is "safe" as engine truth.
+
+Any external safety, security, legal, medical, financial, technical, product-version, vulnerability, pricing, or incident claim must independently pass the normal evidence boundary before appearing in generated content.
+
+## Why this source matters
+
+The earlier beginner-guide archetype focused on getting a novice to first success. This source adds the opposite but equally important ability:
+
+> A good guide must sometimes stop the wrong reader before they proceed.
+
+For risky workflows, completion is not the only objective. Appropriate refusal, deferral, containment, verification, and recovery are part of good instruction.
+
+## 1. Risk disclosure must precede the dangerous action
+
+Do not bury material risk in a late disclaimer.
+
+Preferred order:
+
+```text
+what can go wrong
+-> who should not continue
+-> safer alternative / prerequisite
+-> minimum conditions for proceeding
+-> only then the operational steps
+```
+
+This is especially important when a reader could incur irreversible harm before reaching the warning.
+
+## 2. Qualification can be more important than persuasion
+
+For high-risk or advanced tasks, the article should explicitly identify readers who should stop or take a lower-risk path.
+
+Useful schema:
+
+```text
+GOOD FIT IF
+- required prerequisite exists
+- reader can recognize failure signals
+- rollback / recovery exists
+- stakes are bounded
+
+DO NOT CONTINUE IF
+- prerequisite is missing
+- reader cannot evaluate the risk
+- environment contains irreplaceable assets
+- safe rollback is unavailable
+```
+
+This is not elitism. It is a scope and safety boundary.
+
+## 3. Offer a safer path, not only a warning
+
+A warning that only says "danger" leaves the reader stranded.
+
+Prefer:
+
+```text
+not suitable for this path
+-> here is the safer prerequisite / alternative
+-> return when these conditions are met
+```
+
+Do not invent that the alternative is "safe" in an absolute sense. Describe the relevant reduction in scope or risk when evidence supports it.
+
+## 4. Risk claims need evidence and calibration
+
+Strong language such as:
+
+- "最凶"
+- "全部消される"
+- "絶対安全"
+- "これなら安心"
+- "最新版なら安全"
+
+must not be used merely for impact.
+
+Engine doctrine:
+
+```text
+risk severity claim
+-> evidence / source / scope / date
+-> calibrated language
+-> actionable mitigation
+```
+
+Avoid both understatement and theatrical fear amplification.
+
+## 5. A disclaimer does not repair unsafe instructions
+
+"自己責任" or "筆者は責任を負いません" is not a substitute for:
+
+- accurate scope;
+- evidence-bound risk claims;
+- safe defaults;
+- explicit stop conditions;
+- reversible first steps;
+- verification;
+- recovery.
+
+The engine must never treat a disclaimer as permission to give reckless or overconfident instructions.
+
+## 6. High-risk guides need mandatory gates, not optional tips
+
+When a safety control is necessary for the guide's acceptable risk envelope, do not frame it as a casual optimization.
+
+Preferred structure:
+
+```text
+REQUIRED CONTROL
+-> why it exists
+-> how to verify it is active
+-> if verification fails: STOP
+```
+
+However, a control can only be called mandatory if that requirement is supported for the actual workflow.
+
+## 7. Start inside a reversible sandbox
+
+The source strongly separates a test environment from valuable production data.
+
+Generalizable doctrine:
+
+```text
+high-impact capability
+-> smallest reversible test surface
+-> minimal permissions
+-> observable success/failure
+-> only then consider expanding scope
+```
+
+Equivalent non-technical examples include:
+
+- draft before send;
+- test data before production data;
+- one record before bulk update;
+- preview before publish;
+- human approval before payment/finalization.
+
+This fits BridgePatch's existing principle of bounded one-process automation and human return paths.
+
+## 8. Verify safety controls by observable state
+
+Do not say "enable safety" and move on.
+
+A useful step includes:
+
+```text
+enable control
+-> inspect expected signal
+-> if signal differs: stop / rollback
+```
+
+This extends the beginner-guide `GOAL -> ACTION -> EXPECTED SIGNAL -> IF NOT -> RECOVERY` schema into explicit safety validation.
+
+## 9. Emergency stop belongs before the emergency
+
+A reader should know how to stop or roll back before starting a process that can continue acting.
+
+Preferred placement:
+
+```text
+before activation:
+- how to stop
+- how to revoke access
+- how to return to a safe state
+```
+
+Repeating the emergency-stop instruction near the risky step may be justified when stakes are high.
+
+## 10. Repeat critical warnings at decision points, not everywhere
+
+High-risk guides may need repeated warnings, but repetition should track actual decision points.
+
+Useful repetition:
+
+- before exposure of credentials;
+- before expanding permissions;
+- before enabling external access;
+- before irreversible actions;
+- before leaving a sandbox.
+
+Bad repetition:
+
+- repeating "超重要" every few paragraphs without adding a new decision or consequence.
+
+Over-warning can reduce attention to genuinely critical warnings.
+
+## 11. Separate severity from probability
+
+A catastrophic outcome can be severe without being common.
+
+The engine should avoid collapsing:
+
+```text
+possible harm
+```
+
+into:
+
+```text
+likely harm
+```
+
+unless evidence supports the probability claim.
+
+When the probability is unknown, say so rather than manufacturing certainty.
+
+## 12. Risk controls should map to failure modes
+
+A good safety section explains the relationship:
+
+```text
+failure mode
+-> preventive control
+-> verification
+-> recovery
+```
+
+This is stronger than an unstructured checklist of "best practices."
+
+## 13. Credential handling needs special treatment
+
+For secrets, tokens, passwords, API keys, payment details, or personal information:
+
+- do not ask the reader to paste them into unnecessary places;
+- do not encourage insecure storage;
+- clearly distinguish placeholders from real secrets;
+- minimize exposure and scope;
+- provide revocation/rotation guidance when relevant and evidence-supported.
+
+Avoid misleading analogies such as treating all credentials as equivalent to a credit-card number unless that comparison is specifically useful and accurate.
+
+## 14. The article can intentionally reject the reader
+
+A strong commercial article normally reduces friction. A high-risk guide may need to add friction deliberately.
+
+This is a crucial exception:
+
+```text
+low-risk educational article
+-> reduce unnecessary friction
+
+high-risk operational guide
+-> add necessary friction where it prevents unsafe continuation
+```
+
+Examples:
+
+- prerequisite checklist;
+- explicit confirmation of scope;
+- test environment requirement;
+- manual verification step;
+- stop condition.
+
+Friction is justified only when tied to risk, not as theatrical gatekeeping.
+
+## 15. Utility assets can be safety devices
+
+A checklist, quick reference, printable stop procedure, or verification sheet can be genuinely useful when it reduces configuration error.
+
+Doctrine:
+
+```text
+known multi-step risk
+-> compact verification asset
+-> use it to reduce omission risk
+```
+
+Do not force a lead-generation gate onto safety-critical information that the reader needs immediately to avoid harm. Critical safety instructions should remain in the article itself.
+
+## 16. CTA must not compete with safety
+
+A commercial/resource CTA in a risk article must come after the reader has received the safety-critical information needed to proceed or stop.
+
+Never withhold essential risk controls behind a signup, payment, or engagement action.
+
+## 17. Current-version claims are perishable
+
+Statements such as:
+
+- fixed in version X;
+- latest version is safe;
+- use command Y;
+- risk Z was addressed on date D;
+
+are time-sensitive evidence, not evergreen writing doctrine.
+
+For generated current technical guides:
+
+```text
+freshness-sensitive instruction
+-> current primary source check
+-> date/version scope
+-> fail closed if unverifiable
+```
+
+## 18. METEOR targets exposed by this source
+
+This source is deliberately useful for adversarial testing because it contains tensions that the integrated engine must resolve:
+
+### A. Strong warning vs fearmongering
+Can the engine communicate serious risk without turning unverified worst cases into certainty?
+
+### B. Beginner clarity vs unsafe simplification
+Can it keep one main path without hiding material trade-offs or prerequisites?
+
+### C. Safety confidence vs false guarantee
+Can it say "this reduces risk" without saying "this is safe" or "now you're protected" without evidence?
+
+### D. Disclaimer vs actual duty of care
+Can it refuse to let a disclaimer excuse weak safety design?
+
+### E. Repetition vs warning fatigue
+Can it repeat only at meaningful hazard boundaries?
+
+### F. Helpful CTA vs withholding safety
+Can it keep critical safety information public and immediate while still offering a useful optional asset?
+
+### G. Latest instructions vs stale technical content
+Can the engine force fresh verification for versioned commands, prices, vulnerabilities, and product behavior?
+
+## BridgePatch implication
+
+This source reinforces a major BridgePatch principle:
+
+```text
+make one bounded process easier
+!=
+remove every human checkpoint
+```
+
+For BridgePatch articles, the deeper lesson can be expressed as:
+
+- identify what the tool may do;
+- identify what it must not do;
+- define what success looks like;
+- define failure/stop conditions;
+- keep a manual return path;
+- use a low-impact test before expanding scope.
+
+This provides a strong bridge from the user's lived "endless repair" pain to a defensible product philosophy: **good automation includes the boundary where automation stops.**

--- a/x_article_engine/knowledge_batch_v09/STALE_COMPARISON_DECISION_ANALYSIS.md
+++ b/x_article_engine/knowledge_batch_v09/STALE_COMPARISON_DECISION_ANALYSIS.md
@@ -1,0 +1,197 @@
+# v0.9 Knowledge Intake — Stale Comparison / Decision Archetype
+
+## Source boundary
+
+This analysis comes from a user-supplied public X article about Codex vs Claude Code.
+
+The user explicitly notes that the product roles have since changed substantially. Therefore this source is **not** treated as current product documentation and must not seed present-day facts about Codex, Claude Code, models, plans, pricing, interfaces, capabilities, installation steps, benchmarks, availability, or recommendations.
+
+Any such claim is stale-by-default and requires fresh evidence before reuse.
+
+What survives is the **decision-writing structure**.
+
+## Core lesson
+
+A comparison article should reduce unnecessary migration anxiety, not manufacture a winner.
+
+Useful progression:
+
+```text
+reader anxiety / forced-choice feeling
+-> answer the decision question early
+-> explain the meaningful differences
+-> translate differences into reader consequences
+-> recommend by reader state / existing stack / goal
+-> give one default path
+-> let the tutorial begin
+```
+
+The goal is not "declare Tool A best." The goal is "help this reader make a bounded decision without paying unnecessary switching cost."
+
+## 1. Answer "Do I need to switch?" before the feature dump
+
+A reader comparing two tools often has a more practical question than "which benchmark wins?"
+
+Typical latent questions:
+
+- Do I need to switch from what I already use?
+- Do I need another subscription?
+- Am I falling behind if I do not adopt the new tool?
+- Is the difference meaningful for my actual work?
+
+Useful doctrine:
+
+```text
+comparison request
+-> identify the decision the reader actually needs to make
+-> answer that first
+-> then justify it
+```
+
+## 2. Switching cost belongs in the comparison
+
+Raw capability is only one axis.
+
+A useful comparison may include:
+
+- existing subscription / account;
+- current familiarity;
+- available documentation and support;
+- migration effort;
+- workflow fit;
+- specific task advantage;
+- risk of changing tools without a meaningful gain.
+
+Do not tell a reader to migrate merely because a new product is fashionable.
+
+## 3. Compare consequences, not labels
+
+Instead of "A is stronger at X," explain what that means for the reader.
+
+```text
+verified difference
+-> practical consequence
+-> which reader / task cares about it
+```
+
+A benchmark is not self-explanatory. Both the benchmark result and the relevance claim must stay evidence-bound.
+
+## 4. Recommend by reader state
+
+A useful comparison can map reader states to choices:
+
+```text
+already uses ecosystem A -> default A unless there is a material reason to switch
+already uses ecosystem B -> default B unless there is a material reason to switch
+true beginner -> choose the path with the lowest justified learning/recovery cost
+needs both -> use both only if the second tool adds a real capability or operational advantage
+```
+
+These are decision patterns, not current product recommendations.
+
+## 5. "One path" and "comparison" are not contradictory
+
+The article demonstrates a useful sequence:
+
+```text
+before tutorial: compare enough to choose
+inside tutorial: stop comparing and use one path
+```
+
+This resolves a tension in the beginner-guide doctrine.
+
+Comparison belongs at the decision boundary. Once a safe choice is made, unnecessary alternatives can be removed from the execution path.
+
+## 6. Hype reduction can be a legitimate angle
+
+A comparison article can earn attention by lowering anxiety rather than increasing it.
+
+Useful framing:
+
+- "You may not need to switch."
+- "The new thing is not automatically the right thing for you."
+- "Use the tool that matches your existing workflow unless a verified difference matters."
+
+Do not use this as reflexive contrarianism. The calming conclusion must be supported by actual evidence and scope.
+
+## 7. Stale product articles need aggressive freshness handling
+
+This source is especially useful because its product assumptions later became obsolete.
+
+For comparison/tutorial articles, treat these as high-decay fields:
+
+- model names;
+- release dates;
+- plan inclusion;
+- prices;
+- operating-system support;
+- interface labels;
+- installation paths;
+- tool forms (desktop/CLI/web/extensions);
+- benchmark leadership;
+- current recommendation;
+- "additional charge" claims;
+- time-to-completion promises.
+
+A past verified comparison must not silently become a current comparison.
+
+## 8. Do not preserve stale recommendations as doctrine
+
+The engine may learn the *shape*:
+
+```text
+reader state -> choice
+```
+
+It must not preserve historical assignments such as:
+
+```text
+reader state X -> Tool A
+reader state Y -> Tool B
+```
+
+Those mappings must be rebuilt from current evidence whenever the article is generated.
+
+## 9. Risky reference patterns for METEOR
+
+This source also contains patterns that should be attacked rather than copied:
+
+- "100%できます";
+- fixed completion-time guarantees;
+- "保証します";
+- sweeping "no need to learn code" claims;
+- product/model/version claims without fresh evidence;
+- comparison conclusions built from stale benchmark snapshots;
+- treating observed UI wording as durable product truth;
+- "latest" language that rapidly expires.
+
+## Candidate engine doctrine
+
+```text
+COMPARISON_MODE
+1. What decision is the reader actually trying to make?
+2. What can stay unchanged?
+3. What verified differences are material?
+4. What are the switching / learning / cost consequences?
+5. Which reader states map to which option under current evidence?
+6. Pick one execution path.
+7. Tutorial begins only after the decision is closed.
+```
+
+## BridgePatch implication
+
+This can later help BridgePatch articles that compare:
+
+- manual workflow vs small one-process tool;
+- full system replacement vs bounded automation;
+- "keep current process" vs "change one step".
+
+The useful message is not "automation wins." It is:
+
+```text
+if the current process is good enough, keep it
+if one repeated step is causing disproportionate friction, isolate that step
+only replace more when the evidence justifies it
+```
+
+That keeps the offer from turning into "everything should be automated" marketing.

--- a/x_article_engine/meteor_v09.py
+++ b/x_article_engine/meteor_v09.py
@@ -1,0 +1,569 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import depth_market as _v08
+from .core import XArticleEngineError
+
+
+FRESHNESS_MARKERS = (
+    "最新",
+    "現在",
+    "現時点",
+    "最新版",
+    "今の仕様",
+    "今使える",
+)
+
+DATED_EVIDENCE_RE = re.compile(
+    r"(?:20\d{2}[年/-](?:0?[1-9]|1[0-2])(?:[月/-](?:0?[1-9]|[12]\d|3[01])日?)?|"
+    r"20\d{2}年(?:0?[1-9]|1[0-2])月時点|"
+    r"20\d{2}年時点)"
+)
+
+WARNING_CONTEXT_MARKERS = (
+    "使わない",
+    "使用しない",
+    "しないで",
+    "禁止",
+    "避け",
+    "危険",
+    "やめ",
+    "ダメ",
+    "してはいけ",
+    "無効にしない",
+    "スキップしない",
+)
+
+UNSAFE_BYPASS_PATTERNS = (
+    re.compile(r"--dangerously-skip-permissions", re.I),
+    re.compile(r"(?:権限|確認|承認)[^。\n]{0,25}(?:スキップ|飛ば|省略)"),
+    re.compile(r"認証[^。\n]{0,20}(?:無効|なし|none)", re.I),
+    re.compile(r"サンドボックス[^。\n]{0,20}(?:無効|off)", re.I),
+)
+
+AUTOMATION_OVERREACH_PATTERNS = (
+    re.compile(r"ユーザーに質問せず[^。\n]{0,40}(?:全部|全て|すべて)?[^。\n]{0,20}自動"),
+    re.compile(r"(?:全部|全て|すべて)[^。\n]{0,20}自動で判断"),
+    re.compile(r"確認なしで[^。\n]{0,30}(?:実行|進め|操作)"),
+)
+
+SECRET_MARKERS = (
+    "APIキー",
+    "API key",
+    "シークレット",
+    "secret",
+    "アクセストークン",
+    "トークン",
+    "パスワード",
+    "認証情報",
+    "クレジットカード",
+)
+
+SECRET_TRANSFER_MARKERS = (
+    "貼り付け",
+    "貼って",
+    "送信",
+    "送って",
+    "渡して",
+    "コピペ",
+    "入力して",
+)
+
+AI_TARGET_MARKERS = (
+    "AI",
+    "Claude",
+    "ChatGPT",
+    "Codex",
+    "プロンプト",
+    "チャット",
+)
+
+CTA_MARKERS = (
+    "購入",
+    "申し込",
+    "参加",
+    "登録",
+    "友だち追加",
+    "フォロー",
+    "リプ",
+    "DM",
+    "無料相談",
+    "無料確認",
+    "無料適合確認",
+    "資料請求",
+)
+
+ABSOLUTE_FREE_MARKERS = (
+    "完全無料",
+    "ずっと無料",
+    "永久無料",
+)
+
+SUPERLATIVE_MARKERS = (
+    "世界一",
+    "唯一",
+    "最強",
+    "何でもでき",
+    "全部でき",
+)
+
+PROGRESS_SIGNAL_MARKERS = (
+    "成功",
+    "完了",
+    "表示されたら",
+    "表示されれば",
+    "確認してください",
+    "確認でき",
+    "できていれば",
+    "見えれば",
+)
+
+RECOVERY_MARKERS = (
+    "エラー",
+    "失敗",
+    "うまくいかな",
+    "困った",
+    "場合は",
+    "やり直",
+    "戻",
+    "停止",
+)
+
+RISK_FRONT_MARKERS = (
+    "警告",
+    "危険",
+    "リスク",
+    "対象外",
+    "進めない",
+    "使わないで",
+    "やめて",
+    "停止",
+)
+
+MITIGATION_MARKERS = (
+    "停止",
+    "戻",
+    "バックアップ",
+    "確認",
+    "権限",
+    "テスト",
+    "サンドボックス",
+    "対象外",
+    "人間",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _is_warning_context(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in WARNING_CONTEXT_MARKERS)
+
+
+def _commercial_text(packet: dict) -> str:
+    chunks = [packet.get("offer", ""), packet.get("cta", "")]
+    chunks.extend(
+        item.get("claim", "")
+        for item in packet.get("verified_evidence", [])
+        if item.get("kind") in {"COMMERCIAL", "TIMING", "SCOPE", "POLICY"}
+    )
+    return "\n".join(chunks)
+
+
+def _has_dated_evidence(packet: dict) -> bool:
+    for item in packet.get("verified_evidence", []):
+        if item.get("kind") == "TIMING":
+            return True
+        if DATED_EVIDENCE_RE.search(_norm(item.get("claim", ""))):
+            return True
+    return bool(packet.get("freshness", {}).get("as_of"))
+
+
+def _freshness_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    if not any(marker in normalized for marker in FRESHNESS_MARKERS):
+        return []
+    if _has_dated_evidence(packet):
+        return []
+    return [
+        {
+            "code": "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE",
+            "severity": "REVIEW",
+            "detail": "draft uses current/latest language but packet has no dated/timing evidence or as_of boundary",
+        }
+    ]
+
+
+def _unsafe_bypass_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_warning_context(sentence):
+            continue
+        for pattern in UNSAFE_BYPASS_PATTERNS:
+            if pattern.search(sentence):
+                findings.append(
+                    {
+                        "code": "UNSAFE_PERMISSION_OR_SECURITY_BYPASS",
+                        "severity": "BLOCK",
+                        "detail": sentence,
+                    }
+                )
+                break
+    return findings
+
+
+def _automation_overreach_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_warning_context(sentence):
+            continue
+        if any(pattern.search(sentence) for pattern in AUTOMATION_OVERREACH_PATTERNS):
+            findings.append(
+                {
+                    "code": "AUTOMATION_WITHOUT_HUMAN_CHECKPOINT",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _secret_transfer_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_warning_context(sentence):
+            continue
+        normalized = _norm(sentence)
+        if not any(marker.lower() in normalized.lower() for marker in SECRET_MARKERS):
+            continue
+        if not any(marker in normalized for marker in SECRET_TRANSFER_MARKERS):
+            continue
+        if not any(marker.lower() in normalized.lower() for marker in AI_TARGET_MARKERS):
+            continue
+        findings.append(
+            {
+                "code": "SECRET_TRANSFER_TO_MODEL_RISK",
+                "severity": "BLOCK",
+                "detail": sentence,
+            }
+        )
+    return findings
+
+
+def _multi_cta_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    present = sorted({marker for marker in CTA_MARKERS if marker in normalized})
+    if len(present) < 3:
+        return []
+    return [
+        {
+            "code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK",
+            "severity": "REVIEW",
+            "detail": ", ".join(present),
+        }
+    ]
+
+
+def _warning_fatigue_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    count = normalized.count("超重要") + normalized.count("警告")
+    if count < 6:
+        return []
+    return [
+        {
+            "code": "WARNING_FATIGUE_RISK",
+            "severity": "REVIEW",
+            "detail": f"strong warning markers repeated {count} times",
+        }
+    ]
+
+
+def _self_responsibility_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    if "自己責任" not in normalized:
+        return []
+    if any(marker in normalized for marker in MITIGATION_MARKERS):
+        return []
+    return [
+        {
+            "code": "SELF_RESPONSIBILITY_WITHOUT_MITIGATION",
+            "severity": "REVIEW",
+            "detail": "自己責任 appears without a concrete stop, recovery, permission, test, or mitigation path",
+        }
+    ]
+
+
+def _absolute_free_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    bound = _norm(_commercial_text(packet))
+    findings: list[dict] = []
+    for marker in ABSOLUTE_FREE_MARKERS:
+        if marker in normalized and marker not in bound:
+            findings.append(
+                {
+                    "code": "UNBOUND_ABSOLUTE_FREE_CLAIM",
+                    "severity": "BLOCK",
+                    "detail": marker,
+                }
+            )
+    return findings
+
+
+def _superlative_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    present = sorted({marker for marker in SUPERLATIVE_MARKERS if marker in normalized})
+    if not present:
+        return []
+    return [
+        {
+            "code": "SUPERLATIVE_OR_TOTALIZING_LANGUAGE",
+            "severity": "REVIEW",
+            "detail": ", ".join(present),
+        }
+    ]
+
+
+def _procedural_completion_findings(draft: str, packet: dict) -> list[dict]:
+    if packet.get("topic_mode") != "PROCEDURAL":
+        return []
+    normalized = _norm(draft)
+    step_count = len(re.findall(r"\bSTEP\s*\d+\b", normalized, flags=re.I))
+    if step_count < 3:
+        return []
+    findings: list[dict] = []
+    if not any(marker in normalized for marker in PROGRESS_SIGNAL_MARKERS):
+        findings.append(
+            {
+                "code": "PROCEDURE_WITHOUT_SUCCESS_SIGNAL",
+                "severity": "REVIEW",
+                "detail": f"{step_count} steps but no clear observable completion/success signal",
+            }
+        )
+    if not any(marker in normalized for marker in RECOVERY_MARKERS):
+        findings.append(
+            {
+                "code": "PROCEDURE_WITHOUT_RECOVERY_PATH",
+                "severity": "REVIEW",
+                "detail": f"{step_count} steps but no visible error/recovery path",
+            }
+        )
+    if "なぜ" not in normalized and "理由" not in normalized:
+        findings.append(
+            {
+                "code": "PROCEDURE_WITHOUT_WHY",
+                "severity": "REVIEW",
+                "detail": f"{step_count} steps but no rationale marker",
+            }
+        )
+    return findings
+
+
+def _risk_front_gate_findings(draft: str, packet: dict) -> list[dict]:
+    if packet.get("risk_policy", {}).get("risk_level") != "HIGH":
+        return []
+    front = _norm(draft)[:700]
+    if any(marker in front for marker in RISK_FRONT_MARKERS):
+        return []
+    return [
+        {
+            "code": "HIGH_RISK_WITHOUT_FRONT_STOP_GATE",
+            "severity": "BLOCK",
+            "detail": "high-risk guide begins procedural/persuasive content without a visible risk/stop boundary near the front",
+        }
+    ]
+
+
+def _semantic_attack_findings(draft: str, packet: dict) -> list[dict]:
+    return [
+        *_freshness_findings(draft, packet),
+        *_unsafe_bypass_findings(draft),
+        *_automation_overreach_findings(draft),
+        *_secret_transfer_findings(draft),
+        *_multi_cta_findings(draft),
+        *_warning_fatigue_findings(draft),
+        *_self_responsibility_findings(draft),
+        *_absolute_free_findings(draft, packet),
+        *_superlative_findings(draft),
+        *_procedural_completion_findings(draft, packet),
+        *_risk_front_gate_findings(draft, packet),
+    ]
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    """Synthesize v0.9 knowledge and METEOR hardening on top of v0.8."""
+    if not isinstance(source, dict):
+        raise XArticleEngineError("source must be an object")
+
+    risk_level = str(source.get("risk_level", "STANDARD")).strip().upper()
+    if risk_level not in {"STANDARD", "ELEVATED", "HIGH"}:
+        raise XArticleEngineError("risk_level must be STANDARD, ELEVATED, or HIGH")
+
+    freshness_mode = str(source.get("freshness_mode", "EVERGREEN")).strip().upper()
+    if freshness_mode not in {"EVERGREEN", "CURRENT", "UPDATE"}:
+        raise XArticleEngineError("freshness_mode must be EVERGREEN, CURRENT, or UPDATE")
+    as_of = source.get("as_of")
+    if freshness_mode in {"CURRENT", "UPDATE"} and (not isinstance(as_of, str) or not as_of.strip()):
+        raise XArticleEngineError("CURRENT/UPDATE articles require a non-empty as_of boundary")
+
+    packet = _v08.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-candidate"
+
+    packet["freshness"] = {
+        "mode": freshness_mode,
+        "as_of": as_of.strip() if isinstance(as_of, str) else None,
+        "rule": (
+            "Current product/platform instructions, prices, UI locations, model names, availability, limits, and comparisons decay. "
+            "Preserve an as-of boundary and re-verify them instead of reusing an old article's answer."
+        ),
+        "supersession_rule": (
+            "For UPDATE articles, say what changed, which old steps still survive, which old steps are obsolete, and whether an existing reader must migrate."
+        ),
+    }
+
+    packet["decision_then_path_policy"] = {
+        "principle": (
+            "Before a consequential choice, compare only the differences needed to decide. After a safe choice is made, collapse the tutorial to one main path."
+        ),
+        "pre_decision": "Show material trade-offs, scope, reader fit, and migration cost when they affect the choice.",
+        "post_decision": "Do not keep reopening alternatives inside a zero-to-first-success path unless a new material risk appears.",
+        "anti_overchoice": "Do not hand a beginner a menu of equivalent methods when the article can safely recommend one default.",
+        "anti_hidden_tradeoff": "Do not hide an important risk or limitation merely to preserve a one-path experience.",
+    }
+
+    packet["completion_design_policy"] = {
+        "step_schema": ["GOAL", "ACTION", "EXPECTED_SIGNAL", "RECOVERY", "WHY_WHEN_NEEDED"],
+        "progress_rule": "Show where the reader is, what success looks like, and what remains when the procedure is long.",
+        "micro_completion_rule": "Use real completion signals and small wins, not fake gamification or praise disconnected from an observable result.",
+        "first_real_win_rule": "After setup, move quickly to one small meaningful use so the reader experiences capability rather than merely installation.",
+    }
+
+    packet["risk_policy"] = {
+        "risk_level": risk_level,
+        "front_gate_rule": (
+            "For HIGH-risk material, state the meaningful risk, who should not proceed, and the stop/safer path before operational instructions."
+        ),
+        "minimum_safe_path": [
+            "scope/exclusion before action",
+            "least-privilege or smallest safe test where applicable",
+            "observable confirmation",
+            "human checkpoint for permissions, secrets, irreversible actions, and high-impact judgment",
+            "stop/recovery path before or next to the dangerous step",
+        ],
+        "anti_disclaimer_rule": "A disclaimer or 自己責任 sentence is not a substitute for concrete mitigation.",
+        "safety_asset_rule": "Safety-critical information may not be hidden behind registration, payment, or another CTA.",
+    }
+
+    packet["human_automation_boundary"] = {
+        "human_only_or_human_confirmed": [
+            "sharing or entering secrets/credentials into a model",
+            "permission expansion or security-control bypass",
+            "irreversible/high-impact actions",
+            "final high-risk judgment",
+            "publication authority",
+        ],
+        "good_automation_candidates": [
+            "bounded transformation",
+            "repetitive setup with verified inputs and observable outputs",
+            "checks that can fail closed",
+            "drafting where a human retains final judgment",
+        ],
+        "rule": (
+            "Automation should reduce repetitive work without erasing the point where a human must authorize, verify, stop, or recover."
+        ),
+    }
+
+    packet["pain_to_promise_policy"] = {
+        "principle": (
+            "When the writer has an attested frustration or failure, let the article promise directly answer that friction. "
+            "Do not turn that promise into an unverified guarantee."
+        ),
+        "mapping": "reader/writer friction -> concrete promise -> mechanism -> evidence/conditions -> next action",
+    }
+
+    packet["article_component_roles"] = {
+        "title_and_feed_preview": "earn the tap without an unbound outcome promise",
+        "opening": "make the intended reader's reason to continue legible using evidence or attested experience",
+        "body": "create understanding, usable progress, and decision logic",
+        "cta": "offer one coherent continuation rather than retrofitting an unrelated promotion",
+        "status": "heuristic, not a rigid universal template",
+    }
+
+    packet["knowledge_conflict_rules"] = [
+        "Specificity never overrides evidence binding.",
+        "Beginner simplicity never hides a material trade-off or risk.",
+        "One-path guidance begins after a necessary decision, not before it.",
+        "Long-form depth never justifies padding.",
+        "Strong voice never authorizes fabricated certainty, biography, or guarantees.",
+        "A useful desire peak never authorizes fake scarcity, fear, or multiple competing commercial actions.",
+        "Currentness never survives its evidence date automatically; re-verify time-sensitive claims.",
+        "Safety information outranks CTA optimization.",
+        "Human authorization outranks automation convenience.",
+    ]
+
+    packet["generation_constraints"].extend(
+        [
+            "For time-sensitive product/platform claims, state or preserve an as-of boundary and re-verify currentness; do not recycle an old article's model names, prices, UI, availability, limits, or recommended path as timeless truth.",
+            "When a reader must choose between materially different paths, compare only the differences needed for the decision; after the choice, use one primary path to first success unless a material risk requires branching.",
+            "For procedural articles, pair important actions with an observable success signal and a nearby recovery path; explain WHY where it affects judgment, safety, transfer, or troubleshooting.",
+            "Do not instruct readers to bypass permission/security controls merely to reduce friction. Do not tell them to paste secrets or credentials into a model/chat as a normal workflow.",
+            "Do not use 自己責任, disclaimers, or fear language as substitutes for concrete mitigation, stop conditions, least-privilege handling, or recovery.",
+            "For high-risk tutorials, put the risk/stop boundary before operational steps and give an easier/safer alternative when appropriate.",
+            "Do not hide safety-critical instructions behind a LINE signup, paid download, bonus, or other CTA.",
+            "A CTA may appear at the next predictable wall, but it must remain a continuation of the article and must not compete with multiple follow/register/reply/buy actions.",
+            "If a strong frustration or failure defines the article, make the article promise answer that frustration directly without upgrading it into an absolute completion or outcome guarantee.",
+            "Treat superlatives such as 世界一, 唯一, 最強, 何でも, or 全部 as claims/opinions that need human judgment and, when factual, evidence; they are not default style tokens.",
+        ]
+    )
+
+    packet["human_gate"]["checks"].extend(
+        [
+            "If this article says 最新・現在・現時点, what dated evidence or as-of boundary makes that true now?",
+            "Did I accidentally reuse an old product comparison, UI path, plan, price, model, or recommendation after the product changed?",
+            "Before a beginner path becomes one-way, did I expose the material choice/risk that actually needed a decision?",
+            "For each important procedure, can the reader tell what success looks like and what to do if it does not happen?",
+            "Did any instruction ask the reader to bypass permissions, weaken security, or give a secret/credential to an AI model for convenience?",
+            "If I wrote 自己責任 or a warning, did I also give concrete mitigation, a stop condition, and a recovery path?",
+            "Is any safety-critical information being withheld until after signup/payment/CTA? If yes, move it into the article.",
+            "How many different commercial actions does the draft ask for? Can they be reduced to the single intended next step?",
+            "Does the CTA appear at a real next wall created by the article, or was a wall manufactured to justify the CTA?",
+            "Did the writer's pain shape the article promise without becoming an unsupported guarantee?",
+            "Does automation stop where a human must authorize, verify, judge, or recover?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    """Run v0.8 audits plus v0.9 METEOR attack heuristics."""
+    result = _v08.audit_draft(draft, packet)
+    findings = [*result.get("findings", []), *_semantic_attack_findings(draft, packet)]
+
+    # De-duplicate identical findings from stacked gates.
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_final.py
+++ b/x_article_engine/meteor_v09_final.py
@@ -1,0 +1,433 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import meteor_v09 as _round1
+from .core import XArticleEngineError
+
+
+DATE_RE = re.compile(
+    r"(?:20\d{2}[年/-](?:0?[1-9]|1[0-2])(?:[月/-](?:0?[1-9]|[12]\d|3[01])日?)?|"
+    r"20\d{2}年(?:0?[1-9]|1[0-2])月時点|20\d{2}年時点)"
+)
+
+NEGATION_OR_WARNING = (
+    "使わない",
+    "使用しない",
+    "しない",
+    "しないで",
+    "ないで",
+    "ないでください",
+    "禁止",
+    "避け",
+    "危険",
+    "やめ",
+    "ダメ",
+    "してはいけ",
+    "無効にしない",
+    "スキップしない",
+    "共有しない",
+    "渡さない",
+    "貼り付けない",
+)
+
+IMPERATIVE_SAFETY_MARKERS = (
+    "確認してください",
+    "確認する",
+    "共有しない",
+    "渡さない",
+    "貼り付けない",
+    "停止してください",
+    "停止する",
+    "戻してください",
+    "戻す",
+    "守って",
+    "守る",
+    "禁止",
+    "対象外",
+    "使わない",
+    "しないで",
+)
+
+OUTCOME_OR_PROMISE_MARKERS = (
+    "できる",
+    "できます",
+    "終わる",
+    "終わります",
+    "完了",
+    "成功",
+    "売れる",
+    "伸びる",
+    "稼げる",
+    "増える",
+    "安全です",
+    "大丈夫",
+    "保証",
+    "無料",
+    "追加料金",
+    "返金",
+)
+
+SECRET_RE = re.compile(
+    r"(?:API\s*キー|API\s*key|シークレット|secret|アクセストークン|トークン|パスワード|認証情報|クレジットカード)",
+    re.I,
+)
+
+MODEL_DESTINATION_RE = re.compile(
+    r"(?:(?:AI|Claude|ChatGPT|Codex)(?:に|へ)|プロンプト|チャット|会話|メッセージ)",
+    re.I,
+)
+
+TRANSFER_RE = re.compile(r"(?:貼り付け|貼って|送信|送って|渡して|コピペ|入力して)")
+
+UNSAFE_ACTION_PATTERNS = (
+    re.compile(r"--dangerously-skip-permissions", re.I),
+    re.compile(r"(?:権限|確認|承認)[^。\n]{0,25}(?:スキップ|飛ば|省略)[^。\n]{0,20}(?:して|する|してください|で進)"),
+    re.compile(r"認証[^。\n]{0,18}(?:無効|none|なし)[^。\n]{0,18}(?:にして|に設定|を選|で進)", re.I),
+    re.compile(r"サンドボックス[^。\n]{0,18}(?:無効|off)[^。\n]{0,18}(?:にして|に設定|で進)", re.I),
+)
+
+CTA_ACTION_PATTERNS = {
+    "purchase": re.compile(r"購入(?:して|する|はこちら|できます|へ)"),
+    "apply": re.compile(r"申し込(?:んで|む|み|はこちら|めます)"),
+    "join": re.compile(r"参加(?:して|する|はこちら|できます|へ)"),
+    "register": re.compile(r"登録(?:して|する|はこちら|できます|へ)"),
+    "add_friend": re.compile(r"友だち追加(?:して|する|はこちら|へ)"),
+    "follow": re.compile(r"フォロー(?:して|する|お願いします|してください)"),
+    "reply": re.compile(r"リプ(?:して|する|してください|ください)"),
+    "dm": re.compile(r"DM(?:して|する|ください|してください)"),
+    "consult": re.compile(r"無料相談(?:して|する|はこちら|へ)"),
+    "fit_check": re.compile(r"無料適合確認(?:を使|はこちら|へ|して)"),
+    "request": re.compile(r"資料請求(?:して|する|はこちら|へ)"),
+}
+
+GUARANTEE_RE = re.compile(r"(?:保証します|保証できます|保証する|確実にできます|確実に終わります)")
+ABSOLUTE_SAFETY_RE = re.compile(r"(?:完全に安全|絶対安全|安全です|安心です)")
+OUTCOME_PROMISE_RE = re.compile(r"(?:売れます|売れるようになります|必ず伸びる|伸びます|稼げます|稼げるようになります)")
+
+STEP_RE = re.compile(r"(?:\bSTEP\s*[0-9０-９]+\b|ステップ\s*[0-9０-９一二三四五六七八九十]+|手順\s*[0-9０-９一二三四五六七八九十]+)", re.I)
+
+SUCCESS_MARKERS = (
+    "成功",
+    "完了",
+    "表示されたら",
+    "表示されれば",
+    "確認してください",
+    "確認でき",
+    "できていれば",
+    "見えれば",
+    "表示されます",
+)
+
+RECOVERY_MARKERS = (
+    "エラー",
+    "失敗",
+    "うまくいかな",
+    "困った",
+    "場合は",
+    "やり直",
+    "戻",
+    "停止",
+    "再試行",
+)
+
+LOCAL_MITIGATION_MARKERS = (
+    "停止",
+    "戻",
+    "バックアップ",
+    "確認",
+    "権限",
+    "テスト",
+    "サンドボックス",
+    "対象外",
+    "人間",
+    "復旧",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _is_negative_or_warning(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in NEGATION_OR_WARNING)
+
+
+def _has_verified_dated_evidence(packet: dict) -> bool:
+    for item in packet.get("verified_evidence", []):
+        if item.get("kind") == "TIMING":
+            return True
+        if DATE_RE.search(_norm(item.get("claim", ""))):
+            return True
+    return False
+
+
+def _only_safety_imperative_usage(draft: str, marker: str) -> bool:
+    matched = [sentence for sentence in _sentences(draft) if marker in sentence]
+    if not matched:
+        return False
+    for sentence in matched:
+        if any(item in sentence for item in OUTCOME_OR_PROMISE_MARKERS):
+            return False
+        if not any(item in sentence for item in IMPERATIVE_SAFETY_MARKERS):
+            return False
+    return True
+
+
+def _refined_secret_findings(draft: str) -> list[dict]:
+    findings = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if SECRET_RE.search(sentence) and TRANSFER_RE.search(sentence) and MODEL_DESTINATION_RE.search(sentence):
+            findings.append(
+                {
+                    "code": "SECRET_TRANSFER_TO_MODEL_RISK",
+                    "severity": "BLOCK",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _refined_bypass_findings(draft: str) -> list[dict]:
+    findings = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if any(pattern.search(sentence) for pattern in UNSAFE_ACTION_PATTERNS):
+            findings.append(
+                {
+                    "code": "UNSAFE_PERMISSION_OR_SECURITY_BYPASS",
+                    "severity": "BLOCK",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _refined_cta_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    present = sorted(name for name, pattern in CTA_ACTION_PATTERNS.items() if pattern.search(normalized))
+    if len(present) < 2:
+        return []
+    return [
+        {
+            "code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK",
+            "severity": "REVIEW",
+            "detail": ", ".join(present),
+        }
+    ]
+
+
+def _guarantee_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    commercial = _norm(
+        "\n".join(
+            [packet.get("offer", ""), packet.get("cta", "")]
+            + [
+                item.get("claim", "")
+                for item in packet.get("verified_evidence", [])
+                if item.get("kind") in {"COMMERCIAL", "POLICY", "SCOPE", "TIMING"}
+            ]
+        )
+    )
+    findings = []
+    for match in GUARANTEE_RE.finditer(normalized):
+        phrase = match.group(0)
+        if phrase not in commercial:
+            findings.append(
+                {
+                    "code": "UNBOUND_GUARANTEE_LANGUAGE",
+                    "severity": "BLOCK",
+                    "detail": phrase,
+                }
+            )
+    return findings
+
+
+def _safety_language_findings(draft: str) -> list[dict]:
+    findings = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if ABSOLUTE_SAFETY_RE.search(sentence):
+            findings.append(
+                {
+                    "code": "ABSOLUTE_SAFETY_LANGUAGE",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _outcome_promise_findings(draft: str) -> list[dict]:
+    findings = []
+    for sentence in _sentences(draft):
+        if OUTCOME_PROMISE_RE.search(sentence):
+            findings.append(
+                {
+                    "code": "OUTCOME_PROMISE_LANGUAGE",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _local_self_responsibility_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    findings = []
+    for match in re.finditer("自己責任", normalized):
+        start = max(0, match.start() - 220)
+        end = min(len(normalized), match.end() + 220)
+        window = normalized[start:end]
+        if not any(marker in window for marker in LOCAL_MITIGATION_MARKERS):
+            findings.append(
+                {
+                    "code": "SELF_RESPONSIBILITY_WITHOUT_MITIGATION",
+                    "severity": "REVIEW",
+                    "detail": window[:180],
+                }
+            )
+    return findings
+
+
+def _refined_procedure_findings(draft: str, packet: dict) -> list[dict]:
+    if packet.get("topic_mode") != "PROCEDURAL":
+        return []
+    normalized = _norm(draft)
+    step_count = len(STEP_RE.findall(normalized))
+    if step_count < 3:
+        return []
+    findings = []
+    if not any(marker in normalized for marker in SUCCESS_MARKERS):
+        findings.append(
+            {
+                "code": "PROCEDURE_WITHOUT_SUCCESS_SIGNAL",
+                "severity": "REVIEW",
+                "detail": f"{step_count} steps but no clear observable completion/success signal",
+            }
+        )
+    if not any(marker in normalized for marker in RECOVERY_MARKERS):
+        findings.append(
+            {
+                "code": "PROCEDURE_WITHOUT_RECOVERY_PATH",
+                "severity": "REVIEW",
+                "detail": f"{step_count} steps but no visible error/recovery path",
+            }
+        )
+    if "なぜ" not in normalized and "理由" not in normalized:
+        findings.append(
+            {
+                "code": "PROCEDURE_WITHOUT_WHY",
+                "severity": "REVIEW",
+                "detail": f"{step_count} steps but no rationale marker",
+            }
+        )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _round1.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+
+    freshness_mode = packet.get("freshness", {}).get("mode", "EVERGREEN")
+    if freshness_mode in {"CURRENT", "UPDATE"} and not _has_verified_dated_evidence(packet):
+        raise XArticleEngineError(
+            "CURRENT/UPDATE articles require verified dated/TIMING evidence; as_of alone does not establish current truth"
+        )
+
+    packet["schema_version"] = "0.9-meteor"
+    packet["freshness"]["evidence_rule"] = (
+        "as_of is only a scope label. It never makes a claim current by itself; CURRENT/UPDATE mode also requires verified dated/TIMING evidence."
+    )
+    packet["knowledge_conflict_rules"].extend(
+        [
+            "Safety imperatives such as '必ず確認する' are not commercial guarantees; do not over-sanitize necessary safety language.",
+            "Mentioning a dangerous option in order to forbid it must not be mistaken for recommending it.",
+            "Source/reference links are not commercial CTAs; CTA review should look for reader action requests rather than raw URL count.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "Is as_of backed by dated verified evidence, or is it merely a date label attached to an unverified current claim?",
+            "Did the safety checker mistake a prohibition ('do not share the API key') for an instruction to do the dangerous thing?",
+            "Did a necessary safety imperative such as '必ず確認してください' get flattened because it contains strong wording?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _round1.audit_draft(draft, packet)
+
+    filtered = []
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        # Round-1 CTA detector intentionally used broad tokens; replace it with action-shaped detection.
+        if code == "MULTIPLE_COMMERCIAL_ACTIONS_RISK":
+            continue
+
+        # Round-1 secret/bypass detectors can see a forbidden string inside a warning. Recompute below.
+        if code in {"SECRET_TRANSFER_TO_MODEL_RISK", "UNSAFE_PERMISSION_OR_SECURITY_BYPASS"}:
+            if _is_negative_or_warning(detail):
+                continue
+            # Recomputed below with tighter patterns, so drop all round-1 copies to avoid stale false positives.
+            continue
+
+        # Round-1 self-responsibility check is article-global; replace with a local mitigation window.
+        if code == "SELF_RESPONSIBILITY_WITHOUT_MITIGATION":
+            continue
+
+        # v0.2 treated every 必ず/絶対 token as a commercial strengthening. Keep the block only for outcome/promise use.
+        if code == "UNBOUND_STRONG_CLAIM" and detail in {"必ず", "絶対"}:
+            if _only_safety_imperative_usage(draft, detail):
+                continue
+
+        # Round-1 procedure detector only recognized STEP; replace with broader Japanese/English detection.
+        if code in {"PROCEDURE_WITHOUT_SUCCESS_SIGNAL", "PROCEDURE_WITHOUT_RECOVERY_PATH", "PROCEDURE_WITHOUT_WHY"}:
+            continue
+
+        filtered.append(item)
+
+    findings = [
+        *filtered,
+        *_refined_secret_findings(draft),
+        *_refined_bypass_findings(draft),
+        *_refined_cta_findings(draft),
+        *_guarantee_findings(draft, packet),
+        *_safety_language_findings(draft),
+        *_outcome_promise_findings(draft),
+        *_local_self_responsibility_findings(draft),
+        *_refined_procedure_findings(draft, packet),
+    ]
+
+    deduped = []
+    seen = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_gate.py
+++ b/x_article_engine/meteor_v09_gate.py
@@ -1,0 +1,255 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import meteor_v09_final as _round2
+from .core import XArticleEngineError
+
+
+FRESHNESS_MARKERS = (
+    "最新",
+    "現在",
+    "現時点",
+    "最新版",
+    "今の仕様",
+    "今使える",
+)
+
+DATE_RE = re.compile(
+    r"(?:20\d{2}[年/-](?:0?[1-9]|1[0-2])(?:[月/-](?:0?[1-9]|[12]\d|3[01])日?)?|"
+    r"20\d{2}年(?:0?[1-9]|1[0-2])月時点|20\d{2}年時点)"
+)
+
+OUTCOME_CONTEXT = (
+    "できます",
+    "できる",
+    "終わります",
+    "終わる",
+    "完了",
+    "成功",
+    "売れ",
+    "伸び",
+    "稼げ",
+    "増え",
+    "安全",
+    "大丈夫",
+    "保証",
+    "無料",
+    "返金",
+    "追加料金",
+)
+
+UNIVERSAL_CAPABILITY_RE = re.compile(
+    r"(?:誰でも|全員|どんな人でも|初心者でも)[^。\n]{0,35}(?:できます|できる|使えます|使える|完了できます)"
+)
+
+HARDCODED_SECRET_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b", re.I)
+HARDCODED_SECRET_USE_RE = re.compile(r"(?:API\s*キー|key|認証)[^。\n]{0,50}(?:sk-[A-Za-z0-9_-]{8,})[^。\n]{0,40}(?:使|入力|設定|このまま)", re.I)
+
+PLATFORM_EVASION_MARKERS = (
+    "BAN回避",
+    "BAN対策",
+    "ステルス配信",
+    "判定を回避",
+    "検知を回避",
+    "規制を回避",
+    "ゼロ幅文字",
+)
+
+RISK_EVIDENCE_KINDS = {"RISK", "SAFETY", "POLICY"}
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _has_dated_verified_evidence(packet: dict) -> bool:
+    return any(
+        item.get("kind") == "TIMING" or DATE_RE.search(_norm(item.get("claim", "")))
+        for item in packet.get("verified_evidence", [])
+    )
+
+
+def _has_risk_evidence(packet: dict) -> bool:
+    return any(item.get("kind") in RISK_EVIDENCE_KINDS for item in packet.get("verified_evidence", []))
+
+
+def _strict_freshness_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    if not any(marker in normalized for marker in FRESHNESS_MARKERS):
+        return []
+    if _has_dated_verified_evidence(packet):
+        return []
+    return [
+        {
+            "code": "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE",
+            "severity": "REVIEW",
+            "detail": "current/latest wording requires dated verified evidence; an as_of label alone is not evidence",
+        }
+    ]
+
+
+def _absolute_generalization_findings(draft: str, suppressed_markers: set[str]) -> list[dict]:
+    findings = []
+    for marker in suppressed_markers:
+        for sentence in _sentences(draft):
+            if marker not in sentence:
+                continue
+            if any(context in sentence for context in OUTCOME_CONTEXT):
+                continue
+            findings.append(
+                {
+                    "code": "ABSOLUTE_GENERALIZATION_LANGUAGE",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _universal_capability_findings(draft: str) -> list[dict]:
+    return [
+        {
+            "code": "UNIVERSAL_CAPABILITY_PROMISE",
+            "severity": "REVIEW",
+            "detail": match.group(0),
+        }
+        for match in UNIVERSAL_CAPABILITY_RE.finditer(_norm(draft))
+    ]
+
+
+def _hardcoded_secret_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    findings = []
+    for sentence in _sentences(normalized):
+        if not HARDCODED_SECRET_RE.search(sentence):
+            continue
+        if any(token in sentence for token in ("例", "ダミー", "placeholder", "プレースホルダー", "使わない", "禁止")):
+            continue
+        if HARDCODED_SECRET_USE_RE.search(sentence):
+            findings.append(
+                {
+                    "code": "HARDCODED_SECRET_LITERAL_RISK",
+                    "severity": "BLOCK",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def _platform_evasion_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    present = sorted({marker for marker in PLATFORM_EVASION_MARKERS if marker in normalized})
+    if not present:
+        return []
+    return [
+        {
+            "code": "PLATFORM_EVASION_LANGUAGE",
+            "severity": "REVIEW",
+            "detail": ", ".join(present),
+        }
+    ]
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _round2.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+
+    if packet.get("risk_policy", {}).get("risk_level") == "HIGH" and not _has_risk_evidence(packet):
+        raise XArticleEngineError(
+            "HIGH-risk articles require at least one verified RISK/SAFETY/POLICY evidence claim; warning tone alone is not evidence"
+        )
+
+    packet["schema_version"] = "0.9-meteor-r3"
+    packet["risk_policy"]["evidence_rule"] = (
+        "HIGH-risk mode requires verified RISK/SAFETY/POLICY evidence. The engine may simplify verified risk, but may not invent a scary scenario to justify a stop gate."
+    )
+    packet["strong_language_policy"] = {
+        "outcome_absolute": "BLOCK when unbound: e.g. 必ずできます / 絶対成功 / guaranteed completion.",
+        "general_absolute": "REVIEW: e.g. everyone will hit this wall; do not silently convert a broad prediction into fact.",
+        "safety_imperative": "ALLOW when it is genuinely protective: e.g. APIキーは絶対に共有しない / 権限は必ず確認する.",
+    }
+    packet["security_content_policy"] = {
+        "hardcoded_secret_rule": "Do not normalize a reusable secret literal as a default credential or API key in a public tutorial.",
+        "platform_evasion_rule": (
+            "Language about BAN evasion, stealth sending, detection avoidance, or similar platform-evasion tactics requires human review and policy/terms verification; do not inherit it as a growth best practice."
+        ),
+    }
+    packet["generation_constraints"].extend(
+        [
+            "Classify 必ず/絶対 by meaning: unbound outcome guarantees block; broad predictions require review; genuine safety prohibitions may stay strong.",
+            "Do not use a reusable hard-coded secret/API key as the normal public setup path.",
+            "Do not turn BAN evasion, stealth sending, detection avoidance, or similar platform-evasion tactics into default marketing optimization doctrine.",
+            "In HIGH-risk mode, risk claims themselves must come from verified RISK/SAFETY/POLICY evidence; warning intensity is not evidence.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "Is a strong 必ず/絶対 sentence an outcome guarantee, a broad prediction, or a necessary safety prohibition?",
+            "Does any tutorial publish a reusable secret literal or encourage a predictable default credential?",
+            "Does any growth/safety advice rely on platform-evasion behavior rather than compliant operation?",
+            "For HIGH-risk content, which verified evidence supports the actual risk being described?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _round2.audit_draft(draft, packet)
+
+    filtered = []
+    downgraded_absolute_markers: set[str] = set()
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        # Recompute freshness using evidence only; round 1 could treat as_of as if it were evidence.
+        if code == "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE":
+            continue
+
+        # v0.2's lexical 必ず/絶対 block is too broad. Keep true outcome promises blocked,
+        # let round 2 suppress safety imperatives, and downgrade other broad uses to REVIEW.
+        if code == "UNBOUND_STRONG_CLAIM" and detail in {"必ず", "絶対"}:
+            matching_sentences = [sentence for sentence in _sentences(draft) if detail in sentence]
+            if matching_sentences and not any(
+                any(context in sentence for context in OUTCOME_CONTEXT)
+                for sentence in matching_sentences
+            ):
+                downgraded_absolute_markers.add(detail)
+                continue
+
+        filtered.append(item)
+
+    findings = [
+        *filtered,
+        *_strict_freshness_findings(draft, packet),
+        *_absolute_generalization_findings(draft, downgraded_absolute_markers),
+        *_universal_capability_findings(draft),
+        *_hardcoded_secret_findings(draft),
+        *_platform_evasion_findings(draft),
+    ]
+
+    deduped = []
+    seen = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r10.py
+++ b/x_article_engine/meteor_v09_r10.py
@@ -1,0 +1,168 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import meteor_v09_r9 as _r9
+from . import core as _core
+
+
+NUMERIC_COMPONENT_CLASS = r"0-9一二三四五六七八九十百千万億兆,.，．"
+
+META_REJECTION_MARKERS = (
+    "と書くのはやめ",
+    "と書かない",
+    "とは書かない",
+    "という表現は使わない",
+    "という表現は使いません",
+    "という言い方は使わない",
+    "という言い方は使いません",
+    "という断言はしない",
+    "という断言はしません",
+    "と断言するのはやめ",
+    "は危険な表現",
+    "をAIに作らせてはいけません",
+    "をAIに作らせてはいけない",
+    "を捏造してはいけません",
+    "を捏造してはいけない",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _is_meta_rejection(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in META_REJECTION_MARKERS)
+
+
+def _token_only_in_meta_rejection(draft: str, token: str) -> bool:
+    normalized_token = _norm(token)
+    matches = [sentence for sentence in _sentences(draft) if normalized_token in sentence]
+    return bool(matches) and all(_is_meta_rejection(sentence) for sentence in matches)
+
+
+def _exact_numeric_bound(token: str, packet: dict) -> bool:
+    normalized_token = _norm(token)
+    corpus = _norm(_core._bound_corpus(packet))
+    pattern = re.compile(
+        rf"(?<![{NUMERIC_COMPONENT_CLASS}]){re.escape(normalized_token)}(?![{NUMERIC_COMPONENT_CLASS}])"
+    )
+    return bool(pattern.search(corpus))
+
+
+def _numeric_binding_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    findings: list[dict] = []
+    seen: set[str] = set()
+    for match in _core.NUMERIC_RE.finditer(normalized):
+        token = _core._canonical_numeric(match.group(0), packet)
+        if token in seen:
+            continue
+        seen.add(token)
+        if _token_only_in_meta_rejection(draft, token):
+            continue
+        if not _exact_numeric_bound(token, packet):
+            findings.append(
+                {
+                    "code": "UNBOUND_NUMERIC_CLAIM",
+                    "severity": "BLOCK",
+                    "detail": token,
+                    "meteor_note": "numeric evidence requires a numeric-token boundary match; substring binding is not sufficient",
+                }
+            )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _r9.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r10"
+    packet["numeric_binding_policy"] = {
+        "principle": "Numeric evidence must match at numeric-token boundaries. A shorter number cannot borrow authority by being a substring of a larger verified number.",
+        "examples": [
+            "10,000円 does not bind 0円",
+            "15分 does not bind 5分",
+            "100人 does not bind 0人",
+        ],
+    }
+    packet["meta_rejection_policy"] = {
+        "principle": "A dangerous claim shown only as an example of wording the author rejects is not itself an asserted claim.",
+        "examples": [
+            "『30分で終わります』と書くのはやめます -> not a duration promise",
+            "『100%できます』という表現は使いません -> not an outcome claim",
+            "invented first-person biography shown only as something AI must not fabricate -> not asserted biography",
+        ],
+    }
+    packet["generation_constraints"].extend(
+        [
+            "Never authorize a numeric claim merely because its digits are a substring of a larger verified number.",
+            "When a risky sentence is shown only as wording to reject/avoid, audit its polarity before treating it as an asserted claim.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "数字の根拠が部分一致になっていないか？10,000円の証拠で0円を通すような誤結合がないか？",
+            "悪い文章例として引用して否定している断言を、本文の主張として誤認していないか？",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _r9.audit_draft(draft, packet)
+    findings: list[dict] = []
+
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        # Recompute all numeric claims with exact numeric-token boundaries below.
+        if code == "UNBOUND_NUMERIC_CLAIM":
+            continue
+
+        if code in {
+            "UNBOUND_STRONG_CLAIM",
+            "UNBOUND_IDENTITY_DETAIL",
+            "UNBOUND_GUARANTEE_LANGUAGE",
+            "ABSOLUTE_SAFETY_LANGUAGE",
+            "OUTCOME_PROMISE_LANGUAGE",
+            "UNIVERSAL_CAPABILITY_PROMISE",
+            "SUPERLATIVE_OR_TOTALIZING_LANGUAGE",
+        }:
+            if detail and _token_only_in_meta_rejection(draft, detail):
+                continue
+            if not detail:
+                continue
+            matching = [sentence for sentence in _sentences(draft) if detail in sentence]
+            if matching and all(_is_meta_rejection(sentence) for sentence in matching):
+                continue
+
+        findings.append(item)
+
+    findings.extend(_numeric_binding_findings(draft, packet))
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r11.py
+++ b/x_article_engine/meteor_v09_r11.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+
+from . import meteor_v09_r10 as _r10
+from . import core as _core
+
+
+COMMERCIAL_KINDS = {"COMMERCIAL"}
+RESULT_KINDS = {"RESULT", "CASE_RESULT"}
+TIMING_KINDS = {"TIMING"}
+
+COMMERCIAL_MARKERS = (
+    "価格",
+    "料金",
+    "税込",
+    "月額",
+    "費用",
+    "設計書",
+    "購入",
+    "支払",
+    "標準",
+    "追加料金",
+)
+
+RESULT_MARKERS = (
+    "売上",
+    "売れ",
+    "節約",
+    "削減",
+    "短縮",
+    "増え",
+    "減った",
+    "減りました",
+    "実績",
+    "成果",
+    "顧客",
+    "フォロワー",
+    "リスト",
+    "獲得",
+    "作業時間",
+)
+
+TIMING_MARKERS = (
+    "営業日",
+    "納期",
+    "納品",
+    "以内",
+    "までに",
+    "目安",
+)
+
+
+def _numeric_contexts(sentence: str) -> set[str]:
+    contexts: set[str] = set()
+    if any(marker in sentence for marker in COMMERCIAL_MARKERS):
+        contexts.add("COMMERCIAL")
+    if any(marker in sentence for marker in RESULT_MARKERS):
+        contexts.add("RESULT")
+    if any(marker in sentence for marker in TIMING_MARKERS):
+        contexts.add("TIMING")
+    return contexts
+
+
+def _evidence_contexts_for_numeric(token: str, packet: dict) -> set[str]:
+    contexts: set[str] = set()
+    for item in packet.get("verified_evidence", []):
+        claim = str(item.get("claim", ""))
+        if not _r10._exact_numeric_bound(token, {**packet, "verified_primary_info": [], "offer": "", "target": "", "pain": "", "verified_evidence": [item]}):
+            continue
+        kind = item.get("kind")
+        if kind in COMMERCIAL_KINDS:
+            contexts.add("COMMERCIAL")
+        if kind in RESULT_KINDS:
+            contexts.add("RESULT")
+        if kind in TIMING_KINDS:
+            contexts.add("TIMING")
+    return contexts
+
+
+def _primary_context_bound(token: str, packet: dict) -> bool:
+    for item in packet.get("verified_primary_info", []):
+        claim = str(item.get("claim", ""))
+        # Use the same numeric-token boundary rule against this single primary claim.
+        temp = {
+            **packet,
+            "offer": "",
+            "target": "",
+            "pain": "",
+            "verified_evidence": [],
+            "verified_primary_info": [item],
+        }
+        if _r10._exact_numeric_bound(token, temp):
+            return True
+    return False
+
+
+def _context_laundering_findings(draft: str, packet: dict) -> list[dict]:
+    findings: list[dict] = []
+    normalized = _r10._norm(draft)
+    seen: set[tuple[str, str]] = set()
+
+    for sentence in _r10._sentences(normalized):
+        if _r10._is_meta_rejection(sentence):
+            continue
+        for match in _core.NUMERIC_RE.finditer(sentence):
+            token = _core._canonical_numeric(match.group(0), packet)
+            if not _r10._exact_numeric_bound(token, packet):
+                continue
+            if _primary_context_bound(token, packet):
+                # First-person/lived numeric material can carry context that does not fit commercial/result/timing buckets.
+                continue
+
+            draft_contexts = _numeric_contexts(sentence)
+            if not draft_contexts:
+                continue
+            evidence_contexts = _evidence_contexts_for_numeric(token, packet)
+            if not evidence_contexts:
+                continue
+            if draft_contexts.intersection(evidence_contexts):
+                continue
+
+            key = (token, sentence)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                {
+                    "code": "NUMERIC_CONTEXT_REUSE_RISK",
+                    "severity": "REVIEW",
+                    "detail": token,
+                    "draft_context": sorted(draft_contexts),
+                    "evidence_context": sorted(evidence_contexts),
+                    "sentence": sentence,
+                }
+            )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _r10.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r11"
+    packet["numeric_context_policy"] = {
+        "principle": "Exact numeric-token equality is necessary but not sufficient. A number verified as a price must not silently become a result, savings figure, follower count, or other claim category.",
+        "deterministic_scope": "Only clear commercial/result/timing category changes are reviewed. Fine-grained semantic equivalence remains a /human responsibility.",
+    }
+    packet["generation_constraints"].append(
+        "Do not reuse a verified number under a different claim category merely because the digits match exactly."
+    )
+    packet["human_gate"]["checks"].append(
+        "同じ数字でも意味を横流ししていないか？価格の10,000円を売上・節約額・顧客成果の10,000円として使っていないか？"
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _r10.audit_draft(draft, packet)
+    findings = [*result.get("findings", []), *_context_laundering_findings(draft, packet)]
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r12.py
+++ b/x_article_engine/meteor_v09_r12.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+
+from . import v09_final as _final
+
+
+POSITIVE_PROMISE_PATTERNS = {
+    "REFUND": (
+        re.compile(r"(?:全額|一部)?返金[^。\n]{0,18}(?:します|いたします|できます|可能です|対応します)"),
+    ),
+    "NO_EXTRA_FEE": (
+        re.compile(r"追加料金[^。\n]{0,18}(?:ありません|発生しません|かかりません|不要です)"),
+    ),
+    "GUARANTEE": (
+        re.compile(r"(?:成果|結果|成功)?[^。\n]{0,10}保証[^。\n]{0,16}(?:します|いたします|できます|されます)"),
+    ),
+    "UNLIMITED": (
+        re.compile(r"(?:利用|使用|回数|アクセス)?[^。\n]{0,10}無制限[^。\n]{0,18}(?:です|で利用|で使用|使え|利用でき)"),
+    ),
+    "PERMANENT": (
+        re.compile(r"(?:永続的|永久)[^。\n]{0,20}(?:利用できます|使えます|提供します|アクセスできます|利用可能です)"),
+    ),
+}
+
+NEGATIVE_EVIDENCE_PATTERNS = {
+    "REFUND": (
+        re.compile(r"返金[^。\n]{0,20}(?:行いません|しません|不可|できません|対応しません|対象外)"),
+    ),
+    "NO_EXTRA_FEE": (
+        re.compile(r"追加料金[^。\n]{0,25}(?:発生する|発生します|かかる|必要|場合があります|場合がある)"),
+    ),
+    "GUARANTEE": (
+        re.compile(r"保証[^。\n]{0,25}(?:しません|しない|できません|できない|するものではありません|いたしません)"),
+    ),
+    "UNLIMITED": (
+        re.compile(r"(?:利用|使用|回数|アクセス)?[^。\n]{0,20}(?:上限|制限)[^。\n]{0,20}(?:あります|ある|設定|設け)"),
+    ),
+    "PERMANENT": (
+        re.compile(r"(?:永続的|永久)[^。\n]{0,30}(?:保証しません|保証しない|保証するものではありません|ではありません|ではない)"),
+    ),
+}
+
+
+def _commercial_evidence_text(packet: dict) -> str:
+    return "\n".join(
+        str(item.get("claim", ""))
+        for item in packet.get("verified_evidence", [])
+        if item.get("kind") in {"COMMERCIAL", "POLICY", "SCOPE", "TIMING"}
+    )
+
+
+def _promise_polarity_findings(draft: str, packet: dict) -> list[dict]:
+    evidence = _commercial_evidence_text(packet)
+    findings: list[dict] = []
+
+    for category, positive_patterns in POSITIVE_PROMISE_PATTERNS.items():
+        positive_sentences = [
+            sentence
+            for sentence in _final._sentences(draft)
+            if any(pattern.search(sentence) for pattern in positive_patterns)
+            and not _final._is_meta_rejection(sentence)
+        ]
+        if not positive_sentences:
+            continue
+
+        negative_patterns = NEGATIVE_EVIDENCE_PATTERNS[category]
+        negative_evidence = [
+            sentence
+            for sentence in _final._sentences(evidence)
+            if any(pattern.search(sentence) for pattern in negative_patterns)
+        ]
+        if not negative_evidence:
+            continue
+
+        for sentence in positive_sentences:
+            findings.append(
+                {
+                    "code": "CONTRADICTS_VERIFIED_COMMERCIAL_TERM",
+                    "severity": "BLOCK",
+                    "detail": category,
+                    "draft_sentence": sentence,
+                    "verified_conflict": negative_evidence[0],
+                }
+            )
+
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _final.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r12"
+    packet["commercial_promise_polarity_policy"] = {
+        "principle": (
+            "A verified commercial term cannot authorize its semantic opposite merely because both sentences contain the same word. "
+            "Negative/conditional terms outrank strengthened positive promises."
+        ),
+        "blocked_reversals": [
+            "返金しない -> 全額返金します",
+            "追加料金が発生する場合あり -> 追加料金なし",
+            "保証しない -> 保証します",
+            "上限あり -> 無制限",
+            "永続提供を保証しない -> 永続利用できます",
+        ],
+    }
+    packet["generation_constraints"].append(
+        "Do not reverse a verified commercial limitation, exclusion, conditional fee, no-refund term, no-guarantee term, usage cap, or non-permanence statement into a stronger promise."
+    )
+    packet["human_gate"]["checks"].append(
+        "販売条件の単語だけ一致して、意味が逆転していないか？『返金しない』を『返金する』、『追加料金あり得る』を『追加料金なし』へ強化していないか？"
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _final.audit_draft(draft, packet)
+    findings = [*result.get("findings", []), *_promise_polarity_findings(draft, packet)]
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r4.py
+++ b/x_article_engine/meteor_v09_r4.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import meteor_v09_gate as _r3
+from .core import XArticleEngineError
+
+
+PAIN_OPENING_KINDS = {"PAIN", "FAILURE"}
+CONTRARIAN_HUMAN_KINDS = {"BELIEF", "OPINION"}
+
+EVASION_MARKERS = (
+    "BAN回避",
+    "ステルス配信",
+    "判定を回避",
+    "検知を回避",
+    "規制を回避",
+    "ゼロ幅文字",
+)
+
+EVASION_OPERATION_RE = re.compile(
+    r"(?:BAN回避|ステルス配信|判定を回避|検知を回避|規制を回避|ゼロ幅文字)"
+    r"[^。\n]{0,80}(?:使う|使います|入れる|実装|構築|設定|送信|配信|追加|挿入|有効化)"
+)
+
+EVASION_NEGATION_MARKERS = (
+    "しない",
+    "使わない",
+    "避ける",
+    "避けて",
+    "禁止",
+    "推奨しない",
+    "やめる",
+    "問題",
+    "危険",
+    "規約",
+    "ポリシー",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _verified_primary(packet: dict, kinds: set[str]) -> list[dict]:
+    return [
+        item
+        for item in packet.get("verified_primary_info", [])
+        if item.get("kind") in kinds
+    ]
+
+
+def _contrarian_basis_is_valid(source: dict, packet: dict) -> bool:
+    basis = source.get("counterpoint_basis")
+    if not isinstance(basis, dict):
+        return False
+
+    kind = str(basis.get("kind", "")).strip().upper()
+    source_ref = str(basis.get("source_ref", "")).strip()
+    if not source_ref:
+        return False
+
+    if kind == "HUMAN_OPINION":
+        return any(
+            item.get("source_ref") == source_ref
+            and item.get("kind") in CONTRARIAN_HUMAN_KINDS
+            for item in packet.get("verified_primary_info", [])
+        )
+
+    if kind == "EVIDENCE":
+        return any(
+            item.get("source_ref") == source_ref
+            for item in packet.get("verified_evidence", [])
+        )
+
+    return False
+
+
+def _evasion_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        present = [marker for marker in EVASION_MARKERS if marker in sentence]
+        if not present:
+            continue
+        if any(marker in sentence for marker in EVASION_NEGATION_MARKERS):
+            findings.append(
+                {
+                    "code": "PLATFORM_EVASION_LANGUAGE",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                }
+            )
+            continue
+        if EVASION_OPERATION_RE.search(sentence):
+            findings.append(
+                {
+                    "code": "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION",
+                    "severity": "BLOCK",
+                    "detail": sentence,
+                }
+            )
+        else:
+            findings.append(
+                {
+                    "code": "PLATFORM_EVASION_LANGUAGE",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                }
+            )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    if not isinstance(source, dict):
+        raise XArticleEngineError("source must be an object")
+
+    explicit_opening = source.get("opening_mode")
+    packet = _r3.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+
+    pain_anchors = _verified_primary(packet, PAIN_OPENING_KINDS)
+
+    # Core v0.3 historically allowed ORIGIN to activate LIVED_PAIN. Round 4 narrows
+    # the latest root: origin is useful story material, but it is not pain by itself.
+    if packet.get("opening_mode") == "LIVED_PAIN" and not pain_anchors:
+        if explicit_opening is not None:
+            raise XArticleEngineError(
+                "LIVED_PAIN in v0.9 requires human-attested PAIN or FAILURE; ORIGIN alone cannot authorize a pain opening"
+            )
+        packet["opening_mode"] = "RELATABLE"
+        packet["lived_pain_anchors"] = []
+        packet["narrative"]["sequence"] = [
+            "reader_state",
+            "evidence_if_available",
+            "anticipated_objection",
+            "cause",
+            "solution",
+            "stumbling_point",
+            "one_action_today",
+            "single_cta",
+        ]
+        packet["narrative"]["opening_doctrine"] = (
+            "An attested origin may explain why the article exists, but do not manufacture pain from origin alone."
+        )
+
+    if packet.get("opening_mode") == "CONTRARIAN" and not _contrarian_basis_is_valid(source, packet):
+        raise XArticleEngineError(
+            "CONTRARIAN opening requires counterpoint_basis bound to verified evidence or a human-attested BELIEF/OPINION"
+        )
+
+    packet["schema_version"] = "0.9-meteor-r4"
+    packet["opening_integrity_policy"] = {
+        "lived_pain_rule": (
+            "LIVED_PAIN requires an actual human-attested PAIN or FAILURE anchor. ORIGIN alone may explain causality but must not be converted into drama."
+        ),
+        "contrarian_rule": (
+            "CONTRARIAN requires an explicit counterpoint_basis bound either to verified evidence or to human-attested BELIEF/OPINION."
+        ),
+        "anti_forcing_rule": (
+            "Do not force a pain, proof, or contrarian opening merely because the reference corpus used one successfully. Opening mode follows available material."
+        ),
+    }
+    packet["security_content_policy"]["platform_evasion_rule"] = (
+        "Discussion of platform-evasion language requires review. Operational instructions to evade enforcement/detection are blocked from the latest article engine."
+    )
+    packet["generation_constraints"].extend(
+        [
+            "Do not treat ORIGIN as pain unless the human also attested PAIN or FAILURE. A neutral origin story must remain neutral.",
+            "Do not manufacture a contrarian opening. Require an explicit evidence-bound or human-attested counterpoint basis.",
+            "Do not provide operational instructions for BAN/detection/enforcement evasion. Discussion of such claims remains review-only and should favor compliant alternatives.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "Is the opening emotion actually present in PAIN/FAILURE primary information, or did the draft turn a neutral origin into drama?",
+            "If the opening is contrarian, what exact evidence or human belief/opinion is the counterpoint based on?",
+            "If platform-evasion language appears, is the article explaining/rejecting it rather than teaching how to evade enforcement?",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _r3.audit_draft(draft, packet)
+
+    # Replace r3's coarse evasion review with operational-vs-discussion classification.
+    findings = [
+        item
+        for item in result.get("findings", [])
+        if item.get("code") != "PLATFORM_EVASION_LANGUAGE"
+    ]
+    findings.extend(_evasion_findings(draft))
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r5.py
+++ b/x_article_engine/meteor_v09_r5.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import meteor_v09_r4 as _r4
+
+
+ABSTRACT_MARKERS = ("構造", "設計", "本質", "重要です", "大切です", "最適化")
+GENERIC_SUBJECT_MARKERS = ("多くの人は", "多くの人が", "現代人は", "誰もが", "みんなが", "一般的に")
+
+EVASION_NEGATION_FORMS = (
+    "推奨しない",
+    "推奨しません",
+    "推奨していない",
+    "推奨していません",
+    "教えない",
+    "教えません",
+    "扱わない",
+    "扱いません",
+    "使わない",
+    "実行しない",
+    "避ける",
+    "禁止",
+    "問題がある",
+    "危険",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _generic_abstract_collision_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        subjects = [marker for marker in GENERIC_SUBJECT_MARKERS if marker in sentence]
+        abstracts = [marker for marker in ABSTRACT_MARKERS if marker in sentence]
+        if not subjects or not abstracts:
+            continue
+        findings.append(
+            {
+                "code": "ABSTRACT_WORD_WITHOUT_PAYLOAD",
+                "severity": "REVIEW",
+                "detail": sentence,
+                "markers": abstracts,
+                "meteor_note": (
+                    "generic subject tokens such as 人 must not count as concrete material merely because the older concrete-signal regex contains a bare unit/character"
+                ),
+            }
+        )
+    return findings
+
+
+def _is_evasion_rejection(detail: str) -> bool:
+    normalized = _norm(detail)
+    return any(marker in normalized for marker in EVASION_NEGATION_FORMS)
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _r4.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r5"
+    packet["anti_ai_smell_policy"]["generic_abstract_collision_rule"] = (
+        "A generic subject such as 多くの人 must not make 構造/設計/本質 look concrete. Generic humanity words are not evidence payload."
+    )
+    packet["security_content_policy"]["evasion_negation_rule"] = (
+        "Japanese negative forms, including polite forms such as 推奨しません, must be classified as rejection/discussion rather than operational evasion instructions."
+    )
+    packet["human_gate"]["checks"].append(
+        "権限・安全・自動化の説明で、禁止や停止条件を危険な実行指示として誤読していないか？"
+    )
+    packet["generation_constraints"].extend(
+        [
+            "Do not count generic words such as 人 as concrete payload for an otherwise empty 構造/設計/本質 sentence.",
+            "Recognize polite Japanese negative forms before classifying security/platform-evasion discussion as an operational instruction.",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _r4.audit_draft(draft, packet)
+
+    findings: list[dict] = []
+    for item in result.get("findings", []):
+        if item.get("code") == "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION" and _is_evasion_rejection(
+            str(item.get("detail", ""))
+        ):
+            findings.append(
+                {
+                    "code": "PLATFORM_EVASION_LANGUAGE",
+                    "severity": "REVIEW",
+                    "detail": item.get("detail", ""),
+                }
+            )
+            continue
+        findings.append(item)
+
+    findings.extend(_generic_abstract_collision_findings(draft))
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r6.py
+++ b/x_article_engine/meteor_v09_r6.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import v09 as _flat
+
+
+CLAIM_NEGATION_MARKERS = (
+    "とは限りません",
+    "とは限らない",
+    "とは言いません",
+    "とは言わない",
+    "とは書けません",
+    "とは書かない",
+    "とは断言できません",
+    "とは断言できない",
+    "と断言しません",
+    "と断言しない",
+    "ではありません",
+    "ではない",
+    "わけではありません",
+    "わけではない",
+    "という意味ではありません",
+    "という意味ではない",
+    "とは約束できません",
+    "とは約束できない",
+    "保証しません",
+    "保証しない",
+)
+
+NEGATED_FRESHNESS_PATTERNS = (
+    re.compile(r"(?:最新|最新版|現在|現時点)[^。\n]{0,25}(?:ではありません|ではない|とは限りません|とは限らない)"),
+    re.compile(r"(?:最新|最新版|現在|現時点)[^。\n]{0,25}(?:と断言しません|とは言いません|とは書けません)"),
+)
+
+NEGATED_ABSOLUTE_FREE_PATTERNS = (
+    re.compile(r"(?:完全無料|ずっと無料|永久無料)[^。\n]{0,25}(?:ではありません|ではない|とは限りません|とは限らない)"),
+    re.compile(r"(?:完全無料|ずっと無料|永久無料)[^。\n]{0,25}(?:とは言いません|とは書けません|とは約束できません)"),
+)
+
+NEGATED_SUPERLATIVE_PATTERNS = (
+    re.compile(r"(?:世界一|唯一|最強)[^。\n]{0,25}(?:ではありません|ではない|とは限りません|とは限らない)"),
+    re.compile(r"(?:世界一|唯一|最強)[^。\n]{0,25}(?:とは言いません|とは書けません|と断言しません)"),
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _is_claim_negation(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in CLAIM_NEGATION_MARKERS)
+
+
+def _token_only_in_negated_sentences(draft: str, token: str) -> bool:
+    matches = [sentence for sentence in _sentences(draft) if token in sentence]
+    return bool(matches) and all(_is_claim_negation(sentence) for sentence in matches)
+
+
+def _sentence_matches_any(sentence: str, patterns: tuple[re.Pattern, ...]) -> bool:
+    return any(pattern.search(_norm(sentence)) for pattern in patterns)
+
+
+def _all_marker_mentions_negated(draft: str, marker: str, patterns: tuple[re.Pattern, ...]) -> bool:
+    matches = [sentence for sentence in _sentences(draft) if marker in sentence]
+    return bool(matches) and all(_sentence_matches_any(sentence, patterns) or _is_claim_negation(sentence) for sentence in matches)
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _flat.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r6"
+    packet["negated_claim_policy"] = {
+        "principle": (
+            "A draft may quote or explicitly reject a dangerous claim without adopting it. "
+            "The audit must judge whether the claim is asserted, not merely whether its tokens appear."
+        ),
+        "examples": [
+            "必ず成功するとは限りません -> not a guarantee",
+            "完全無料ではありません -> not a free promise",
+            "保証します、とは書けません -> not a guarantee",
+            "30分で終わるとは言いません -> not a duration promise",
+            "これは最新版ではありません -> not a currentness claim",
+        ],
+    }
+    packet["generation_constraints"].append(
+        "Do not convert a claim being explicitly denied, quoted for criticism, or refused into an asserted factual/commercial promise merely because the same tokens appear."
+    )
+    packet["human_gate"]["checks"].append(
+        "危険な断言を『否定・批判するために引用した文』まで、断言そのものとして扱っていないか？"
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _flat.audit_draft(draft, packet)
+    findings: list[dict] = []
+
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        if code in {"UNBOUND_NUMERIC_CLAIM", "UNBOUND_FUZZY_QUANT_CLAIM"}:
+            if _token_only_in_negated_sentences(draft, detail):
+                continue
+
+        if code == "UNBOUND_IDENTITY_DETAIL" and _is_claim_negation(detail):
+            continue
+
+        if code == "UNBOUND_STRONG_CLAIM":
+            if _token_only_in_negated_sentences(draft, detail):
+                continue
+
+        if code == "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE":
+            freshness_tokens = [marker for marker in _flat.FRESHNESS_MARKERS if marker in _norm(draft)]
+            if freshness_tokens and all(
+                _all_marker_mentions_negated(draft, marker, NEGATED_FRESHNESS_PATTERNS)
+                for marker in freshness_tokens
+            ):
+                continue
+
+        if code == "UNBOUND_ABSOLUTE_FREE_CLAIM":
+            if _all_marker_mentions_negated(draft, detail, NEGATED_ABSOLUTE_FREE_PATTERNS):
+                continue
+
+        if code == "SUPERLATIVE_OR_TOTALIZING_LANGUAGE":
+            present = [marker for marker in _flat.SUPERLATIVE_MARKERS if marker in _norm(draft)]
+            if present and all(
+                _all_marker_mentions_negated(draft, marker, NEGATED_SUPERLATIVE_PATTERNS)
+                for marker in present
+            ):
+                continue
+
+        if code in {
+            "UNBOUND_GUARANTEE_LANGUAGE",
+            "ABSOLUTE_SAFETY_LANGUAGE",
+            "OUTCOME_PROMISE_LANGUAGE",
+            "UNIVERSAL_CAPABILITY_PROMISE",
+            "ABSOLUTE_GENERALIZATION_LANGUAGE",
+        }:
+            matching = [
+                sentence
+                for sentence in _sentences(draft)
+                if detail in sentence or any(token in sentence for token in re.findall(r"[一-龥ぁ-んァ-ンA-Za-z0-9%％]+", detail))
+            ]
+            if matching and all(_is_claim_negation(sentence) for sentence in matching):
+                continue
+
+        findings.append(item)
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r7.py
+++ b/x_article_engine/meteor_v09_r7.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import meteor_v09_r6 as _r6
+from . import v09 as _flat
+
+
+PROHIBITION_MARKERS = (
+    "てはいけません",
+    "てはいけない",
+    "ではいけません",
+    "ではいけない",
+    "ないでください",
+    "禁止です",
+    "禁止します",
+    "やめてください",
+    "避けてください",
+    "推奨しません",
+    "推奨しない",
+    "書いてはいけません",
+    "書いてはいけない",
+)
+
+POSITIVE_RISK_FRONT_PATTERNS = (
+    re.compile(r"警告\s*[:：]"),
+    re.compile(r"(?:危険|リスク)[^。\n]{0,30}(?:があります|がある|を伴|が高|が生じ|が発生|可能性があります|可能性がある)"),
+    re.compile(r"対象外[^。\n]{0,45}(?:進めない|進まない|使わない|避けて|やめて)"),
+    re.compile(r"(?:進め|使わ|実行し|共有し)[^。\n]{0,20}(?:ないでください|てはいけません|てはいけない)"),
+    re.compile(r"(?:停止|中止)[^。\n]{0,20}(?:してください|して戻|する必要|します)"),
+)
+
+NEGATED_RISK_FRONT_PATTERNS = (
+    re.compile(r"(?:危険|リスク)[^。\n]{0,20}(?:ではありません|ではない|はありません|はない)"),
+    re.compile(r"(?:停止|中止)[^。\n]{0,15}(?:しないで|不要|する必要はない)"),
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _is_prohibition(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in PROHIBITION_MARKERS)
+
+
+def _real_reader_actions(draft: str) -> set[str]:
+    actions: set[str] = set()
+    for sentence in _sentences(draft):
+        if _r6._is_claim_negation(sentence) or _is_prohibition(sentence):
+            continue
+        for name, pattern in _flat.CTA_ACTION_PATTERNS.items():
+            if pattern.search(sentence):
+                actions.add(name)
+    return actions
+
+
+def _has_positive_front_gate(draft: str) -> bool:
+    front = _norm(draft)[:700]
+    for sentence in _sentences(front):
+        if any(pattern.search(sentence) for pattern in NEGATED_RISK_FRONT_PATTERNS):
+            continue
+        if any(pattern.search(sentence) for pattern in POSITIVE_RISK_FRONT_PATTERNS):
+            return True
+    return False
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _r6.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r7"
+    packet["polarity_policy"] = {
+        "principle": (
+            "Operational and safety audits must distinguish recommendation from prohibition. "
+            "A dangerous phrase inside 'do not do this' is not the same as an instruction to do it."
+        ),
+        "front_gate_rule": (
+            "HIGH-risk front gates require an actual warning/stop/exclusion meaning; a negated phrase such as 'リスクはありません' cannot satisfy the gate."
+        ),
+        "cta_rule": (
+            "A rejected action such as '登録してくださいとは言いません' is not a CTA and must not contribute to multi-CTA counting."
+        ),
+    }
+    packet["generation_constraints"].extend(
+        [
+            "Determine polarity before classifying a security instruction: '送ってはいけません' is a prohibition, not a transfer instruction.",
+            "Do not let a negated safety phrase such as 'リスクはありません' or '停止しないでください' satisfy a HIGH-risk front stop gate.",
+            "Do not count an action that the draft explicitly refuses/rejects as a CTA.",
+        ]
+    )
+    packet["human_gate"]["checks"].append(
+        "危険語・CTA語が出ているだけで判定せず、その文は実行を勧めているのか、禁止・否定しているのかを確認したか？"
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _r6.audit_draft(draft, packet)
+    findings: list[dict] = []
+
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        if code in {"UNSAFE_PERMISSION_OR_SECURITY_BYPASS", "SECRET_TRANSFER_TO_MODEL_RISK"}:
+            if _is_prohibition(detail):
+                continue
+
+        if code == "MULTIPLE_COMMERCIAL_ACTIONS_RISK":
+            continue
+
+        if code == "HIGH_RISK_WITHOUT_FRONT_STOP_GATE":
+            continue
+
+        findings.append(item)
+
+    actions = _real_reader_actions(draft)
+    if len(actions) >= 2:
+        findings.append(
+            {
+                "code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK",
+                "severity": "REVIEW",
+                "detail": ", ".join(sorted(actions)),
+            }
+        )
+
+    if packet.get("risk_policy", {}).get("risk_level") == "HIGH" and not _has_positive_front_gate(draft):
+        findings.append(
+            {
+                "code": "HIGH_RISK_WITHOUT_FRONT_STOP_GATE",
+                "severity": "BLOCK",
+                "detail": "high-risk guide lacks an affirmative warning/stop/exclusion meaning near the front; negated risk words do not count",
+            }
+        )
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r8.py
+++ b/x_article_engine/meteor_v09_r8.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from . import meteor_v09_r7 as _r7
+from .core import XArticleEngineError
+
+
+CURRENT_MODES = {"CURRENT", "UPDATE"}
+RISK_KINDS = {"RISK", "SAFETY", "POLICY"}
+
+
+def _verified_by_ref(packet: dict) -> dict[str, list[dict]]:
+    index: dict[str, list[dict]] = {}
+    for item in packet.get("verified_evidence", []):
+        ref = str(item.get("source_ref", "")).strip()
+        if ref:
+            index.setdefault(ref, []).append(item)
+    return index
+
+
+def _normalize_ref_list(source: dict, field: str) -> list[str]:
+    value = source.get(field, [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise XArticleEngineError(f"{field} must be a list of source_ref strings")
+    refs: list[str] = []
+    for item in value:
+        ref = str(item).strip()
+        if not ref:
+            raise XArticleEngineError(f"{field} must not contain empty refs")
+        if ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _require_bound_refs(
+    *,
+    refs: list[str],
+    verified_index: dict[str, list[dict]],
+    allowed_kinds: set[str],
+    field: str,
+) -> list[dict]:
+    if not refs:
+        raise XArticleEngineError(f"{field} requires at least one explicitly bound verified evidence ref")
+    bound: list[dict] = []
+    for ref in refs:
+        candidates = verified_index.get(ref, [])
+        allowed = [item for item in candidates if item.get("kind") in allowed_kinds]
+        if not allowed:
+            kinds = "/".join(sorted(allowed_kinds))
+            raise XArticleEngineError(
+                f"{field} ref {ref!r} must resolve to verified evidence of kind {kinds}"
+            )
+        bound.extend(allowed)
+    return bound
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _r7.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    verified_index = _verified_by_ref(packet)
+
+    freshness_refs = _normalize_ref_list(source, "freshness_evidence_refs")
+    if packet.get("freshness", {}).get("mode") in CURRENT_MODES:
+        freshness_bound = _require_bound_refs(
+            refs=freshness_refs,
+            verified_index=verified_index,
+            allowed_kinds={"TIMING"},
+            field="freshness_evidence_refs",
+        )
+    else:
+        freshness_bound = []
+
+    risk_refs = _normalize_ref_list(source, "risk_evidence_refs")
+    if packet.get("risk_policy", {}).get("risk_level") == "HIGH":
+        risk_bound = _require_bound_refs(
+            refs=risk_refs,
+            verified_index=verified_index,
+            allowed_kinds=RISK_KINDS,
+            field="risk_evidence_refs",
+        )
+    else:
+        risk_bound = []
+
+    packet["schema_version"] = "0.9-meteor-r8"
+    packet["freshness"]["evidence_refs"] = freshness_refs
+    packet["freshness"]["bound_evidence"] = freshness_bound
+    packet["freshness"]["binding_rule"] = (
+        "CURRENT/UPDATE is not authorized by any arbitrary dated fact. The brief must explicitly bind freshness_evidence_refs to verified TIMING evidence."
+    )
+    packet["risk_policy"]["evidence_refs"] = risk_refs
+    packet["risk_policy"]["bound_evidence"] = risk_bound
+    packet["risk_policy"]["binding_rule"] = (
+        "HIGH-risk mode is not authorized by an unrelated risk fact. The brief must explicitly bind risk_evidence_refs to verified RISK/SAFETY/POLICY evidence."
+    )
+    packet["evidence_purpose_binding_policy"] = {
+        "principle": "Evidence cannot be borrowed merely because it is verified; the brief must bind evidence to the decision it is supposed to authorize.",
+        "freshness": "freshness_evidence_refs -> verified TIMING evidence",
+        "high_risk": "risk_evidence_refs -> verified RISK/SAFETY/POLICY evidence",
+        "contrarian": "counterpoint_basis -> verified evidence or human-attested opinion/belief",
+    }
+    packet["generation_constraints"].extend(
+        [
+            "Do not use an unrelated dated fact to authorize current/latest wording; currentness must be bound to freshness_evidence_refs.",
+            "Do not use an unrelated risk fact to authorize a HIGH-risk warning; high-risk mode must be bound to risk_evidence_refs.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "『最新』を支える freshness_evidence_refs は、その仕様・価格・UI・提供状況そのものの現在性を本当に支えているか？",
+            "HIGH-risk の risk_evidence_refs は、本文で警告している具体的な危険と本当に同じ危険を支えているか？",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _r7.audit_draft(draft, packet)
+
+    # R7/flat freshness audit can clear wording merely because some dated evidence exists.
+    # R8 re-applies purpose binding: current wording is only clean in CURRENT/UPDATE mode
+    # with explicit freshness evidence refs.
+    normalized = _r7._norm(draft)
+    current_words = [marker for marker in _r7._flat.FRESHNESS_MARKERS if marker in normalized]
+    if current_words:
+        non_negated_current = [
+            marker
+            for marker in current_words
+            if not _r7._r6._all_marker_mentions_negated(
+                draft,
+                marker,
+                _r7._r6.NEGATED_FRESHNESS_PATTERNS,
+            )
+        ]
+        if non_negated_current:
+            clean = (
+                packet.get("freshness", {}).get("mode") in CURRENT_MODES
+                and bool(packet.get("freshness", {}).get("evidence_refs"))
+            )
+            if not clean and not any(
+                item.get("code") == "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE"
+                for item in result.get("findings", [])
+            ):
+                result.setdefault("findings", []).append(
+                    {
+                        "code": "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE",
+                        "severity": "REVIEW",
+                        "detail": ", ".join(non_negated_current),
+                    }
+                )
+
+    findings = result.get("findings", [])
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/meteor_v09_r9.py
+++ b/x_article_engine/meteor_v09_r9.py
@@ -32,7 +32,8 @@ def _reader_actions(draft: str) -> set[str]:
 
 def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
     packet = _hardened.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
-    packet["schema_version"] = "0.9-meteor-r9"
+    packet["schema_version"] = "0.9"
+    packet["meteor_round"] = "R9_DOGFOOD_CTA"
     packet["cta_semantics_policy"] = {
         "principle": "Count an action as a CTA when the reader is invited to take it, not merely when the action's noun appears.",
         "fit_check_examples": [

--- a/x_article_engine/meteor_v09_r9.py
+++ b/x_article_engine/meteor_v09_r9.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+
+from . import v09_hardened as _hardened
+
+
+FIT_CHECK_ACTION_RE = re.compile(
+    r"(?:無料(?:適合確認|制作可否確認)|無料で(?:適合|制作可否)を?確認)"
+    r"[^。\n]{0,30}"
+    r"(?:から始め|で始め|を使|を受け|へ進|はこちら|できます|できる|してみ|してください|しませんか)"
+)
+
+FIT_CHECK_NON_ACTION_RE = re.compile(
+    r"(?:無料適合確認|無料制作可否確認)[^。\n]{0,25}"
+    r"(?:という考え|という言葉|を説明|の意味|について書|について話)"
+)
+
+
+def _reader_actions(draft: str) -> set[str]:
+    actions: set[str] = set()
+    for sentence in _hardened._sentences(draft):
+        if _hardened._is_claim_negation(sentence) or _hardened._is_prohibition(sentence):
+            continue
+        for name, pattern in _hardened._base.CTA_ACTION_PATTERNS.items():
+            if pattern.search(sentence):
+                actions.add(name)
+        if FIT_CHECK_ACTION_RE.search(sentence) and not FIT_CHECK_NON_ACTION_RE.search(sentence):
+            actions.add("fit_check")
+    return actions
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _hardened.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9-meteor-r9"
+    packet["cta_semantics_policy"] = {
+        "principle": "Count an action as a CTA when the reader is invited to take it, not merely when the action's noun appears.",
+        "fit_check_examples": [
+            "無料適合確認から始められます -> CTA",
+            "無料適合確認を使ってください -> CTA",
+            "無料適合確認という考え方を説明します -> not a CTA",
+        ],
+    }
+    packet["generation_constraints"].append(
+        "Treat natural continuation language such as '無料適合確認から始められます' as an actual CTA when checking whether the draft asks for multiple competing actions."
+    )
+    packet["human_gate"]["checks"].append(
+        "CTAは命令形だけで数えていないか？『〜から始められます』のような自然な次行動も含めて、読者に何個の行動を求めているか確認したか？"
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _hardened.audit_draft(draft, packet)
+    findings = [
+        item
+        for item in result.get("findings", [])
+        if item.get("code") != "MULTIPLE_COMMERCIAL_ACTIONS_RISK"
+    ]
+
+    actions = _reader_actions(draft)
+    if len(actions) >= 2:
+        findings.append(
+            {
+                "code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK",
+                "severity": "REVIEW",
+                "detail": ", ".join(sorted(actions)),
+            }
+        )
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/terminology.py
+++ b/x_article_engine/terminology.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+import re
 import unicodedata
 
 from . import core as _core
@@ -220,6 +221,35 @@ def _product_name_findings(draft: str, packet: dict) -> list[dict]:
     return findings
 
 
+def _is_all_katakana_token(value: str) -> bool:
+    return bool(value) and all(
+        ("ァ" <= char <= "ヺ") or char in {"ー", "・"}
+        for char in value
+    )
+
+
+def _is_all_ascii_word_token(value: str) -> bool:
+    return bool(value) and all(char.isascii() and (char.isalnum() or char in {"_", "-"}) for char in value)
+
+
+def _term_first_position(text: str, term: str) -> int:
+    """Find a lexical term occurrence without matching inside a larger same-script token.
+
+    This prevents short glossary terms such as ``ログ`` from firing inside
+    ``プログラム`` or ``ブログ``. If a compound such as ``アクセスログ`` needs its
+    own explanation, it should be listed explicitly as an article-specific term.
+    """
+    if _is_all_katakana_token(term):
+        pattern = re.compile(rf"(?<![ァ-ヺー・]){re.escape(term)}(?![ァ-ヺー・])")
+        match = pattern.search(text)
+        return -1 if match is None else match.start()
+    if _is_all_ascii_word_token(term):
+        pattern = re.compile(rf"(?<![A-Za-z0-9_-]){re.escape(term)}(?![A-Za-z0-9_-])", re.I)
+        match = pattern.search(text)
+        return -1 if match is None else match.start()
+    return text.find(term)
+
+
 def _term_findings(draft: str, packet: dict) -> list[dict]:
     policy = packet.get("terminology_policy") or {}
     if not policy.get("explain_on_first_use"):
@@ -229,7 +259,7 @@ def _term_findings(draft: str, packet: dict) -> list[dict]:
     findings = []
     for item in policy.get("glossary", []):
         term = _norm(item["term"])
-        position = normalized.find(term)
+        position = _term_first_position(normalized, term)
         if position < 0:
             continue
         window = normalized[position : position + EXPLANATION_WINDOW_CHARS]

--- a/x_article_engine/v09.py
+++ b/x_article_engine/v09.py
@@ -1,0 +1,751 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import depth_market as _v08
+from .core import XArticleEngineError
+
+
+FRESHNESS_MARKERS = (
+    "最新",
+    "現在",
+    "現時点",
+    "最新版",
+    "今の仕様",
+    "今使える",
+)
+
+DATE_RE = re.compile(
+    r"(?:20\d{2}[年/-](?:0?[1-9]|1[0-2])(?:[月/-](?:0?[1-9]|[12]\d|3[01])日?)?|"
+    r"20\d{2}年(?:0?[1-9]|1[0-2])月時点|20\d{2}年時点)"
+)
+
+PAIN_OPENING_KINDS = {"PAIN", "FAILURE"}
+CONTRARIAN_HUMAN_KINDS = {"BELIEF", "OPINION"}
+RISK_EVIDENCE_KINDS = {"RISK", "SAFETY", "POLICY"}
+
+NEGATION_OR_WARNING = (
+    "使わない",
+    "使用しない",
+    "しない",
+    "しないで",
+    "ないで",
+    "ないでください",
+    "禁止",
+    "避け",
+    "危険",
+    "やめ",
+    "ダメ",
+    "してはいけ",
+    "無効にしない",
+    "スキップしない",
+    "共有しない",
+    "渡さない",
+    "貼り付けない",
+)
+
+IMPERATIVE_SAFETY_MARKERS = (
+    "確認してください",
+    "確認する",
+    "共有しない",
+    "渡さない",
+    "貼り付けない",
+    "停止してください",
+    "停止する",
+    "戻してください",
+    "戻す",
+    "守って",
+    "守る",
+    "禁止",
+    "対象外",
+    "使わない",
+    "しないで",
+)
+
+OUTCOME_CONTEXT = (
+    "できます",
+    "できる",
+    "終わります",
+    "終わる",
+    "完了",
+    "成功",
+    "売れ",
+    "伸び",
+    "稼げ",
+    "増え",
+    "安全",
+    "大丈夫",
+    "保証",
+    "無料",
+    "返金",
+    "追加料金",
+)
+
+UNSAFE_ACTION_PATTERNS = (
+    re.compile(r"--dangerously-skip-permissions", re.I),
+    re.compile(r"(?:権限|確認|承認)[^。\n]{0,25}(?:スキップ|飛ば|省略)[^。\n]{0,20}(?:して|する|してください|で進)"),
+    re.compile(r"認証[^。\n]{0,18}(?:無効|none|なし)[^。\n]{0,18}(?:にして|に設定|を選|で進)", re.I),
+    re.compile(r"サンドボックス[^。\n]{0,18}(?:無効|off)[^。\n]{0,18}(?:にして|に設定|で進)", re.I),
+)
+
+AUTOMATION_OVERREACH_PATTERNS = (
+    re.compile(r"ユーザーに質問せず[^。\n]{0,40}(?:全部|全て|すべて)?[^。\n]{0,20}自動"),
+    re.compile(r"(?:全部|全て|すべて)[^。\n]{0,20}自動で判断"),
+    re.compile(r"確認なしで[^。\n]{0,30}(?:実行|進め|操作)"),
+)
+
+SECRET_RE = re.compile(
+    r"(?:API\s*キー|API\s*key|シークレット|secret|アクセストークン|トークン|パスワード|認証情報|クレジットカード)",
+    re.I,
+)
+MODEL_DESTINATION_RE = re.compile(
+    r"(?:(?:AI|Claude|ChatGPT|Codex)(?:に|へ)|プロンプト|チャット|会話|メッセージ)",
+    re.I,
+)
+TRANSFER_RE = re.compile(r"(?:貼り付け|貼って|送信|送って|渡して|コピペ|入力して)")
+
+CTA_ACTION_PATTERNS = {
+    "purchase": re.compile(r"購入(?:して|する|はこちら|できます|へ)"),
+    "apply": re.compile(r"申し込(?:んで|む|み|はこちら|めます)"),
+    "join": re.compile(r"参加(?:して|する|はこちら|できます|へ)"),
+    "register": re.compile(r"登録(?:して|する|はこちら|できます|へ)"),
+    "add_friend": re.compile(r"友だち追加(?:して|する|はこちら|へ)"),
+    "follow": re.compile(r"フォロー(?:して|する|お願いします|してください)"),
+    "reply": re.compile(r"リプ(?:して|する|してください|ください)"),
+    "dm": re.compile(r"DM(?:して|する|ください|してください)"),
+    "consult": re.compile(r"無料相談(?:して|する|はこちら|へ)"),
+    "fit_check": re.compile(r"無料適合確認(?:を使|はこちら|へ|して)"),
+    "request": re.compile(r"資料請求(?:して|する|はこちら|へ)"),
+}
+
+ABSOLUTE_FREE_MARKERS = ("完全無料", "ずっと無料", "永久無料")
+SUPERLATIVE_MARKERS = ("世界一", "唯一", "最強", "何でもでき", "全部でき")
+GUARANTEE_RE = re.compile(r"(?:保証します|保証できます|保証する|確実にできます|確実に終わります)")
+ABSOLUTE_SAFETY_RE = re.compile(r"(?:完全に安全|絶対安全|安全です|安心です)")
+OUTCOME_PROMISE_RE = re.compile(r"(?:売れます|売れるようになります|必ず伸びる|伸びます|稼げます|稼げるようになります)")
+UNIVERSAL_CAPABILITY_RE = re.compile(
+    r"(?:誰でも|全員|どんな人でも|初心者でも)[^。\n]{0,35}(?:できます|できる|使えます|使える|完了できます)"
+)
+
+HARDCODED_SECRET_RE = re.compile(r"\bsk-[A-Za-z0-9_-]{8,}\b", re.I)
+HARDCODED_SECRET_USE_RE = re.compile(
+    r"(?:API\s*キー|key|認証)[^。\n]{0,50}(?:sk-[A-Za-z0-9_-]{8,})[^。\n]{0,40}(?:使|入力|設定|このまま)",
+    re.I,
+)
+
+STEP_RE = re.compile(
+    r"(?:\bSTEP\s*[0-9０-９]+\b|ステップ\s*[0-9０-９一二三四五六七八九十]+|手順\s*[0-9０-９一二三四五六七八九十]+)",
+    re.I,
+)
+SUCCESS_MARKERS = (
+    "成功",
+    "完了",
+    "表示されたら",
+    "表示されれば",
+    "確認してください",
+    "確認でき",
+    "できていれば",
+    "見えれば",
+    "表示されます",
+)
+RECOVERY_MARKERS = (
+    "エラー",
+    "失敗",
+    "うまくいかな",
+    "困った",
+    "場合は",
+    "やり直",
+    "戻",
+    "停止",
+    "再試行",
+)
+
+RISK_FRONT_MARKERS = (
+    "警告",
+    "危険",
+    "リスク",
+    "対象外",
+    "進めない",
+    "使わないで",
+    "やめて",
+    "停止",
+)
+LOCAL_MITIGATION_MARKERS = (
+    "停止",
+    "戻",
+    "バックアップ",
+    "確認",
+    "権限",
+    "テスト",
+    "サンドボックス",
+    "対象外",
+    "人間",
+    "復旧",
+)
+
+ABSTRACT_MARKERS = ("構造", "設計", "本質", "重要です", "大切です", "最適化")
+GENERIC_SUBJECT_MARKERS = ("多くの人は", "多くの人が", "現代人は", "誰もが", "みんなが", "一般的に")
+
+EVASION_MARKERS = (
+    "BAN回避",
+    "ステルス配信",
+    "判定を回避",
+    "検知を回避",
+    "規制を回避",
+    "ゼロ幅文字",
+)
+EVASION_OPERATION_RE = re.compile(
+    r"(?:BAN回避|ステルス配信|判定を回避|検知を回避|規制を回避|ゼロ幅文字)"
+    r"[^。\n]{0,80}(?:使う|使います|入れる|実装|構築|設定|送信|配信|追加|挿入|有効化)"
+)
+EVASION_NEGATION_FORMS = (
+    "推奨しない",
+    "推奨しません",
+    "推奨していない",
+    "推奨していません",
+    "教えない",
+    "教えません",
+    "扱わない",
+    "扱いません",
+    "使わない",
+    "実行しない",
+    "避ける",
+    "禁止",
+    "問題がある",
+    "危険",
+    "規約",
+    "ポリシー",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _commercial_text(packet: dict) -> str:
+    chunks = [packet.get("offer", ""), packet.get("cta", "")]
+    chunks.extend(
+        item.get("claim", "")
+        for item in packet.get("verified_evidence", [])
+        if item.get("kind") in {"COMMERCIAL", "TIMING", "SCOPE", "POLICY"}
+    )
+    return "\n".join(chunks)
+
+
+def _has_dated_verified_evidence(packet: dict) -> bool:
+    return any(
+        item.get("kind") == "TIMING" or DATE_RE.search(_norm(item.get("claim", "")))
+        for item in packet.get("verified_evidence", [])
+    )
+
+
+def _has_risk_evidence(packet: dict) -> bool:
+    return any(item.get("kind") in RISK_EVIDENCE_KINDS for item in packet.get("verified_evidence", []))
+
+
+def _is_negative_or_warning(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in NEGATION_OR_WARNING)
+
+
+def _only_safety_imperative_usage(draft: str, marker: str) -> bool:
+    matched = [sentence for sentence in _sentences(draft) if marker in sentence]
+    if not matched:
+        return False
+    for sentence in matched:
+        if any(item in sentence for item in OUTCOME_CONTEXT):
+            return False
+        if not any(item in sentence for item in IMPERATIVE_SAFETY_MARKERS):
+            return False
+    return True
+
+
+def _contrarian_basis_is_valid(source: dict, packet: dict) -> bool:
+    basis = source.get("counterpoint_basis")
+    if not isinstance(basis, dict):
+        return False
+    kind = str(basis.get("kind", "")).strip().upper()
+    source_ref = str(basis.get("source_ref", "")).strip()
+    if not source_ref:
+        return False
+    if kind == "HUMAN_OPINION":
+        return any(
+            item.get("source_ref") == source_ref and item.get("kind") in CONTRARIAN_HUMAN_KINDS
+            for item in packet.get("verified_primary_info", [])
+        )
+    if kind == "EVIDENCE":
+        return any(item.get("source_ref") == source_ref for item in packet.get("verified_evidence", []))
+    return False
+
+
+def _freshness_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    if not any(marker in normalized for marker in FRESHNESS_MARKERS):
+        return []
+    if _has_dated_verified_evidence(packet):
+        return []
+    return [
+        {
+            "code": "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE",
+            "severity": "REVIEW",
+            "detail": "current/latest wording requires dated verified evidence; an as_of label alone is not evidence",
+        }
+    ]
+
+
+def _unsafe_bypass_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if any(pattern.search(sentence) for pattern in UNSAFE_ACTION_PATTERNS):
+            findings.append(
+                {"code": "UNSAFE_PERMISSION_OR_SECURITY_BYPASS", "severity": "BLOCK", "detail": sentence}
+            )
+    return findings
+
+
+def _automation_overreach_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if any(pattern.search(sentence) for pattern in AUTOMATION_OVERREACH_PATTERNS):
+            findings.append(
+                {"code": "AUTOMATION_WITHOUT_HUMAN_CHECKPOINT", "severity": "REVIEW", "detail": sentence}
+            )
+    return findings
+
+
+def _secret_transfer_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if SECRET_RE.search(sentence) and TRANSFER_RE.search(sentence) and MODEL_DESTINATION_RE.search(sentence):
+            findings.append({"code": "SECRET_TRANSFER_TO_MODEL_RISK", "severity": "BLOCK", "detail": sentence})
+    return findings
+
+
+def _cta_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    present = sorted(name for name, pattern in CTA_ACTION_PATTERNS.items() if pattern.search(normalized))
+    if len(present) < 2:
+        return []
+    return [
+        {"code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK", "severity": "REVIEW", "detail": ", ".join(present)}
+    ]
+
+
+def _warning_fatigue_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    count = normalized.count("超重要") + normalized.count("警告")
+    if count < 6:
+        return []
+    return [
+        {"code": "WARNING_FATIGUE_RISK", "severity": "REVIEW", "detail": f"strong warning markers repeated {count} times"}
+    ]
+
+
+def _self_responsibility_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    findings: list[dict] = []
+    for match in re.finditer("自己責任", normalized):
+        start = max(0, match.start() - 220)
+        end = min(len(normalized), match.end() + 220)
+        window = normalized[start:end]
+        if not any(marker in window for marker in LOCAL_MITIGATION_MARKERS):
+            findings.append(
+                {"code": "SELF_RESPONSIBILITY_WITHOUT_MITIGATION", "severity": "REVIEW", "detail": window[:180]}
+            )
+    return findings
+
+
+def _absolute_free_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    bound = _norm(_commercial_text(packet))
+    return [
+        {"code": "UNBOUND_ABSOLUTE_FREE_CLAIM", "severity": "BLOCK", "detail": marker}
+        for marker in ABSOLUTE_FREE_MARKERS
+        if marker in normalized and marker not in bound
+    ]
+
+
+def _superlative_findings(draft: str) -> list[dict]:
+    normalized = _norm(draft)
+    present = sorted({marker for marker in SUPERLATIVE_MARKERS if marker in normalized})
+    if not present:
+        return []
+    return [
+        {"code": "SUPERLATIVE_OR_TOTALIZING_LANGUAGE", "severity": "REVIEW", "detail": ", ".join(present)}
+    ]
+
+
+def _guarantee_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    commercial = _norm(_commercial_text(packet))
+    return [
+        {"code": "UNBOUND_GUARANTEE_LANGUAGE", "severity": "BLOCK", "detail": match.group(0)}
+        for match in GUARANTEE_RE.finditer(normalized)
+        if match.group(0) not in commercial
+    ]
+
+
+def _safety_language_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if _is_negative_or_warning(sentence):
+            continue
+        if ABSOLUTE_SAFETY_RE.search(sentence):
+            findings.append({"code": "ABSOLUTE_SAFETY_LANGUAGE", "severity": "REVIEW", "detail": sentence})
+    return findings
+
+
+def _outcome_promise_findings(draft: str) -> list[dict]:
+    return [
+        {"code": "OUTCOME_PROMISE_LANGUAGE", "severity": "REVIEW", "detail": sentence}
+        for sentence in _sentences(draft)
+        if OUTCOME_PROMISE_RE.search(sentence)
+    ]
+
+
+def _universal_capability_findings(draft: str) -> list[dict]:
+    return [
+        {"code": "UNIVERSAL_CAPABILITY_PROMISE", "severity": "REVIEW", "detail": match.group(0)}
+        for match in UNIVERSAL_CAPABILITY_RE.finditer(_norm(draft))
+    ]
+
+
+def _hardcoded_secret_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if not HARDCODED_SECRET_RE.search(sentence):
+            continue
+        if any(token in sentence for token in ("例", "ダミー", "placeholder", "プレースホルダー", "使わない", "禁止")):
+            continue
+        if HARDCODED_SECRET_USE_RE.search(sentence):
+            findings.append({"code": "HARDCODED_SECRET_LITERAL_RISK", "severity": "BLOCK", "detail": sentence})
+    return findings
+
+
+def _procedure_findings(draft: str, packet: dict) -> list[dict]:
+    if packet.get("topic_mode") != "PROCEDURAL":
+        return []
+    normalized = _norm(draft)
+    step_count = len(STEP_RE.findall(normalized))
+    if step_count < 3:
+        return []
+    findings: list[dict] = []
+    if not any(marker in normalized for marker in SUCCESS_MARKERS):
+        findings.append(
+            {"code": "PROCEDURE_WITHOUT_SUCCESS_SIGNAL", "severity": "REVIEW", "detail": f"{step_count} steps but no clear observable completion/success signal"}
+        )
+    if not any(marker in normalized for marker in RECOVERY_MARKERS):
+        findings.append(
+            {"code": "PROCEDURE_WITHOUT_RECOVERY_PATH", "severity": "REVIEW", "detail": f"{step_count} steps but no visible error/recovery path"}
+        )
+    if "なぜ" not in normalized and "理由" not in normalized:
+        findings.append(
+            {"code": "PROCEDURE_WITHOUT_WHY", "severity": "REVIEW", "detail": f"{step_count} steps but no rationale marker"}
+        )
+    return findings
+
+
+def _high_risk_front_findings(draft: str, packet: dict) -> list[dict]:
+    if packet.get("risk_policy", {}).get("risk_level") != "HIGH":
+        return []
+    front = _norm(draft)[:700]
+    if any(marker in front for marker in RISK_FRONT_MARKERS):
+        return []
+    return [
+        {
+            "code": "HIGH_RISK_WITHOUT_FRONT_STOP_GATE",
+            "severity": "BLOCK",
+            "detail": "high-risk guide begins without a visible risk/stop boundary near the front",
+        }
+    ]
+
+
+def _generic_abstract_collision_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        subjects = [marker for marker in GENERIC_SUBJECT_MARKERS if marker in sentence]
+        abstracts = [marker for marker in ABSTRACT_MARKERS if marker in sentence]
+        if subjects and abstracts:
+            findings.append(
+                {
+                    "code": "ABSTRACT_WORD_WITHOUT_PAYLOAD",
+                    "severity": "REVIEW",
+                    "detail": sentence,
+                    "markers": abstracts,
+                }
+            )
+    return findings
+
+
+def _evasion_findings(draft: str) -> list[dict]:
+    findings: list[dict] = []
+    for sentence in _sentences(draft):
+        if not any(marker in sentence for marker in EVASION_MARKERS):
+            continue
+        if any(marker in sentence for marker in EVASION_NEGATION_FORMS):
+            findings.append({"code": "PLATFORM_EVASION_LANGUAGE", "severity": "REVIEW", "detail": sentence})
+            continue
+        if EVASION_OPERATION_RE.search(sentence):
+            findings.append(
+                {"code": "PLATFORM_EVASION_OPERATIONAL_INSTRUCTION", "severity": "BLOCK", "detail": sentence}
+            )
+        else:
+            findings.append({"code": "PLATFORM_EVASION_LANGUAGE", "severity": "REVIEW", "detail": sentence})
+    return findings
+
+
+def _absolute_generalization_findings(draft: str, markers: set[str]) -> list[dict]:
+    findings: list[dict] = []
+    for marker in markers:
+        for sentence in _sentences(draft):
+            if marker not in sentence:
+                continue
+            if any(context in sentence for context in OUTCOME_CONTEXT):
+                continue
+            findings.append({"code": "ABSOLUTE_GENERALIZATION_LANGUAGE", "severity": "REVIEW", "detail": sentence})
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    if not isinstance(source, dict):
+        raise XArticleEngineError("source must be an object")
+
+    risk_level = str(source.get("risk_level", "STANDARD")).strip().upper()
+    if risk_level not in {"STANDARD", "ELEVATED", "HIGH"}:
+        raise XArticleEngineError("risk_level must be STANDARD, ELEVATED, or HIGH")
+
+    freshness_mode = str(source.get("freshness_mode", "EVERGREEN")).strip().upper()
+    if freshness_mode not in {"EVERGREEN", "CURRENT", "UPDATE"}:
+        raise XArticleEngineError("freshness_mode must be EVERGREEN, CURRENT, or UPDATE")
+    as_of = source.get("as_of")
+    if freshness_mode in {"CURRENT", "UPDATE"} and (not isinstance(as_of, str) or not as_of.strip()):
+        raise XArticleEngineError("CURRENT/UPDATE articles require a non-empty as_of boundary")
+
+    explicit_opening = source.get("opening_mode")
+    packet = _v08.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+
+    packet["freshness"] = {
+        "mode": freshness_mode,
+        "as_of": as_of.strip() if isinstance(as_of, str) else None,
+        "rule": "Current product/platform facts decay; preserve date/scope and re-verify them.",
+        "evidence_rule": "as_of is only a scope label; CURRENT/UPDATE also requires verified dated/TIMING evidence.",
+        "supersession_rule": "For UPDATE articles, say what changed, what survives, what is obsolete, and whether migration is needed.",
+    }
+    if freshness_mode in {"CURRENT", "UPDATE"} and not _has_dated_verified_evidence(packet):
+        raise XArticleEngineError(
+            "CURRENT/UPDATE articles require verified dated/TIMING evidence; as_of alone does not establish current truth"
+        )
+
+    packet["risk_policy"] = {
+        "risk_level": risk_level,
+        "front_gate_rule": "For HIGH-risk material, state verified risk, who should not proceed, and the stop/safer path before operational instructions.",
+        "evidence_rule": "HIGH-risk mode requires verified RISK/SAFETY/POLICY evidence.",
+        "anti_disclaimer_rule": "A disclaimer or 自己責任 sentence is not a substitute for concrete mitigation.",
+        "safety_asset_rule": "Safety-critical information may not be hidden behind registration, payment, or another CTA.",
+    }
+    if risk_level == "HIGH" and not _has_risk_evidence(packet):
+        raise XArticleEngineError(
+            "HIGH-risk articles require at least one verified RISK/SAFETY/POLICY evidence claim; warning tone alone is not evidence"
+        )
+
+    pain_anchors = [
+        item for item in packet.get("verified_primary_info", []) if item.get("kind") in PAIN_OPENING_KINDS
+    ]
+    if packet.get("opening_mode") == "LIVED_PAIN" and not pain_anchors:
+        if explicit_opening is not None:
+            raise XArticleEngineError(
+                "LIVED_PAIN in v0.9 requires human-attested PAIN or FAILURE; ORIGIN alone cannot authorize a pain opening"
+            )
+        packet["opening_mode"] = "RELATABLE"
+        packet["lived_pain_anchors"] = []
+        packet["narrative"]["sequence"] = [
+            "reader_state",
+            "evidence_if_available",
+            "anticipated_objection",
+            "cause",
+            "solution",
+            "stumbling_point",
+            "one_action_today",
+            "single_cta",
+        ]
+        packet["narrative"]["opening_doctrine"] = (
+            "An attested origin may explain why the article exists, but do not manufacture pain from origin alone."
+        )
+
+    if packet.get("opening_mode") == "CONTRARIAN" and not _contrarian_basis_is_valid(source, packet):
+        raise XArticleEngineError(
+            "CONTRARIAN opening requires counterpoint_basis bound to verified evidence or a human-attested BELIEF/OPINION"
+        )
+
+    packet["schema_version"] = "0.9"
+    packet["decision_then_path_policy"] = {
+        "principle": "Compare only material differences before a consequential choice; after a safe choice, collapse to one main path.",
+        "anti_overchoice": "Do not hand beginners a menu of equivalent methods when one safe default is enough.",
+        "anti_hidden_tradeoff": "Do not hide a material risk or trade-off merely to preserve a one-path experience.",
+    }
+    packet["completion_design_policy"] = {
+        "step_schema": ["GOAL", "ACTION", "EXPECTED_SIGNAL", "RECOVERY", "WHY_WHEN_NEEDED"],
+        "progress_rule": "Show current position, observable success, and what remains in long procedures.",
+        "micro_completion_rule": "Use real completion signals, not fake praise or gamification.",
+        "first_real_win_rule": "After setup, move quickly to one small meaningful use.",
+    }
+    packet["human_automation_boundary"] = {
+        "human_only_or_human_confirmed": [
+            "secrets/credentials",
+            "permission expansion/security bypass",
+            "irreversible or high-impact actions",
+            "final high-risk judgment",
+            "publication authority",
+        ],
+        "rule": "Automation may reduce repetition but must preserve human authorization, verification, stop, and recovery points.",
+    }
+    packet["pain_to_promise_policy"] = {
+        "principle": "Let an attested frustration shape the article promise, but do not upgrade it into an unverified guarantee.",
+        "mapping": "friction -> concrete promise -> mechanism -> evidence/conditions -> next action",
+    }
+    packet["strong_language_policy"] = {
+        "outcome_absolute": "BLOCK when unbound.",
+        "general_absolute": "REVIEW broad predictions/generalizations.",
+        "safety_imperative": "ALLOW genuinely protective strong wording.",
+    }
+    packet["opening_integrity_policy"] = {
+        "lived_pain_rule": "LIVED_PAIN requires actual attested PAIN or FAILURE; ORIGIN alone is not pain.",
+        "contrarian_rule": "CONTRARIAN requires explicit evidence-bound or human-attested counterpoint_basis.",
+        "anti_forcing_rule": "Opening mode follows available material; successful reference patterns do not authorize forced drama/proof/contrarianism.",
+    }
+    packet["security_content_policy"] = {
+        "hardcoded_secret_rule": "Do not normalize a reusable secret literal as a default public credential.",
+        "platform_evasion_rule": "Discussion of evasion requires review; operational evasion instructions are blocked.",
+        "evasion_negation_rule": "Recognize Japanese negative forms including polite forms before classifying discussion as operational instruction.",
+    }
+    packet["anti_ai_smell_policy"]["generic_abstract_collision_rule"] = (
+        "A generic subject such as 多くの人 must not make 構造/設計/本質 look concrete."
+    )
+    packet["knowledge_conflict_rules"] = [
+        "Specificity never overrides evidence binding.",
+        "Beginner simplicity never hides a material trade-off or risk.",
+        "One-path guidance begins after the decision that matters.",
+        "Long-form depth never justifies padding.",
+        "Strong voice never authorizes fabricated certainty, biography, or guarantees.",
+        "CTA usefulness never authorizes fake scarcity, fear, or competing actions.",
+        "Currentness never survives its evidence date automatically.",
+        "Safety information outranks CTA optimization.",
+        "Human authorization outranks automation convenience.",
+        "ORIGIN alone does not authorize LIVED_PAIN.",
+        "Contrarianism requires an explicit basis.",
+    ]
+
+    packet["generation_constraints"].extend(
+        [
+            "For time-sensitive product/platform claims, preserve as_of and re-verify currentness; do not recycle old UI, price, model, availability, limit, or recommendation claims as timeless truth.",
+            "Before a consequential choice, show material differences; after the choice, use one primary path unless a new material risk requires branching.",
+            "For procedures, pair important actions with observable success and nearby recovery; explain WHY where it affects judgment, safety, transfer, or troubleshooting.",
+            "Do not instruct readers to bypass permission/security controls or paste secrets/credentials into model chat as a normal workflow.",
+            "Do not use 自己責任 or fear language as substitutes for mitigation, stop conditions, least privilege, or recovery.",
+            "For HIGH-risk tutorials, put verified risk/stop boundaries before operational steps; never hide safety-critical information behind a CTA.",
+            "A CTA may appear at the next predictable wall but must remain one coherent continuation rather than multiple competing actions.",
+            "Classify 必ず/絶対 by meaning: unbound outcome guarantees block; broad predictions review; genuine safety imperatives may stay strong.",
+            "Do not use reusable hard-coded secret/API keys as the normal public setup path.",
+            "Do not provide operational instructions for BAN/detection/enforcement evasion.",
+            "Do not treat ORIGIN as pain unless the human also attested PAIN or FAILURE.",
+            "Do not manufacture a contrarian opening; require an explicit evidence-bound or human-attested counterpoint basis.",
+            "Do not count generic words such as 人 as concrete payload for an otherwise empty 構造/設計/本質 sentence.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "If this article says 最新・現在・現時点, what dated verified evidence makes that true now?",
+            "Did I reuse an old UI path, plan, price, model, comparison, or recommendation after the product changed?",
+            "Before the path became one-way, did I expose the material choice/risk that required a decision?",
+            "For each important procedure, can the reader tell what success looks like and what to do if it does not happen?",
+            "Did any instruction ask the reader to bypass permissions, weaken security, or give a secret/credential to an AI model for convenience?",
+            "If I wrote 自己責任 or a warning, did I also give concrete mitigation, a stop condition, and a recovery path?",
+            "Is any safety-critical information being withheld until after signup/payment/CTA?",
+            "How many different commercial actions does the draft ask for? Can they be reduced to the single intended next step?",
+            "Does the CTA appear at a real next wall, or was a wall manufactured to justify it?",
+            "Does automation stop where a human must authorize, verify, judge, or recover?",
+            "Is a strong 必ず/絶対 sentence an outcome guarantee, a broad prediction, or a necessary safety prohibition?",
+            "Does any tutorial publish a reusable secret literal or predictable default credential?",
+            "Does any advice rely on platform-evasion behavior rather than compliant operation?",
+            "For HIGH-risk content, which verified evidence supports the actual risk?",
+            "Is the opening emotion actually present in PAIN/FAILURE, or did the draft turn neutral origin into drama?",
+            "If the opening is contrarian, what exact evidence or human belief/opinion is it based on?",
+            "権限・安全・自動化の説明で、禁止や停止条件を危険な実行指示として誤読していないか？",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _v08.audit_draft(draft, packet)
+    filtered: list[dict] = []
+    downgraded_absolute_markers: set[str] = set()
+
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+        if code == "UNBOUND_STRONG_CLAIM" and detail in {"必ず", "絶対"}:
+            if _only_safety_imperative_usage(draft, detail):
+                continue
+            matching_sentences = [sentence for sentence in _sentences(draft) if detail in sentence]
+            if matching_sentences and not any(
+                any(context in sentence for context in OUTCOME_CONTEXT) for sentence in matching_sentences
+            ):
+                downgraded_absolute_markers.add(detail)
+                continue
+        filtered.append(item)
+
+    findings = [
+        *filtered,
+        *_freshness_findings(draft, packet),
+        *_unsafe_bypass_findings(draft),
+        *_automation_overreach_findings(draft),
+        *_secret_transfer_findings(draft),
+        *_cta_findings(draft),
+        *_warning_fatigue_findings(draft),
+        *_self_responsibility_findings(draft),
+        *_absolute_free_findings(draft, packet),
+        *_superlative_findings(draft),
+        *_guarantee_findings(draft, packet),
+        *_safety_language_findings(draft),
+        *_outcome_promise_findings(draft),
+        *_universal_capability_findings(draft),
+        *_hardcoded_secret_findings(draft),
+        *_procedure_findings(draft, packet),
+        *_high_risk_front_findings(draft, packet),
+        *_generic_abstract_collision_findings(draft),
+        *_evasion_findings(draft),
+        *_absolute_generalization_findings(draft, downgraded_absolute_markers),
+    ]
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/v09_final.py
+++ b/x_article_engine/v09_final.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import v09_hardened as _hardened
+from . import core as _core
+
+
+# ---- R9: CTA semantics -----------------------------------------------------
+
+FIT_CHECK_ACTION_RE = re.compile(
+    r"(?:無料(?:適合確認|制作可否確認)|無料で(?:適合|制作可否)を?確認)"
+    r"[^。\n]{0,30}"
+    r"(?:から始め|で始め|を使|を受け|へ進|はこちら|できます|できる|してみ|してください|しませんか)"
+)
+
+FIT_CHECK_NON_ACTION_RE = re.compile(
+    r"(?:無料適合確認|無料制作可否確認)[^。\n]{0,25}"
+    r"(?:という考え|という言葉|を説明|の意味|について書|について話)"
+)
+
+
+# ---- R10: numeric-boundary + rejected bad-example semantics ---------------
+
+NUMERIC_COMPONENT_CLASS = r"0-9一二三四五六七八九十百千万億兆,.，．"
+
+META_REJECTION_MARKERS = (
+    "と書くのはやめ",
+    "と書かない",
+    "とは書かない",
+    "という表現は使わない",
+    "という表現は使いません",
+    "という言い方は使わない",
+    "という言い方は使いません",
+    "という断言はしない",
+    "という断言はしません",
+    "と断言するのはやめ",
+    "は危険な表現",
+    "をAIに作らせてはいけません",
+    "をAIに作らせてはいけない",
+    "を捏造してはいけません",
+    "を捏造してはいけない",
+)
+
+
+# ---- R11: numeric-context laundering --------------------------------------
+
+COMMERCIAL_KINDS = {"COMMERCIAL"}
+RESULT_KINDS = {"RESULT", "CASE_RESULT"}
+TIMING_KINDS = {"TIMING"}
+
+COMMERCIAL_MARKERS = (
+    "価格",
+    "料金",
+    "税込",
+    "月額",
+    "費用",
+    "設計書",
+    "購入",
+    "支払",
+    "標準",
+    "追加料金",
+)
+
+RESULT_MARKERS = (
+    "売上",
+    "売れ",
+    "節約",
+    "削減",
+    "短縮",
+    "増え",
+    "減った",
+    "減りました",
+    "実績",
+    "成果",
+    "顧客",
+    "フォロワー",
+    "リスト",
+    "獲得",
+    "作業時間",
+)
+
+TIMING_MARKERS = (
+    "営業日",
+    "納期",
+    "納品",
+    "以内",
+    "までに",
+    "目安",
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _reader_actions(draft: str) -> set[str]:
+    actions: set[str] = set()
+    for sentence in _hardened._sentences(draft):
+        if _hardened._is_claim_negation(sentence) or _hardened._is_prohibition(sentence):
+            continue
+        for name, pattern in _hardened._base.CTA_ACTION_PATTERNS.items():
+            if pattern.search(sentence):
+                actions.add(name)
+        if FIT_CHECK_ACTION_RE.search(sentence) and not FIT_CHECK_NON_ACTION_RE.search(sentence):
+            actions.add("fit_check")
+    return actions
+
+
+def _is_meta_rejection(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in META_REJECTION_MARKERS)
+
+
+def _token_only_in_meta_rejection(draft: str, token: str) -> bool:
+    normalized_token = _norm(token)
+    matches = [sentence for sentence in _sentences(draft) if normalized_token in sentence]
+    return bool(matches) and all(_is_meta_rejection(sentence) for sentence in matches)
+
+
+def _all_identity_risk_is_meta_rejected(draft: str) -> bool:
+    identity_sentences = []
+    for sentence in _sentences(draft):
+        if any(pattern.search(sentence) for pattern in _core.IDENTITY_RISK_PATTERNS):
+            identity_sentences.append(sentence)
+    return bool(identity_sentences) and all(_is_meta_rejection(sentence) for sentence in identity_sentences)
+
+
+def _exact_numeric_in_text(token: str, text: str) -> bool:
+    normalized_token = _norm(token)
+    normalized_text = _norm(text)
+    pattern = re.compile(
+        rf"(?<![{NUMERIC_COMPONENT_CLASS}]){re.escape(normalized_token)}(?![{NUMERIC_COMPONENT_CLASS}])"
+    )
+    return bool(pattern.search(normalized_text))
+
+
+def _exact_numeric_bound(token: str, packet: dict) -> bool:
+    return _exact_numeric_in_text(token, _core._bound_corpus(packet))
+
+
+def _numeric_binding_findings(draft: str, packet: dict) -> list[dict]:
+    normalized = _norm(draft)
+    findings: list[dict] = []
+    seen: set[str] = set()
+    for match in _core.NUMERIC_RE.finditer(normalized):
+        token = _core._canonical_numeric(match.group(0), packet)
+        if token in seen:
+            continue
+        seen.add(token)
+        if _token_only_in_meta_rejection(draft, token):
+            continue
+        if not _exact_numeric_bound(token, packet):
+            findings.append(
+                {
+                    "code": "UNBOUND_NUMERIC_CLAIM",
+                    "severity": "BLOCK",
+                    "detail": token,
+                    "meteor_note": "numeric evidence requires a numeric-token boundary match; substring binding is not sufficient",
+                }
+            )
+    return findings
+
+
+def _numeric_contexts(sentence: str) -> set[str]:
+    contexts: set[str] = set()
+    if any(marker in sentence for marker in COMMERCIAL_MARKERS):
+        contexts.add("COMMERCIAL")
+    if any(marker in sentence for marker in RESULT_MARKERS):
+        contexts.add("RESULT")
+    if any(marker in sentence for marker in TIMING_MARKERS):
+        contexts.add("TIMING")
+    return contexts
+
+
+def _evidence_contexts_for_numeric(token: str, packet: dict) -> set[str]:
+    contexts: set[str] = set()
+    for item in packet.get("verified_evidence", []):
+        if not _exact_numeric_in_text(token, str(item.get("claim", ""))):
+            continue
+        kind = item.get("kind")
+        if kind in COMMERCIAL_KINDS:
+            contexts.add("COMMERCIAL")
+        if kind in RESULT_KINDS:
+            contexts.add("RESULT")
+        if kind in TIMING_KINDS:
+            contexts.add("TIMING")
+    return contexts
+
+
+def _primary_context_bound(token: str, packet: dict) -> bool:
+    return any(
+        _exact_numeric_in_text(token, str(item.get("claim", "")))
+        for item in packet.get("verified_primary_info", [])
+    )
+
+
+def _context_laundering_findings(draft: str, packet: dict) -> list[dict]:
+    findings: list[dict] = []
+    seen: set[tuple[str, str]] = set()
+
+    for sentence in _sentences(draft):
+        if _is_meta_rejection(sentence):
+            continue
+        for match in _core.NUMERIC_RE.finditer(sentence):
+            token = _core._canonical_numeric(match.group(0), packet)
+            if not _exact_numeric_bound(token, packet):
+                continue
+            if _primary_context_bound(token, packet):
+                continue
+
+            draft_contexts = _numeric_contexts(sentence)
+            if not draft_contexts:
+                continue
+            evidence_contexts = _evidence_contexts_for_numeric(token, packet)
+            if not evidence_contexts or draft_contexts.intersection(evidence_contexts):
+                continue
+
+            key = (token, sentence)
+            if key in seen:
+                continue
+            seen.add(key)
+            findings.append(
+                {
+                    "code": "NUMERIC_CONTEXT_REUSE_RISK",
+                    "severity": "REVIEW",
+                    "detail": token,
+                    "draft_context": sorted(draft_contexts),
+                    "evidence_context": sorted(evidence_contexts),
+                    "sentence": sentence,
+                }
+            )
+    return findings
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _hardened.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    packet["schema_version"] = "0.9"
+    packet["meteor_status"] = "R11_SYNTHESIZED"
+    packet["cta_semantics_policy"] = {
+        "principle": "Count an action as a CTA when the reader is invited to take it, not merely when its noun appears.",
+        "fit_check_examples": [
+            "無料適合確認から始められます -> CTA",
+            "無料適合確認を使ってください -> CTA",
+            "無料適合確認という考え方を説明します -> not a CTA",
+        ],
+    }
+    packet["numeric_binding_policy"] = {
+        "principle": "Numeric evidence must match at numeric-token boundaries. A shorter number cannot borrow authority by being a substring of a larger verified number.",
+    }
+    packet["meta_rejection_policy"] = {
+        "principle": "A dangerous claim shown only as wording the author rejects is not itself an asserted claim.",
+    }
+    packet["numeric_context_policy"] = {
+        "principle": "Exact numeric equality is necessary but not sufficient; obvious commercial/result/timing category changes require review.",
+        "deterministic_scope": "Fine-grained semantic equivalence remains a /human responsibility.",
+    }
+    packet["generation_constraints"].extend(
+        [
+            "Treat natural continuation language such as '無料適合確認から始められます' as a real CTA for multi-action review.",
+            "Never authorize a numeric claim merely because its digits are a substring of a larger verified number.",
+            "When risky wording is shown only as an example to reject, determine polarity before auditing it as an asserted claim.",
+            "Do not reuse a verified number under a different claim category merely because the digits match exactly.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "CTAは命令形だけで数えていないか？『〜から始められます』のような自然な次行動も含めて確認したか？",
+            "数字の根拠が部分一致になっていないか？10,000円の証拠で0円を通すような誤結合がないか？",
+            "悪い文章例として引用して否定している断言を、本文の主張として誤認していないか？",
+            "同じ数字でも意味を横流ししていないか？価格の数字を売上・節約額・顧客成果へ化けさせていないか？",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _hardened.audit_draft(draft, packet)
+    findings: list[dict] = []
+    all_identity_meta_rejected = _all_identity_risk_is_meta_rejected(draft)
+
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        # Recompute CTA semantics and numeric evidence below.
+        if code in {"MULTIPLE_COMMERCIAL_ACTIONS_RISK", "UNBOUND_NUMERIC_CLAIM"}:
+            continue
+
+        if code == "UNBOUND_IDENTITY_DETAIL" and all_identity_meta_rejected:
+            continue
+
+        if code in {
+            "UNBOUND_STRONG_CLAIM",
+            "UNBOUND_GUARANTEE_LANGUAGE",
+            "ABSOLUTE_SAFETY_LANGUAGE",
+            "OUTCOME_PROMISE_LANGUAGE",
+            "UNIVERSAL_CAPABILITY_PROMISE",
+            "SUPERLATIVE_OR_TOTALIZING_LANGUAGE",
+        }:
+            if detail and _token_only_in_meta_rejection(draft, detail):
+                continue
+            matching = [sentence for sentence in _sentences(draft) if detail and detail in sentence]
+            if matching and all(_is_meta_rejection(sentence) for sentence in matching):
+                continue
+
+        findings.append(item)
+
+    actions = _reader_actions(draft)
+    if len(actions) >= 2:
+        findings.append(
+            {
+                "code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK",
+                "severity": "REVIEW",
+                "detail": ", ".join(sorted(actions)),
+            }
+        )
+
+    findings.extend(_numeric_binding_findings(draft, packet))
+    findings.extend(_context_laundering_findings(draft, packet))
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result

--- a/x_article_engine/v09_hardened.py
+++ b/x_article_engine/v09_hardened.py
@@ -1,0 +1,381 @@
+from __future__ import annotations
+
+import re
+import unicodedata
+
+from . import v09 as _base
+from .core import XArticleEngineError
+
+
+CURRENT_MODES = {"CURRENT", "UPDATE"}
+RISK_KINDS = {"RISK", "SAFETY", "POLICY"}
+
+CLAIM_NEGATION_MARKERS = (
+    "とは限りません",
+    "とは限らない",
+    "とは言いません",
+    "とは言わない",
+    "とは書けません",
+    "とは書かない",
+    "とは断言できません",
+    "とは断言できない",
+    "と断言しません",
+    "と断言しない",
+    "ではありません",
+    "ではない",
+    "わけではありません",
+    "わけではない",
+    "という意味ではありません",
+    "という意味ではない",
+    "とは約束できません",
+    "とは約束できない",
+    "保証しません",
+    "保証しない",
+)
+
+PROHIBITION_MARKERS = (
+    "てはいけません",
+    "てはいけない",
+    "ではいけません",
+    "ではいけない",
+    "ないでください",
+    "禁止です",
+    "禁止します",
+    "やめてください",
+    "避けてください",
+    "推奨しません",
+    "推奨しない",
+    "書いてはいけません",
+    "書いてはいけない",
+)
+
+NEGATED_FRESHNESS_PATTERNS = (
+    re.compile(r"(?:最新|最新版|現在|現時点)[^。\n]{0,25}(?:ではありません|ではない|とは限りません|とは限らない)"),
+    re.compile(r"(?:最新|最新版|現在|現時点)[^。\n]{0,25}(?:と断言しません|とは言いません|とは書けません)"),
+)
+
+NEGATED_ABSOLUTE_FREE_PATTERNS = (
+    re.compile(r"(?:完全無料|ずっと無料|永久無料)[^。\n]{0,25}(?:ではありません|ではない|とは限りません|とは限らない)"),
+    re.compile(r"(?:完全無料|ずっと無料|永久無料)[^。\n]{0,25}(?:とは言いません|とは書けません|とは約束できません)"),
+)
+
+NEGATED_SUPERLATIVE_PATTERNS = (
+    re.compile(r"(?:世界一|唯一|最強)[^。\n]{0,25}(?:ではありません|ではない|とは限りません|とは限らない)"),
+    re.compile(r"(?:世界一|唯一|最強)[^。\n]{0,25}(?:とは言いません|とは書けません|と断言しません)"),
+)
+
+POSITIVE_RISK_FRONT_PATTERNS = (
+    re.compile(r"警告\s*[:：]"),
+    re.compile(r"(?:危険|リスク)[^。\n]{0,30}(?:があります|がある|を伴|が高|が生じ|が発生|可能性があります|可能性がある)"),
+    re.compile(r"対象外[^。\n]{0,45}(?:進めない|進まない|使わない|避けて|やめて)"),
+    re.compile(r"(?:進め|使わ|実行し|共有し)[^。\n]{0,20}(?:ないでください|てはいけません|てはいけない)"),
+    re.compile(r"(?:停止|中止)[^。\n]{0,20}(?:してください|して戻|する必要|します)"),
+)
+
+NEGATED_RISK_FRONT_PATTERNS = (
+    re.compile(r"(?:危険|リスク)[^。\n]{0,20}(?:ではありません|ではない|はありません|はない)"),
+    re.compile(r"(?:停止|中止)[^。\n]{0,15}(?:しないで|不要|する必要はない)"),
+)
+
+
+def _norm(value: str) -> str:
+    return unicodedata.normalize("NFKC", value)
+
+
+def _sentences(text: str) -> list[str]:
+    return [
+        item.strip()
+        for item in re.split(r"(?<=[。！？!?])|\n+", _norm(text))
+        if item.strip()
+    ]
+
+
+def _is_claim_negation(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in CLAIM_NEGATION_MARKERS)
+
+
+def _is_prohibition(sentence: str) -> bool:
+    normalized = _norm(sentence)
+    return any(marker in normalized for marker in PROHIBITION_MARKERS)
+
+
+def _token_only_in_negated_sentences(draft: str, token: str) -> bool:
+    matches = [sentence for sentence in _sentences(draft) if token in sentence]
+    return bool(matches) and all(_is_claim_negation(sentence) for sentence in matches)
+
+
+def _sentence_matches_any(sentence: str, patterns: tuple[re.Pattern, ...]) -> bool:
+    return any(pattern.search(_norm(sentence)) for pattern in patterns)
+
+
+def _all_marker_mentions_negated(draft: str, marker: str, patterns: tuple[re.Pattern, ...]) -> bool:
+    matches = [sentence for sentence in _sentences(draft) if marker in sentence]
+    return bool(matches) and all(
+        _sentence_matches_any(sentence, patterns) or _is_claim_negation(sentence)
+        for sentence in matches
+    )
+
+
+def _verified_by_ref(packet: dict) -> dict[str, list[dict]]:
+    index: dict[str, list[dict]] = {}
+    for item in packet.get("verified_evidence", []):
+        ref = str(item.get("source_ref", "")).strip()
+        if ref:
+            index.setdefault(ref, []).append(item)
+    return index
+
+
+def _normalize_ref_list(source: dict, field: str) -> list[str]:
+    value = source.get(field, [])
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise XArticleEngineError(f"{field} must be a list of source_ref strings")
+    refs: list[str] = []
+    for item in value:
+        ref = str(item).strip()
+        if not ref:
+            raise XArticleEngineError(f"{field} must not contain empty refs")
+        if ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _require_bound_refs(
+    *,
+    refs: list[str],
+    verified_index: dict[str, list[dict]],
+    allowed_kinds: set[str],
+    field: str,
+) -> list[dict]:
+    if not refs:
+        raise XArticleEngineError(f"{field} requires at least one explicitly bound verified evidence ref")
+    bound: list[dict] = []
+    for ref in refs:
+        candidates = verified_index.get(ref, [])
+        allowed = [item for item in candidates if item.get("kind") in allowed_kinds]
+        if not allowed:
+            kinds = "/".join(sorted(allowed_kinds))
+            raise XArticleEngineError(
+                f"{field} ref {ref!r} must resolve to verified evidence of kind {kinds}"
+            )
+        bound.extend(allowed)
+    return bound
+
+
+def _real_reader_actions(draft: str) -> set[str]:
+    actions: set[str] = set()
+    for sentence in _sentences(draft):
+        if _is_claim_negation(sentence) or _is_prohibition(sentence):
+            continue
+        for name, pattern in _base.CTA_ACTION_PATTERNS.items():
+            if pattern.search(sentence):
+                actions.add(name)
+    return actions
+
+
+def _has_positive_front_gate(draft: str) -> bool:
+    front = _norm(draft)[:700]
+    for sentence in _sentences(front):
+        if any(pattern.search(sentence) for pattern in NEGATED_RISK_FRONT_PATTERNS):
+            continue
+        if any(pattern.search(sentence) for pattern in POSITIVE_RISK_FRONT_PATTERNS):
+            return True
+    return False
+
+
+def build_generation_packet(source: dict, *, trusted_source_refs: list[dict]) -> dict:
+    packet = _base.build_generation_packet(source, trusted_source_refs=trusted_source_refs)
+    verified_index = _verified_by_ref(packet)
+
+    freshness_refs = _normalize_ref_list(source, "freshness_evidence_refs")
+    if packet.get("freshness", {}).get("mode") in CURRENT_MODES:
+        freshness_bound = _require_bound_refs(
+            refs=freshness_refs,
+            verified_index=verified_index,
+            allowed_kinds={"TIMING"},
+            field="freshness_evidence_refs",
+        )
+    else:
+        freshness_bound = []
+
+    risk_refs = _normalize_ref_list(source, "risk_evidence_refs")
+    if packet.get("risk_policy", {}).get("risk_level") == "HIGH":
+        risk_bound = _require_bound_refs(
+            refs=risk_refs,
+            verified_index=verified_index,
+            allowed_kinds=RISK_KINDS,
+            field="risk_evidence_refs",
+        )
+    else:
+        risk_bound = []
+
+    packet["schema_version"] = "0.9"
+    packet["freshness"]["evidence_refs"] = freshness_refs
+    packet["freshness"]["bound_evidence"] = freshness_bound
+    packet["freshness"]["binding_rule"] = (
+        "CURRENT/UPDATE is not authorized by an arbitrary dated fact; freshness_evidence_refs must bind verified TIMING evidence."
+    )
+    packet["risk_policy"]["evidence_refs"] = risk_refs
+    packet["risk_policy"]["bound_evidence"] = risk_bound
+    packet["risk_policy"]["binding_rule"] = (
+        "HIGH-risk mode is not authorized by an unrelated risk fact; risk_evidence_refs must bind verified RISK/SAFETY/POLICY evidence."
+    )
+    packet["negated_claim_policy"] = {
+        "principle": "Claims explicitly denied/quoted for criticism are not assertions merely because the same tokens appear."
+    }
+    packet["polarity_policy"] = {
+        "principle": "Security, stop-gate, and CTA audits distinguish recommendation from prohibition/negation.",
+        "front_gate_rule": "Negated risk words do not satisfy a HIGH-risk stop gate.",
+        "cta_rule": "Rejected actions do not count as CTAs.",
+    }
+    packet["evidence_purpose_binding_policy"] = {
+        "principle": "Verified evidence cannot be borrowed for an unrelated decision; bind it to its purpose.",
+        "freshness": "freshness_evidence_refs -> verified TIMING evidence",
+        "high_risk": "risk_evidence_refs -> verified RISK/SAFETY/POLICY evidence",
+        "contrarian": "counterpoint_basis -> verified evidence or human-attested opinion/belief",
+    }
+    packet["generation_constraints"].extend(
+        [
+            "Do not audit an explicitly denied/criticized claim as if the author asserted it.",
+            "Determine polarity before classifying security instructions and CTAs.",
+            "Do not let negated safety wording satisfy a HIGH-risk front gate.",
+            "CURRENT/UPDATE must bind freshness_evidence_refs to verified TIMING evidence.",
+            "HIGH-risk mode must bind risk_evidence_refs to verified RISK/SAFETY/POLICY evidence.",
+        ]
+    )
+    packet["human_gate"]["checks"].extend(
+        [
+            "危険な断言を否定・批判するために引用した文まで、断言そのものとして扱っていないか？",
+            "危険語・CTA語は実行を勧めているのか、それとも禁止・否定しているのか？",
+            "freshness_evidence_refs は、本文の現在性そのものを本当に支えているか？",
+            "risk_evidence_refs は、本文で警告している具体的な危険と本当に同じ危険を支えているか？",
+        ]
+    )
+    return packet
+
+
+def audit_draft(draft: str, packet: dict) -> dict:
+    result = _base.audit_draft(draft, packet)
+    findings: list[dict] = []
+
+    for item in result.get("findings", []):
+        code = item.get("code")
+        detail = str(item.get("detail", ""))
+
+        if code in {"UNBOUND_NUMERIC_CLAIM", "UNBOUND_FUZZY_QUANT_CLAIM"}:
+            if _token_only_in_negated_sentences(draft, detail):
+                continue
+
+        if code == "UNBOUND_IDENTITY_DETAIL" and _is_claim_negation(detail):
+            continue
+
+        if code == "UNBOUND_STRONG_CLAIM" and _token_only_in_negated_sentences(draft, detail):
+            continue
+
+        if code == "FRESHNESS_CLAIM_WITHOUT_DATED_EVIDENCE":
+            freshness_tokens = [marker for marker in _base.FRESHNESS_MARKERS if marker in _norm(draft)]
+            if freshness_tokens and all(
+                _all_marker_mentions_negated(draft, marker, NEGATED_FRESHNESS_PATTERNS)
+                for marker in freshness_tokens
+            ):
+                continue
+
+        if code == "UNBOUND_ABSOLUTE_FREE_CLAIM":
+            if _all_marker_mentions_negated(draft, detail, NEGATED_ABSOLUTE_FREE_PATTERNS):
+                continue
+
+        if code == "SUPERLATIVE_OR_TOTALIZING_LANGUAGE":
+            present = [marker for marker in _base.SUPERLATIVE_MARKERS if marker in _norm(draft)]
+            if present and all(
+                _all_marker_mentions_negated(draft, marker, NEGATED_SUPERLATIVE_PATTERNS)
+                for marker in present
+            ):
+                continue
+
+        if code in {
+            "UNBOUND_GUARANTEE_LANGUAGE",
+            "ABSOLUTE_SAFETY_LANGUAGE",
+            "OUTCOME_PROMISE_LANGUAGE",
+            "UNIVERSAL_CAPABILITY_PROMISE",
+            "ABSOLUTE_GENERALIZATION_LANGUAGE",
+        }:
+            matching = [
+                sentence
+                for sentence in _sentences(draft)
+                if detail in sentence
+                or any(
+                    token in sentence
+                    for token in re.findall(r"[一-龥ぁ-んァ-ンA-Za-z0-9%％]+", detail)
+                )
+            ]
+            if matching and all(_is_claim_negation(sentence) for sentence in matching):
+                continue
+
+        if code in {"UNSAFE_PERMISSION_OR_SECURITY_BYPASS", "SECRET_TRANSFER_TO_MODEL_RISK"}:
+            if _is_prohibition(detail):
+                continue
+
+        if code in {"MULTIPLE_COMMERCIAL_ACTIONS_RISK", "HIGH_RISK_WITHOUT_FRONT_STOP_GATE"}:
+            continue
+
+        findings.append(item)
+
+    actions = _real_reader_actions(draft)
+    if len(actions) >= 2:
+        findings.append(
+            {
+                "code": "MULTIPLE_COMMERCIAL_ACTIONS_RISK",
+                "severity": "REVIEW",
+                "detail": ", ".join(sorted(actions)),
+            }
+        )
+
+    if packet.get("risk_policy", {}).get("risk_level") == "HIGH" and not _has_positive_front_gate(draft):
+        findings.append(
+            {
+                "code": "HIGH_RISK_WITHOUT_FRONT_STOP_GATE",
+                "severity": "BLOCK",
+                "detail": "high-risk guide lacks an affirmative warning/stop/exclusion meaning near the front; negated risk words do not count",
+            }
+        )
+
+    normalized = _norm(draft)
+    current_words = [marker for marker in _base.FRESHNESS_MARKERS if marker in normalized]
+    if current_words:
+        non_negated_current = [
+            marker
+            for marker in current_words
+            if not _all_marker_mentions_negated(draft, marker, NEGATED_FRESHNESS_PATTERNS)
+        ]
+        if non_negated_current:
+            clean = (
+                packet.get("freshness", {}).get("mode") in CURRENT_MODES
+                and bool(packet.get("freshness", {}).get("evidence_refs"))
+            )
+            if not clean:
+                findings.append(
+                    {
+                        "code": "FRESHNESS_CLAIM_WITHOUT_BOUND_EVIDENCE",
+                        "severity": "REVIEW",
+                        "detail": ", ".join(non_negated_current),
+                    }
+                )
+
+    deduped: list[dict] = []
+    seen: set[tuple[str, str, str]] = set()
+    for item in findings:
+        key = (str(item.get("code")), str(item.get("severity")), str(item.get("detail")))
+        if key not in seen:
+            seen.add(key)
+            deduped.append(item)
+
+    blocked = any(item.get("severity") == "BLOCK" for item in deduped)
+    review_count = sum(1 for item in deduped if item.get("severity") == "REVIEW")
+    result["findings"] = deduped
+    result["status"] = "BLOCKED" if blocked else "HUMAN_REVIEW_REQUIRED"
+    result["meteor_v09_review_count"] = review_count
+    result["meteor_v09_block_count"] = sum(1 for item in deduped if item.get("severity") == "BLOCK")
+    result["meteor_v09_gate"] = "BLOCK" if blocked else ("REVIEW" if review_count else "CLEAN_BY_HEURISTIC")
+    return result


### PR DESCRIPTION
## Purpose
Turn the accumulated X Article Engine reference-learning batch into an adversarially tested v0.9 candidate instead of copying any reference article's factual claims, metrics, product instructions, or sales tactics as timeless doctrine.

## What METEOR now covers
- evidence-bound freshness and supersession
- compare-before-choice / one-path-after-choice
- procedural completion signals, recovery, and WHY
- risk-first stop gates backed by verified risk evidence
- permission/security bypass detection
- secret-to-model workflow detection
- human/automation authorization boundaries
- hard-coded secret-default detection
- strong `必ず/絶対` semantics: guarantee vs broad prediction vs safety imperative
- CTA action-count review rather than raw keyword counting
- warning fatigue and `自己責任` without mitigation
- platform-evasion discussion vs operational evasion instructions
- LIVED_PAIN integrity: ORIGIN alone cannot manufacture pain
- CONTRARIAN integrity: explicit evidence/human basis required
- anti-AI-smell false-positive hardening for generic subjects + abstract nouns
- Japanese polite-negation handling
- explicit negated-claim attacks (`完全無料ではありません`, `保証しますとは書けません`, etc.)

## Counter-DA findings
METEOR attacked its own defenses and found/fixed cases where:
- `as_of` was being mistaken for currentness evidence
- a dangerous command inside a prohibition looked like a recommendation
- `APIキーは絶対に共有しない` looked like a commercial guarantee
- a settings-screen credential looked like a secret pasted into model chat
- narrative mentions of registration/followers looked like CTAs
- `推奨しません` was misread as an operational evasion instruction
- the bare character `人` let empty `本質/構造/設計` language escape the AI-smell audit

## Regression architecture
Historical version tests are now pinned to their actual historical modules. Only the latest-root contract imports `x_article_engine` root. This prevents old schema assertions from silently following the newest layer.

## CI
Dedicated workflow: `.github/workflows/x-article-engine-meteor.yml`

It runs:

`python -m pytest -q tests/test_x_article_engine*.py`

and cancels stale runs when a newer commit arrives.

Meaningful CI milestones:
- first full pytest: **126 passed / 4 failed**
- after fixes/R5: **136 passed**
- after flattening R1-R5 into direct `x_article_engine/v09.py` and adding consolidation equivalence attacks: **149 passed**
- after R6 negated-claim attack layer: **165 passed**

Important: package root currently points to the flat `v09.py` production candidate. The R6 negated-claim fix is validated in an attack layer but has not yet been absorbed into the flat production module, so this PR is intentionally **not ready to merge yet**.

## Anti-SimCity consolidation
R1-R5 remain as attack-history/regression artifacts, but the normal runtime path was flattened to `x_article_engine/v09.py` on top of v0.8. The attack stack is no longer the package-root runtime path.

The next step is to absorb the validated R6 negation semantics into flat v0.9, rerun the root/equivalence suite, then decide final promotion.

## Report
See `x_article_engine/V09_METEOR_REPORT.md` for the round-by-round findings and residual `/human` semantic risks.

Publication remains `/human` gated, `BLOCKED_PENDING_HUMAN`, and `USER_ONLY`.