### PR TITLE
Add Control Plane Escape recovery rule

### DIFF
--- a/thin-rts/ultimate-loop/CONTROL_PLANE_ESCAPE_GATE_2026-08-16.md
+++ b/thin-rts/ultimate-loop/CONTROL_PLANE_ESCAPE_GATE_2026-08-16.md
@@ -1,0 +1,145 @@
+# ULTIMATE LOOP — Control Plane Escape / Recovery Control Surface Gate
+
+Date: **2026-08-16 JST**
+
+Status: `CANDIDATE / PR_PENDING`
+
+## Purpose
+
+When the normal operator surface becomes unusable, degraded, misleading, or unavailable, recovery must not depend on that same failed surface.
+
+The objective is to regain bounded control through an independent surface, preserve available failure evidence, escalate only as far as required, and then prove the recovered runtime through Deployment Identity and the Post-Deploy Reality Gate.
+
+This gate does **not** make CLI, SSH, provider APIs, service managers, reboot mechanisms, or failover engines part of Ultimate Loop. Those remain replaceable external executors.
+
+## Core distinction
+
+A control surface is the mechanism used to observe or actuate a workload, for example:
+
+- web console / GUI;
+- CLI;
+- provider API / SDK;
+- SSH / remote shell;
+- service manager such as `systemd`;
+- host or provider recovery interface.
+
+The workload is the service or capability being protected.
+
+`CONTROL_SURFACE_FAILURE != WORKLOAD_FAILURE`
+
+A dead GUI may coexist with a healthy workload. A healthy GUI may coexist with a broken workload. They must be evidenced separately.
+
+## State path
+
+```text
+PRIMARY CONTROL SURFACE HEALTHY
+-> PRIMARY CONTROL SURFACE DEGRADED / FAILED / UNTRUSTWORTHY
+-> EVIDENCE CAPTURE ATTEMPT
+-> ALTERNATE CONTROL SURFACE ESTABLISHED
+-> SERVICE-SCOPE RECOVERY WHEN SUFFICIENT
+-> PROCESS-SCOPE RECOVERY WHEN REQUIRED
+-> HOST-SCOPE RECOVERY WHEN REQUIRED
+-> EXTERNAL RECREATE / FAILOVER WHEN REQUIRED
+-> DEPLOYMENT IDENTITY RE-ESTABLISHED
+-> POST-DEPLOY REALITY VALIDATION
+-> RECOVERED / RETURN TO ANALYSIS
+```
+
+Every successful stage stops escalation. A broader destructive action is not justified merely because it is available.
+
+## Hard invariants
+
+- `FAILED CONTROL SURFACE != REQUIRED RECOVERY SURFACE`;
+- `NO RECOVERY DEPENDENCY ON THE FAILED CONTROL SURFACE`;
+- `CONTROL_SURFACE_FAILURE != WORKLOAD_FAILURE`;
+- `GUI FAILURE != PROVIDER FAILURE`;
+- `RESTARTED != RECOVERED`;
+- `REBOOTED != FIXED`;
+- `RECOVERY ACTION != ROOT CAUSE`;
+- `RECOVERY ACTION != RECOVERY VALIDATED`;
+- destructive escalation requires bounded authority;
+- where delay does not materially worsen recovery, capture logs/state before destructive reset;
+- skipped pre-reset evidence becomes explicit Recovery Debt rather than silently disappearing;
+- after a control-changing recovery action, Deployment Identity must be re-established before runtime claims are accepted;
+- Post-Deploy Reality validation must bind to the recovered runtime identity;
+- recovery through an alternate surface does not permanently promote that surface or provider.
+
+## Escalation ladder
+
+Use the narrowest available action that can restore verified control:
+
+1. **Escape the failed UI/surface** — switch to an independent CLI, API, SSH path, or another trusted operator surface.
+2. **Observe before reset** — acquire logs, health, resource pressure, process/service state, and relevant timestamps when feasible.
+3. **Service scope** — restart or reload only the affected service when sufficient.
+4. **Process scope** — terminate and recreate the affected process when service-level recovery cannot restore control.
+5. **Host scope** — reboot the host only when narrower recovery paths are unavailable or ineffective.
+6. **External recovery scope** — recreate, redeploy, or fail over using an independent provider/control path when the host or provider boundary is no longer trustworthy or usable.
+7. **Reality validation** — re-establish Deployment Identity and run the required probes before declaring recovery.
+
+The ladder is an escalation order, not a requirement to execute every stage.
+
+## Evidence-before-reset rule
+
+A restart or reboot may erase volatile evidence. Therefore:
+
+```text
+IF evidence can be captured without materially worsening the outage
+THEN capture it before destructive reset
+ELSE restore first and record the missing evidence as Recovery Debt
+```
+
+Minimum useful evidence depends on the workload, but may include:
+
+- control-surface failure observation;
+- workload health observation independent of that surface;
+- logs / journal references;
+- memory, disk, CPU, or resource-pressure evidence;
+- service/process state;
+- action authority;
+- executor/action timestamp;
+- post-action Deployment Identity and probe evidence.
+
+## Independence rule
+
+An alternate recovery surface must not merely be another view backed by the same failed control path when that shared dependency is the suspected failure domain.
+
+Examples of stronger independence include:
+
+- browser console -> authenticated CLI/API from another host;
+- application admin UI -> SSH + service manager;
+- failed host-local control -> provider-level recovery plane;
+- unusable primary provider control -> pre-authorized external failover path.
+
+Independence is workload- and failure-domain-specific; labels alone do not prove it.
+
+## Relationship to Emergency Recovery
+
+Control Plane Escape is the **control-regain subpath** of bounded recovery.
+
+It may be used before Emergency Failover when the primary workload can still be recovered in place. If the workload remains `FAILED` or `UNSAFE`, or the failure domain cannot be trusted, the existing Emergency Recovery / Failover Gate governs fallback eligibility and temporary recovery semantics.
+
+This gate does not weaken:
+
+- failover authority boundaries;
+- fallback identity requirements;
+- single-writer fencing requirements;
+- recovery validation requirements;
+- Recovery Debt;
+- prohibition on automatic permanent promotion or failback.
+
+## Externalization boundary
+
+Keep external and replaceable:
+
+- web consoles;
+- CLIs and provider SDKs;
+- SSH clients and remote shells;
+- service managers;
+- process supervisors;
+- reboot/recreate mechanisms;
+- deployment executors;
+- provider failover controls.
+
+Ultimate Loop owns only the decision/evidence rule:
+
+> **If the normal control surface fails, do not make recovery depend on it. Escape to an independent control path, use the narrowest sufficient recovery action, and validate the recovered reality before calling it fixed.**

--- a/thin-rts/ultimate-loop/EMERGENCY_RECOVERY_GATE_2026-08-14.md
+++ b/thin-rts/ultimate-loop/EMERGENCY_RECOVERY_GATE_2026-08-14.md
@@ -33,6 +33,9 @@ HEALTHY
 - `EMERGENCY_USE != PROMOTION`;
 - `SERVICE_AVAILABLE != SERVICE_HEALTHY`;
 - `DEGRADED != FAILED`;
+- `CONTROL_SURFACE_FAILURE != WORKLOAD_FAILURE`;
+- `FAILED CONTROL SURFACE != REQUIRED RECOVERY SURFACE`;
+- `RECOVERY ACTION != RECOVERY VALIDATED`;
 - ordinary degradation/failure requires hysteresis before failover eligibility;
 - `FAILOVER_ELIGIBLE != FAILOVER_EXECUTED`;
 - failover actuation remains external and separately authorized;
@@ -54,6 +57,26 @@ HEALTHY
 This gate does not own or authorize monitoring, DNS/load-balancer changes, service-mesh control, provider SDK actions, restart, secret access, traffic switching, deployment, rollback, promotion or failback.
 
 Existing `lifecycle.py` remains the lifecycle/failover authority owner. The gate may classify evidence and declare an external failover eligible; an authorized external operator/tool performs the action.
+
+## Control Plane Escape before failover
+
+A failed or unusable operator surface does not by itself prove that the protected workload has failed. Before escalating to provider failover, an authorized operator may attempt bounded in-place recovery through an independent control surface under `CONTROL_PLANE_ESCAPE_GATE_2026-08-16.md`.
+
+Typical escalation is:
+
+```text
+FAILED / UNTRUSTWORTHY NORMAL CONTROL SURFACE
+-> ALTERNATE CLI / API / SSH / SERVICE-MANAGER PATH
+-> CAPTURE VOLATILE EVIDENCE WHEN FEASIBLE
+-> NARROW SERVICE / PROCESS RECOVERY
+-> HOST RECOVERY ONLY WHEN REQUIRED
+-> DEPLOYMENT IDENTITY RE-ESTABLISHMENT
+-> POST-DEPLOY REALITY VALIDATION
+```
+
+If in-place control cannot be regained, the workload remains `FAILED`/`UNSAFE`, or the suspected failure domain cannot be trusted, this Emergency Recovery / Failover Gate remains the authority boundary for fallback eligibility.
+
+A restart, process replacement or host reboot is an external actuation. It does not prove recovery, erase root-cause debt, or permanently authorize the alternate control surface.
 
 ## Recovery binding
 
@@ -79,6 +102,8 @@ A temporary recovery carries:
 
 Emergency restoration may shorten the normal comparison path; it may not silently erase the skipped judgment.
 
+If volatile evidence could not be captured before an urgent destructive reset, the missing pre-reset evidence is also retained as explicit recovery/root-cause debt.
+
 ## Externalization boundary
 
 Keep external and replaceable:
@@ -88,6 +113,9 @@ Keep external and replaceable:
 - DNS/load balancers/service meshes;
 - traffic switching;
 - provider APIs;
+- CLIs / SSH / remote operator surfaces;
+- service managers and process supervisors;
+- restart / reboot / recreate mechanisms;
 - secret stores;
 - schedulers;
 - deployment/failover executors.

--- a/thin-rts/ultimate-loop/README.md
+++ b/thin-rts/ultimate-loop/README.md
@@ -23,6 +23,7 @@ DISCOVERY REFRESH
 → DEPLOYMENT IDENTITY
 → POST-DEPLOY DEBUG / REALITY GATE
 → STABLE / WATCH
+→ CONTROL PLANE ESCAPE WHEN THE NORMAL CONTROL SURFACE FAILS
 → DARWIN KNOCKOUT MATCH WHEN A MATERIAL CHALLENGER EXISTS
 → EMERGENCY RECOVERY WHEN FAILURE/UNSAFE CONDITIONS REQUIRE IT
 → PHOENIX LINEAGE
@@ -35,6 +36,7 @@ DISCOVERY REFRESH
 - `NEW_BUILD_SUPERIORITY_GATE_2026-08-14.md` — bounded new-build permission for irreducible gaps or proven architecture deficits;
 - `POST_DEPLOY_DEBUG_GATE_2026-08-14.md` — deployed-reality verification and regression binding;
 - `EMERGENCY_RECOVERY_GATE_2026-08-14.md` — bounded emergency recovery semantics;
+- `CONTROL_PLANE_ESCAPE_GATE_2026-08-16.md` — candidate control-regain rule: escape a failed operator surface, preserve evidence when feasible, escalate narrowly, then revalidate runtime reality;
 - `lifecycle.py` — lifecycle/failover authority binding;
 - `emergency.py` — thin Emergency Recovery evidence/state binder;
 - associated regression suites — retained death-memory for known failure classes.
@@ -53,9 +55,9 @@ Ultimate Loop itself is therefore an occupant of a Movable Frame: it can survive
 
 ## Externalization boundary
 
-This project intentionally does **not** become a crawler platform, scheduler, database, daemon, model runtime, monitoring platform, traffic switch, deployment engine, backup product, or autonomous promotion system.
+This project intentionally does **not** become a crawler platform, scheduler, database, daemon, model runtime, monitoring platform, traffic switch, deployment engine, backup product, autonomous promotion system, or provider control-plane replacement.
 
-Search/crawling, monitoring, provider APIs, DNS/load balancers/service meshes, schedulers, deployment/failover execution, and other commodity mechanisms remain replaceable external occupants. Ultimate Loop owns the minimum decision/evidence/authority contracts needed to compare and safely use them.
+Search/crawling, monitoring, provider APIs, DNS/load-balancers/service meshes, schedulers, deployment/failover execution, CLIs, SSH, service managers, reboot/recreate mechanisms, and other commodity mechanisms remain replaceable external occupants. Ultimate Loop owns the minimum decision/evidence/authority contracts needed to compare and safely use them.
 
 ## Historical evidence vs current authority
 
@@ -70,6 +72,12 @@ History is preserved; stale experiment labels are not operational authority.
 `BETTER CANDIDATE != AUTHORIZED REPLACEMENT`
 
 `DEPLOYED != OBSERVED_CORRECT`
+
+`FAILED CONTROL SURFACE != REQUIRED RECOVERY SURFACE`
+
+`CONTROL_SURFACE_FAILURE != WORKLOAD_FAILURE`
+
+`RECOVERY ACTION != RECOVERY VALIDATED`
 
 `EMERGENCY_USE != PROMOTION`
 


### PR DESCRIPTION
## Purpose

Formalize a recovery invariant discovered through real operation: when the normal control surface becomes unusable, recovery must not depend on that same failed surface.

## Changes

- add `CONTROL_PLANE_ESCAPE_GATE_2026-08-16.md`
- define separation between control-surface failure and workload failure
- define alternate control-path escape and narrow escalation ladder
- require evidence capture before destructive reset when feasible
- require Deployment Identity + Post-Deploy Reality validation after recovery
- bind the rule into the existing Emergency Recovery / Failover Gate
- index the candidate rule and invariants in the Ultimate Loop README

## Core invariants

- `FAILED CONTROL SURFACE != REQUIRED RECOVERY SURFACE`
- `CONTROL_SURFACE_FAILURE != WORKLOAD_FAILURE`
- `RECOVERY ACTION != RECOVERY VALIDATED`
- `RESTARTED != RECOVERED`
- `REBOOTED != FIXED`

## Scope

No owned CLI, SSH, provider API, restart engine, or failover platform is added. Those remain external replaceable executors; RTS owns only the decision/evidence boundary.