### PR TITLE
experiment: add Reconstruction Furnace blind task gate

### DIFF
--- a/.github/workflows/reconstruction-furnace-preflight.yml
+++ b/.github/workflows/reconstruction-furnace-preflight.yml
@@ -1,0 +1,35 @@
+name: Reconstruction Furnace Preflight
+
+on:
+  pull_request:
+    paths:
+      - "experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/**"
+      - ".github/workflows/reconstruction-furnace-preflight.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reconstruction-furnace-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  preflight:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run Furnace preflight regressions
+        run: >-
+          python -m unittest discover
+          -s experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818
+          -p 'test_*.py'
+          -v

--- a/.github/workflows/reconstruction-furnace-preflight.yml
+++ b/.github/workflows/reconstruction-furnace-preflight.yml
@@ -20,10 +20,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 

--- a/.github/workflows/reconstruction-furnace-stage0-validator.yml
+++ b/.github/workflows/reconstruction-furnace-stage0-validator.yml
@@ -24,20 +24,22 @@ jobs:
 
     steps:
       - name: Checkout experiment branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           path: rts
+          persist-credentials: false
 
       - name: Checkout pinned SWE-bench-Live evaluator
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           repository: microsoft/SWE-bench-Live
           ref: 70ec57e852e3f2d195790fe71f553e272c691833
           path: evaluator
           submodules: recursive
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -107,7 +109,7 @@ jobs:
 
       - name: Upload solver-safe admission artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: furnace-stage0-${{ matrix.split }}-safe
           path: ${{ runner.temp }}/furnace-stage0/safe/${{ matrix.split }}/

--- a/.github/workflows/reconstruction-furnace-stage0-validator.yml
+++ b/.github/workflows/reconstruction-furnace-stage0-validator.yml
@@ -41,17 +41,23 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install validator dependencies
+      - name: Install bounded validator dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install datasets -e evaluator/launch
+          python -m pip install datasets docker typing-extensions
 
       - name: Record safe resource preflight
         working-directory: rts/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818
+        env:
+          SAFE_ROOT: ${{ runner.temp }}/furnace-stage0/safe/${{ matrix.split }}
+          SPLIT: ${{ matrix.split }}
         run: |
           python - <<'PY'
+          import json
           import os
+          from pathlib import Path
           import stage0_control
+
           pages = os.sysconf('SC_PHYS_PAGES')
           page_size = os.sysconf('SC_PAGE_SIZE')
           mem_gib = pages * page_size / (1024 ** 3)
@@ -59,8 +65,28 @@ jobs:
               cpu_count=os.cpu_count() or 1,
               memory_gib=mem_gib,
           )
-          print('SAFE_RESOURCE_PREFLIGHT state=' + result['state'])
-          if result['state'] != 'RESOURCE_READY':
+          safe = {
+              'schema_version': 'ultimate-loop-reconstruction-furnace/resource-v1',
+              'split': os.environ['SPLIT'],
+              'state': result['state'],
+              'cpu_count': result['cpu_count'],
+              'memory_gib': round(result['memory_gib'], 2),
+              'hard_min_memory_gib': result['hard_min_memory_gib'],
+              'guidance_memory_gib': result['guidance_memory_gib'],
+              'warnings': result['warnings'],
+              'blockers': result['blockers'],
+              'solver_failure': False,
+          }
+          root = Path(os.environ['SAFE_ROOT'])
+          root.mkdir(parents=True, exist_ok=True)
+          (root / 'resource-summary.json').write_text(
+              json.dumps(safe, sort_keys=True, indent=2) + '\n', encoding='utf-8'
+          )
+          print(
+              'SAFE_RESOURCE_PREFLIGHT '
+              f"state={result['state']} cpu={result['cpu_count']} mem_gib={mem_gib:.2f}"
+          )
+          if result['state'] == 'RESOURCE_BLOCKED':
               raise SystemExit(3)
           PY
 

--- a/.github/workflows/reconstruction-furnace-stage0-validator.yml
+++ b/.github/workflows/reconstruction-furnace-stage0-validator.yml
@@ -1,0 +1,100 @@
+name: Reconstruction Furnace Stage 0 Validator
+
+on:
+  pull_request:
+    paths:
+      - "experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/**"
+      - ".github/workflows/reconstruction-furnace-stage0-validator.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: reconstruction-furnace-stage0-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    strategy:
+      fail-fast: false
+      matrix:
+        split: [c, go]
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+
+    steps:
+      - name: Checkout experiment branch
+        uses: actions/checkout@v4
+        with:
+          path: rts
+
+      - name: Checkout pinned SWE-bench-Live evaluator
+        uses: actions/checkout@v4
+        with:
+          repository: microsoft/SWE-bench-Live
+          ref: 70ec57e852e3f2d195790fe71f553e272c691833
+          path: evaluator
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install validator dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install datasets -e evaluator/launch
+
+      - name: Record safe resource preflight
+        working-directory: rts/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818
+        run: |
+          python - <<'PY'
+          import os
+          import stage0_control
+          pages = os.sysconf('SC_PHYS_PAGES')
+          page_size = os.sysconf('SC_PAGE_SIZE')
+          mem_gib = pages * page_size / (1024 ** 3)
+          result = stage0_control.resource_preflight(
+              cpu_count=os.cpu_count() or 1,
+              memory_gib=mem_gib,
+          )
+          print('SAFE_RESOURCE_PREFLIGHT state=' + result['state'])
+          if result['state'] != 'RESOURCE_READY':
+              raise SystemExit(3)
+          PY
+
+      - name: Run sealed 3x gold validation
+        id: validator
+        working-directory: rts/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818
+        shell: bash
+        run: |
+          set +e
+          python gold_validator.py \
+            --split "${{ matrix.split }}" \
+            --evaluator-root "${{ github.workspace }}/evaluator" \
+            --output-root "${{ runner.temp }}/furnace-stage0" \
+            --max-candidates 4
+          rc=$?
+          echo "validator_rc=$rc" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Upload solver-safe admission artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: furnace-stage0-${{ matrix.split }}-safe
+          path: ${{ runner.temp }}/furnace-stage0/safe/${{ matrix.split }}/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Enforce validator result
+        if: always()
+        run: |
+          rc="${{ steps.validator.outputs.validator_rc }}"
+          if [ "$rc" = "0" ]; then
+            echo "SAFE_STAGE0_GATE split=${{ matrix.split }} state=ADMITTED"
+            exit 0
+          fi
+          echo "SAFE_STAGE0_GATE split=${{ matrix.split }} state=VALIDATOR_BLOCKED"
+          exit 1

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/README.md
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/README.md
@@ -1,0 +1,88 @@
+# Ultimate Loop Reconstruction Furnace — Experiment Preflight
+
+Status: `EXPERIMENT_ONLY / NOT_CANONICAL / BLINDNESS_GATE_REQUIRED`
+
+Parent experiment: issue #353.
+
+## Purpose
+
+This directory contains only the smallest repository-local glue required to keep the SWE-bench-Live experiment blind. It is not a benchmark platform and it is not canonical Ultimate Loop authority.
+
+The first preflight attempt exposed a material trust-boundary failure: the ordinary dataset viewer presents solver-allowed task material adjacent to gold patches, test patches, hints, commit URLs, and hidden evaluation material.
+
+Therefore the solver must never consume raw benchmark rows.
+
+`SOLVER DIRECT DATASET ACCESS -> EXPERIMENT INVALID`
+
+## Boundary
+
+The data path is deliberately split:
+
+```text
+PINNED BENCHMARK DATASET
+        |
+        v
+OUT-OF-BAND VALIDATOR
+  - may access gold
+  - runs gold evaluation exactly 3 times
+  - retains validator-side provenance only
+        |
+        v
+TASK ENVELOPE SANITIZER
+  - explicit allowlist serializer
+  - no raw-row copy / blacklist stripping
+        |
+        v
+SOLVER-VISIBLE ENVELOPE
+  - opaque task id
+  - repo
+  - base commit
+  - problem statement
+  - rebuild/test command contract
+  - sandbox image identity
+  - TASK_VALID=true
+  - offline-after-prepare network policy
+        |
+        v
+ULTIMATE LOOP + TRACE
+```
+
+The validator and solver namespaces must remain separate. A validator-side source fingerprint is provenance, not solver input.
+
+## Files
+
+- `task_envelope.py` — strict allowlist serializer, validator provenance helper, solver-envelope verifier, recursive forbidden-key scan.
+- `test_task_envelope.py` — regression cases for gold leakage, schema drift, invalid tasks, hidden evaluation fields, trace leakage, and source mutation.
+
+## Hard invariants
+
+`CAN ACCESS TASK != CAN ACCESS TASK BLINDLY`
+
+`COLUMN IGNORED AFTER RETRIEVAL != COLUMN NEVER ENTERED CONTEXT`
+
+`DATASET VIEWER != SAFE SOLVER INPUT`
+
+`GOLD VALIDATION != GOLD ACCESS BY SOLVER`
+
+`GENERALIZED METHOD MEMORY != ANSWER CACHE`
+
+`BROKEN EXPERIMENT HARNESS != SOLVER FAILURE`
+
+## Required preflight before Stage 0
+
+1. Pin the exact dataset revision.
+2. Deterministically sample candidate rows outside solver context.
+3. Validate each candidate with the benchmark gold path exactly three times.
+4. Admit only 3/3 reproducibly valid tasks.
+5. Generate an opaque task ID unrelated to the fixing PR number.
+6. Serialize with `sanitize_for_solver`.
+7. Verify the emitted object with `verify_solver_envelope`.
+8. Scan the full solver-visible input/TRACE bootstrap namespace with `forbidden_key_scan`.
+9. Prepare the sandbox, then remove outbound solution-lookup capability where practical.
+10. Only then start the Ultimate Loop task clock.
+
+Any inability to prove this separation is an experiment-integrity failure and should produce `EXPERIMENT_INVALID`, not a benchmark result.
+
+## Scope
+
+Do not promote this directory into the canonical method merely because the experiment uses it. After the furnace, Raison d'etre / DA / Counter-DA / METEOR decides whether any responsibility discovered here deserves a durable home.

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/README.md
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/README.md
@@ -1,58 +1,87 @@
 # Ultimate Loop Reconstruction Furnace — Experiment Preflight
 
-Status: `EXPERIMENT_ONLY / NOT_CANONICAL / BLINDNESS_GATE_REQUIRED`
+Status: `EXPERIMENT_ONLY / NOT_CANONICAL / STAGE0_VALIDATOR_RUNNING`
 
-Parent experiment: issue #353.
+Parent experiment: issue #353. Draft integration vehicle: PR #354.
 
 ## Purpose
 
-This directory contains only the smallest repository-local glue required to keep the SWE-bench-Live experiment blind. It is not a benchmark platform and it is not canonical Ultimate Loop authority.
+This directory contains only the smallest experiment-local glue required to run the SWE-bench-Live reconstruction furnace without contaminating Ultimate Loop with benchmark answers or evaluator-only metadata. It is not a benchmark platform and it is not canonical Ultimate Loop authority.
 
-The first preflight attempt exposed a material trust-boundary failure: the ordinary dataset viewer presents solver-allowed task material adjacent to gold patches, test patches, hints, commit URLs, and hidden evaluation material.
+The first preflight attempt exposed a material trust-boundary failure: the ordinary dataset surface presents solver-allowed task material adjacent to gold patches, test patches, hints, commit URLs, hidden evaluation metadata, and task identities that can point back to fixing work.
 
-Therefore the solver must never consume raw benchmark rows.
+The second DA pass against the pinned official evaluator found that `rebuild_cmds`, `test_cmds`, `print_cmds`, `log_parser`, hidden pass/fail lists, and sandbox image identity belong to the evaluator/runner boundary rather than the blind solver boundary.
+
+Therefore the solver never consumes raw benchmark rows or evaluator metadata.
 
 `SOLVER DIRECT DATASET ACCESS -> EXPERIMENT INVALID`
 
+`EVALUATOR METADATA != SOLVER INPUT`
+
+## Frozen Stage 0
+
+- dataset: `SWE-bench-Live/MultiLang`
+- dataset revision: `608f7ae9ab8ea1f9f0d030fe04562cf6bd1a0c8b`
+- evaluator: `microsoft/SWE-bench-Live`
+- evaluator revision: `70ec57e852e3f2d195790fe71f553e272c691833`
+- seed SHA-256: `050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b`
+- deterministic Stage 0 splits: `c`, `go`
+- admission: first deterministic candidate in each split that passes official gold evaluation `3/3`
+
+No candidate is manually selected for ease.
+
 ## Boundary
 
-The data path is deliberately split:
-
 ```text
-PINNED BENCHMARK DATASET
+PINNED RAW BENCHMARK DATASET
         |
         v
-OUT-OF-BAND VALIDATOR
-  - may access gold
-  - runs gold evaluation exactly 3 times
-  - retains validator-side provenance only
+OUT-OF-BAND VALIDATOR / RUNNER
+  - raw instance identity allowed
+  - gold patch / hidden test patch allowed
+  - evaluator commands allowed
+  - sandbox image identity allowed
+  - official gold evaluation exactly 3x
+  - raw stdout/stderr sealed from solver/operator model
         |
         v
-TASK ENVELOPE SANITIZER
-  - explicit allowlist serializer
-  - no raw-row copy / blacklist stripping
+STRICT ALLOWLIST SANITIZER v2
         |
         v
 SOLVER-VISIBLE ENVELOPE
   - opaque task id
   - repo
   - base commit
-  - problem statement
-  - rebuild/test command contract
-  - sandbox image identity
+  - public problem statement
+  - platform
   - TASK_VALID=true
-  - offline-after-prepare network policy
+  - offline-after-prepare policy
         |
         v
 ULTIMATE LOOP + TRACE
 ```
 
-The validator and solver namespaces must remain separate. A validator-side source fingerprint is provenance, not solver input.
+The validator and solver namespaces remain separate. Validator provenance is retained runner-side and is never solver input.
 
 ## Files
 
-- `task_envelope.py` — strict allowlist serializer, validator provenance helper, solver-envelope verifier, recursive forbidden-key scan.
-- `test_task_envelope.py` — regression cases for gold leakage, schema drift, invalid tasks, hidden evaluation fields, trace leakage, and source mutation.
+- `task_envelope.py` — v2 allowlist serializer and forbidden-key scanner.
+- `stage0_control.py` — pinned deterministic split/candidate ordering, opaque IDs, resource preflight, first-valid admission.
+- `trace_contract.py` — sequenceable fail-closed TRACE contract.
+- `gold_validator.py` — sealed out-of-band 3x gold validator; emits only solver-safe artifacts.
+- `STAGE0_RUN_MANIFEST.json` — frozen Stage 0 revisions, seed and admission rule.
+- `VALIDATOR_RUNBOOK.md` — exact namespace and validity procedure.
+- `test_*.py` — regression coverage for blindness, deterministic admission, resource classification and TRACE integrity.
+
+## TRACE Stage 0 gate
+
+A trace is not accepted merely because an event file exists. It must preserve contiguous sequence numbers, monotonic timestamps, run/task binding, material event categories, `TASK_START` first, and `TASK_END` last. Missing required categories produce `TRACE_INCOMPLETE`; sequence gaps, reordering or cross-task mixing fail closed.
+
+Stage 0 measures observer overhead separately from solver performance.
+
+`TRACE EXISTS != TRACE COMPLETE`
+
+`OBSERVER FAILURE != SOLVER FAILURE`
 
 ## Hard invariants
 
@@ -64,25 +93,33 @@ The validator and solver namespaces must remain separate. A validator-side sourc
 
 `GOLD VALIDATION != GOLD ACCESS BY SOLVER`
 
+`EVALUATOR COMMAND != PUBLIC TASK CONTRACT`
+
+`RAW INSTANCE ID != REQUIRED SOLVER IDENTITY`
+
 `GENERALIZED METHOD MEMORY != ANSWER CACHE`
 
 `BROKEN EXPERIMENT HARNESS != SOLVER FAILURE`
 
-## Required preflight before Stage 0
+`RESOURCE_BLOCKED != SOLVER_FAILURE`
 
-1. Pin the exact dataset revision.
-2. Deterministically sample candidate rows outside solver context.
-3. Validate each candidate with the benchmark gold path exactly three times.
-4. Admit only 3/3 reproducibly valid tasks.
-5. Generate an opaque task ID unrelated to the fixing PR number.
-6. Serialize with `sanitize_for_solver`.
-7. Verify the emitted object with `verify_solver_envelope`.
-8. Scan the full solver-visible input/TRACE bootstrap namespace with `forbidden_key_scan`.
-9. Prepare the sandbox, then remove outbound solution-lookup capability where practical.
-10. Only then start the Ultimate Loop task clock.
+`FAILURE WITH CLEAN TRACE > CONTAMINATED PASS`
 
-Any inability to prove this separation is an experiment-integrity failure and should produce `EXPERIMENT_INVALID`, not a benchmark result.
+## Stage 0 admission and execution
+
+1. Use the frozen dataset/evaluator revisions and seed.
+2. Deterministically order C and Go candidates outside solver context.
+3. Evaluate each candidate's gold patch exactly three times on the experiment machine.
+4. Continue in deterministic order until the first `3/3` candidate is found; never skip an earlier valid candidate for convenience.
+5. Build only the v2 solver envelope.
+6. Scan the complete solver bootstrap namespace for forbidden keys.
+7. Prepare the sandbox runner-side and remove outbound solution lookup where practical.
+8. Start the task clock only after the clean boundary is proven.
+9. Run two telemetry-torture tasks through normal Ultimate Loop reasoning without benchmark-specific method changes.
+10. Proceed to the eight-world Stage 1 gauntlet only if TRACE completeness and observer overhead survive Stage 0.
+
+If no valid candidate can be established, resources are insufficient, or the boundary cannot be proven, stop as a validator/experiment-integrity result rather than inventing a solver failure.
 
 ## Scope
 
-Do not promote this directory into the canonical method merely because the experiment uses it. After the furnace, Raison d'etre / DA / Counter-DA / METEOR decides whether any responsibility discovered here deserves a durable home.
+Do not promote any mechanism in this directory into the canonical Development Sequence Loop merely because the furnace needs it. After the experiment, Raison d'etre / DA / Counter-DA / METEOR decides whether any discovered responsibility deserves a durable home.

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/STAGE0_RUN_MANIFEST.json
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/STAGE0_RUN_MANIFEST.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "ultimate-loop-reconstruction-furnace/run-manifest-v1",
+  "stage": "STAGE0",
+  "status": "SELECTION_FROZEN / GOLD_VALIDATION_PENDING",
+  "dataset_repo": "SWE-bench-Live/MultiLang",
+  "dataset_revision": "608f7ae9ab8ea1f9f0d030fe04562cf6bd1a0c8b",
+  "evaluator_repo": "microsoft/SWE-bench-Live",
+  "evaluator_revision": "70ec57e852e3f2d195790fe71f553e272c691833",
+  "seed_label": "ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_STAGE0",
+  "seed_sha256": "050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b",
+  "selected_splits": [
+    "c",
+    "go"
+  ],
+  "candidate_selection": "DETERMINISTIC_HASH_ORDER_WITHIN_SPLIT",
+  "candidate_cherry_pick_allowed": false,
+  "gold_validation_runs_required": 3,
+  "gold_validation_passes_required": 3,
+  "solver_dataset_access": false,
+  "solver_gold_access": false,
+  "default_resource_preflight": {
+    "cpu": 4,
+    "memory_gib": 16,
+    "note": "Task-specific requirements may exceed defaults; resource failure is not solver failure."
+  },
+  "admission_rule": "FIRST_DETERMINISTIC_CANDIDATE_WITH_3_OF_3_GOLD_PASS_PER_SELECTED_SPLIT",
+  "task_count_after_admission": 2,
+  "trace_contract": "ultimate-loop-reconstruction-furnace/trace-v1"
+}

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/STAGE0_RUN_MANIFEST.json
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/STAGE0_RUN_MANIFEST.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "ultimate-loop-reconstruction-furnace/run-manifest-v1",
   "stage": "STAGE0",
-  "status": "SELECTION_FROZEN / GOLD_VALIDATION_PENDING",
+  "status": "SELECTION_FROZEN / TRACE_V2_TORTURE_GREEN / GOLD_VALIDATION_PENDING",
   "dataset_repo": "SWE-bench-Live/MultiLang",
   "dataset_revision": "608f7ae9ab8ea1f9f0d030fe04562cf6bd1a0c8b",
   "evaluator_repo": "microsoft/SWE-bench-Live",
@@ -25,5 +25,19 @@
   },
   "admission_rule": "FIRST_DETERMINISTIC_CANDIDATE_WITH_3_OF_3_GOLD_PASS_PER_SELECTED_SPLIT",
   "task_count_after_admission": 2,
-  "trace_contract": "ultimate-loop-reconstruction-furnace/trace-v1"
+  "trace_contract": "ultimate-loop-reconstruction-furnace/trace-v2",
+  "trace_torture": {
+    "synthetic_concurrency": "8 threads x 250 TOOL_INVOCATION events",
+    "required_properties": [
+      "no event loss",
+      "strict sequence continuity",
+      "monotonic time non-regression",
+      "disk replay equality",
+      "declared event counts equal observed counts",
+      "forbidden benchmark keys rejected",
+      "caller payload mutation cannot rewrite retained trace"
+    ],
+    "local_regression_result": "12/12 PASS",
+    "real_stage0_required": true
+  }
 }

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/TRACE_DA_COUNTER_DA_2026-08-18.md
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/TRACE_DA_COUNTER_DA_2026-08-18.md
@@ -6,17 +6,15 @@ Parent experiment: #353. Candidate PR: #354.
 
 ## Frozen question
 
-Can the observer retain the material state transitions of Ultimate Loop while the loop is moving quickly, without silently dropping, reordering, fabricating, or contaminating evidence?
+Can the observer retain the material state transitions of Ultimate Loop while the loop is moving quickly, without silently dropping, reordering, fabricating, contaminating, or weakening its own experiment boundary?
 
 This review attacks the observer contract itself before using it to judge Ultimate Loop.
 
-## DA — deaths found in TRACE v1
-
-TRACE v1 was not strong enough to call a run complete.
+## DA — deaths found before real Stage 0
 
 ### Death 1 — presence could masquerade as completeness
 
-The validator required one occurrence of every named event type, but did not require meaningful payloads. A trace containing empty payloads could satisfy the shape of a complete run.
+TRACE v1 required one occurrence of every named event type, but did not require meaningful payloads. A trace containing empty payloads could satisfy the shape of a complete run.
 
 `EVENT NAME EXISTS != MATERIAL EVIDENCE CAPTURED`
 
@@ -56,7 +54,15 @@ A noisy baseline could produce a negative overhead percentage and make the obser
 
 `NOISY NEGATIVE DELTA != NEGATIVE OBSERVER COST`
 
-## Repair — TRACE v2
+### Death 8 — the experiment workflow weakened its own supply-chain boundary
+
+The first green GitHub preflight resolved mutable action tags such as `actions/checkout@v4` and `actions/setup-python@v5`, and checkout retained credentials by default. That is weaker than the repository's existing fail-closed action-pinning discipline and gives the experiment unnecessary mutation/credential surface.
+
+`PINNED BENCHMARK != PINNED EXPERIMENT EXECUTION`
+
+`CONTENTS:READ != CREDENTIALS NEED TO PERSIST`
+
+## Repair — TRACE v2 and workflow hardening
 
 The experiment-local TRACE contract now:
 
@@ -73,9 +79,16 @@ The experiment-local TRACE contract now:
 - clamps negative timing noise to zero reported overhead;
 - supports JSONL replay for captured traces.
 
+The experiment workflows now also:
+
+- pin checkout and Python setup to exact observed commit SHAs;
+- pin the v4 artifact uploader to an exact commit SHA;
+- set `persist-credentials: false` on both RTS and evaluator checkouts;
+- retain `contents: read` as the only declared workflow permission.
+
 ## Counter-DA — attacks retained as regressions
 
-The hardened test set attacks the repair with:
+The hardened TRACE test set attacks the repair with:
 
 1. empty-payload completeness spoof;
 2. declared-vs-observed event count mismatch;
@@ -90,9 +103,13 @@ The hardened test set attacks the repair with:
 11. clean first-pass success with zero fake failure events;
 12. burst capture: 8 concurrent threads x 250 tool events, followed by disk replay and exact sequence/count verification.
 
-Local isolated replay result after repair:
+Isolated TRACE replay after repair:
 
 `12 / 12 PASS`
+
+The first complete GitHub preflight over Stage 0 control, blind envelope, and TRACE regressions produced:
+
+`27 / 27 PASS`
 
 The burst test retains 2,000 concurrent `TOOL_INVOCATION` events with no observed loss in the test process, strict sequence continuity, memory/disk row equality, and a complete replayable trace.
 

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/TRACE_DA_COUNTER_DA_2026-08-18.md
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/TRACE_DA_COUNTER_DA_2026-08-18.md
@@ -1,0 +1,138 @@
+# Stage 0 TRACE — DA / Counter-DA result
+
+Status: `EXPERIMENT_ONLY / TRACE_V2_TORTURE_GREEN / REAL_STAGE0_REQUIRED`
+
+Parent experiment: #353. Candidate PR: #354.
+
+## Frozen question
+
+Can the observer retain the material state transitions of Ultimate Loop while the loop is moving quickly, without silently dropping, reordering, fabricating, or contaminating evidence?
+
+This review attacks the observer contract itself before using it to judge Ultimate Loop.
+
+## DA — deaths found in TRACE v1
+
+TRACE v1 was not strong enough to call a run complete.
+
+### Death 1 — presence could masquerade as completeness
+
+The validator required one occurrence of every named event type, but did not require meaningful payloads. A trace containing empty payloads could satisfy the shape of a complete run.
+
+`EVENT NAME EXISTS != MATERIAL EVIDENCE CAPTURED`
+
+### Death 2 — normal first-pass success forced fake failure history
+
+`FAILURE_SIGNATURE`, `HYPOTHESIS_REOPEN`, `FALSE_TRANSFER`, `METHOD_MEMORY_REUSE`, and `HUMAN_TOUCH` were globally mandatory even when the real count was zero. That incentivized synthetic placeholder events merely to satisfy completeness.
+
+`ZERO REAL EVENTS != MISSING EVENTS`
+
+### Death 3 — event counts were not reconciled
+
+A task summary could not prove that the number of patch attempts, tests, reopens, tool invocations, transfers, or human touches matched the retained event stream.
+
+`SUMMARY COUNT != OBSERVED COUNT`
+
+### Death 4 — causal order was under-specified
+
+Sequence continuity alone did not prevent logically impossible traces such as patching before Counter-DA or a test result bound to an attempt that had no prior patch.
+
+`SEQUENCED != CAUSALLY COHERENT`
+
+### Death 5 — TRACE itself could become a contamination path
+
+TRACE payloads were not independently checked for benchmark-forbidden field names. A nested `patch`, `test_patch`, hint, fixing URL, or hidden evaluation field could enter retained logs.
+
+`BLIND SOLVER INPUT != BLIND TRACE`
+
+### Death 6 — caller mutation could rewrite retained evidence
+
+A recorder that stores caller-owned nested payload objects by reference can have old events changed after emission.
+
+`EMITTED != IMMUTABLE`
+
+### Death 7 — timing noise could report negative observer cost
+
+A noisy baseline could produce a negative overhead percentage and make the observer appear to speed up the workload.
+
+`NOISY NEGATIVE DELTA != NEGATIVE OBSERVER COST`
+
+## Repair — TRACE v2
+
+The experiment-local TRACE contract now:
+
+- requires event-specific material payload keys;
+- distinguishes always-required lifecycle evidence from conditional counted events;
+- binds `TASK_END.event_counts` to exact observed event counts;
+- enforces the causal spine from task start through discovery, model, hypothesis, evidence, DA and Counter-DA;
+- rejects patch-before-Counter-DA and test-without-prior-patch-for-the-same-attempt;
+- requires exactly one `TASK_START` and one final `TASK_END`;
+- recursively rejects benchmark-forbidden TRACE keys;
+- validates patch SHA-256 shape and key enum values;
+- freezes nested payloads at emission time;
+- serializes concurrent writes through one sequence authority;
+- clamps negative timing noise to zero reported overhead;
+- supports JSONL replay for captured traces.
+
+## Counter-DA — attacks retained as regressions
+
+The hardened test set attacks the repair with:
+
+1. empty-payload completeness spoof;
+2. declared-vs-observed event count mismatch;
+3. patch-before-Counter-DA reorder;
+4. sequence gap;
+5. cross-task trace mixing;
+6. negative timing noise;
+7. nested forbidden benchmark field leakage;
+8. duplicate/early `TASK_END`;
+9. test result bound to an attempt with no prior patch;
+10. post-emission mutation of nested caller payload;
+11. clean first-pass success with zero fake failure events;
+12. burst capture: 8 concurrent threads x 250 tool events, followed by disk replay and exact sequence/count verification.
+
+Local isolated replay result after repair:
+
+`12 / 12 PASS`
+
+The burst test retains 2,000 concurrent `TOOL_INVOCATION` events with no observed loss in the test process, strict sequence continuity, memory/disk row equality, and a complete replayable trace.
+
+## Counter-DA residuals
+
+This is not yet proof that the observer survives a real Ultimate Loop run.
+
+Remaining live risks include:
+
+- the synthetic burst does not reproduce every real Codex/tool scheduling pattern;
+- OS/process crash durability beyond per-write flush is not proven;
+- observer overhead on a real repository repair remains unmeasured;
+- evidence references are structurally required but their external truth must still be bound by the real experiment;
+- a real solver could expose a new event class not represented in TRACE v2;
+- resource pressure/OOM must remain an experiment or environment classification unless causally attributable to the solver.
+
+Therefore the correct promotion state is:
+
+`TRACE_V2_TORTURE_GREEN`
+
+not:
+
+`OBSERVER_PROVEN`
+
+## Gate to Ultimate Loop validation
+
+Proceed to the two-task Stage 0 smoke only when:
+
+1. the pinned dataset/evaluator pair remains fixed;
+2. each task passes the out-of-band gold path 3/3 on the actual runner;
+3. resource preflight admits the runner;
+4. only the sanitized solver envelope enters Ultimate Loop context;
+5. TRACE v2 is active before `TASK_START`;
+6. no forbidden benchmark field enters solver-visible input or TRACE;
+7. after each task, emitted/captured counts, order, replay and observer overhead are checked before interpreting solver performance.
+
+If TRACE becomes incomplete under real load, classify the run as observer failure rather than Ultimate Loop failure.
+
+`TRACE TORTURE PASS != REAL OBSERVER PROOF`
+
+`OBSERVER FAILURE != SOLVER FAILURE`
+
+`FAILURE WITH CLEAN TRACE > CONTAMINATED PASS`

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/VALIDATOR_RUNBOOK.md
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/VALIDATOR_RUNBOOK.md
@@ -1,0 +1,84 @@
+# Stage 0 out-of-band validator runbook
+
+Status: `EXPERIMENT_ONLY / VALIDATOR_SIDE / NEVER_SOLVER_CONTEXT`
+
+Parent: issue #353 / PR #354.
+
+## Frozen inputs
+
+- dataset: `SWE-bench-Live/MultiLang`
+- dataset revision: `608f7ae9ab8ea1f9f0d030fe04562cf6bd1a0c8b`
+- evaluator: `microsoft/SWE-bench-Live`
+- evaluator revision: `70ec57e852e3f2d195790fe71f553e272c691833`
+- Stage 0 splits: `c`, `go`
+- seed SHA-256: `050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b`
+
+Do not substitute `main` for either pinned revision after the run begins.
+
+## Namespace boundary
+
+The validator may access raw dataset rows, gold `patch`, `test_patch`, hidden evaluation fields, and the benchmark evaluator because it is outside Ultimate Loop solver context.
+
+The solver may receive none of those materials.
+
+`VALIDATOR KNOWS GOLD != SOLVER MAY KNOW GOLD`
+
+## Candidate ordering
+
+For each selected split, load the raw rows only in the validator namespace and call `stage0_control.candidate_order(...)` with the frozen seed. Validate candidates strictly in that resulting order.
+
+Do not skip a valid earlier candidate because a later task looks easier, smaller, more familiar, or more convenient.
+
+For the first candidate, run the official gold evaluation three independent times. If it does not pass 3/3, record the invalidity and continue to the next candidate in deterministic order. The first 3/3 candidate is admitted for that split.
+
+## Gold validity execution
+
+Use the pinned evaluator checkout and its official evaluation path. Each attempt must have a separate output location or otherwise prove an actual new evaluation rather than reusing cached success.
+
+Conceptually, for candidate `<INSTANCE_ID>`:
+
+```text
+python -m evaluation.evaluation \
+  --dataset SWE-bench-Live/MultiLang \
+  --split <c-or-go> \
+  --instance_ids <INSTANCE_ID> \
+  --platform linux \
+  --patch_dir gold \
+  --output_dir logs/furnace-gold/<INSTANCE_ID>/run-1 \
+  --workers 1 \
+  --overwrite 1
+
+# repeat as run-2 and run-3 with fresh output paths
+```
+
+If the pinned evaluator expects a local pinned dataset file to guarantee the exact Hugging Face revision, materialize that revision outside solver context and pass the local dataset path instead of silently resolving current `main`.
+
+## Resource preflight
+
+Before counting any failed execution, record CPU and memory availability. The benchmark's ordinary guidance is approximately 4 CPUs / 16 GiB per instance, and some large C++ repositories may require much more memory.
+
+A task blocked by insufficient host resources, image pull failure, benchmark drift, sandbox corruption, or validator failure is not an Ultimate Loop solver failure.
+
+`RESOURCE_BLOCKED != SOLVER_FAILED`
+
+## Admission
+
+After 3/3 gold PASS:
+
+1. call `build_validator_provenance`;
+2. generate the opaque ID with `stage0_control.opaque_task_id`;
+3. call `sanitize_for_solver`;
+4. call `verify_solver_envelope`;
+5. recursively scan the solver bootstrap namespace with `forbidden_key_scan`;
+6. retain raw/gold validator artifacts outside the solver workspace;
+7. prepare the sandbox;
+8. remove outbound solution-lookup capability where practical;
+9. start TRACE only after the clean envelope and prepared sandbox cross the boundary.
+
+If any forbidden benchmark field is present in solver input or TRACE bootstrap, classify the run as `EXPERIMENT_INVALID`.
+
+## Stage 0 completion gate
+
+Stage 0 begins only when one C task and one Go task have independently passed gold validation 3/3 and each has a clean solver envelope.
+
+Stage 0 itself passes the instrumentation gate only when both tasks produce sequenceable TRACE with acceptable observer overhead and no contamination. Solver success is not required for the instrumentation gate; a cleanly observed solver failure remains useful data.

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/gold_validator.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/gold_validator.py
@@ -1,0 +1,220 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+from datasets import load_dataset
+
+import stage0_control
+import task_envelope
+
+
+DATASET_REPO = "SWE-bench-Live/MultiLang"
+DATASET_REVISION = "608f7ae9ab8ea1f9f0d030fe04562cf6bd1a0c8b"
+EVALUATOR_REVISION = "70ec57e852e3f2d195790fe71f553e272c691833"
+SEED_SHA256 = "050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b"
+SPLIT_ORDINAL = {"c": 1, "go": 2}
+
+
+class ValidatorError(RuntimeError):
+    pass
+
+
+def _json_dump(path: pathlib.Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, sort_keys=True, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _evaluate_once(
+    *,
+    evaluator_root: pathlib.Path,
+    candidate_jsonl: pathlib.Path,
+    private_root: pathlib.Path,
+    candidate_rank: int,
+    run_number: int,
+) -> bool:
+    output_dir = private_root / f"candidate-{candidate_rank:02d}" / f"run-{run_number}"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_path = output_dir / "validator-private.log"
+    command = [
+        sys.executable,
+        "evaluation/evaluation.py",
+        "--dataset",
+        str(candidate_jsonl.resolve()),
+        "--patch_dir",
+        "gold",
+        "--platform",
+        "linux",
+        "--workers",
+        "1",
+        "--output_dir",
+        str(output_dir.resolve()),
+        "--overwrite",
+        "1",
+    ]
+    with log_path.open("wb") as private_log:
+        proc = subprocess.run(
+            command,
+            cwd=evaluator_root,
+            stdout=private_log,
+            stderr=subprocess.STDOUT,
+            check=False,
+            timeout=170 * 60,
+        )
+    if proc.returncode != 0:
+        return False
+    results_path = output_dir / "results.json"
+    if not results_path.exists():
+        return False
+    try:
+        results = json.loads(results_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    return (
+        results.get("submitted") == 1
+        and results.get("success") == 1
+        and results.get("failure") == 0
+        and results.get("error") == 0
+        and results.get("incomplete") == 0
+        and results.get("empty_patch") == 0
+    )
+
+
+def run(*, split: str, evaluator_root: pathlib.Path, output_root: pathlib.Path, max_candidates: int) -> int:
+    if split not in SPLIT_ORDINAL:
+        raise ValidatorError("Stage 0 validator accepts only frozen c/go splits")
+    if max_candidates < 1:
+        raise ValidatorError("max_candidates must be positive")
+    if not (evaluator_root / "evaluation" / "evaluation.py").exists():
+        raise ValidatorError("pinned evaluator checkout missing")
+
+    private_root = output_root / ".validator-private" / split
+    safe_root = output_root / "safe" / split
+    private_root.mkdir(parents=True, exist_ok=True)
+    safe_root.mkdir(parents=True, exist_ok=True)
+
+    dataset = load_dataset(DATASET_REPO, split=split, revision=DATASET_REVISION)
+    rows = [dict(row) for row in dataset]
+    ordered = stage0_control.candidate_order(rows, split=split, seed_sha256=SEED_SHA256)
+
+    safe_summary: dict[str, Any] = {
+        "schema_version": "ultimate-loop-reconstruction-furnace/validator-summary-v1",
+        "stage": "STAGE0",
+        "split": split,
+        "state": "NO_VALID_IN_BOUNDED_PREFIX",
+        "candidate_rank": None,
+        "gold_validation_runs": 3,
+        "gold_validation_passes": None,
+        "task_id": None,
+        "dataset_revision": DATASET_REVISION,
+        "evaluator_revision": EVALUATOR_REVISION,
+        "solver_dataset_access": False,
+        "solver_gold_access": False,
+    }
+
+    for candidate_rank, row in enumerate(ordered[:max_candidates], 1):
+        candidate_file = private_root / f"candidate-{candidate_rank:02d}.jsonl"
+        candidate_file.write_text(
+            json.dumps(row, sort_keys=True, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+        passes = 0
+        for run_number in (1, 2, 3):
+            if _evaluate_once(
+                evaluator_root=evaluator_root,
+                candidate_jsonl=candidate_file,
+                private_root=private_root,
+                candidate_rank=candidate_rank,
+                run_number=run_number,
+            ):
+                passes += 1
+
+        provenance = task_envelope.build_validator_provenance(
+            row,
+            gold_validation_runs=3,
+            gold_validation_passes=passes,
+        )
+        _json_dump(
+            private_root / f"candidate-{candidate_rank:02d}-provenance.json",
+            {
+                "source_record_sha256": provenance.source_record_sha256,
+                "source_instance_id_sha256": provenance.source_instance_id_sha256,
+                "gold_validation_runs": provenance.gold_validation_runs,
+                "gold_validation_passes": provenance.gold_validation_passes,
+            },
+        )
+        if not provenance.task_valid:
+            continue
+
+        task_id = stage0_control.opaque_task_id(
+            instance_id=str(row["instance_id"]),
+            seed_sha256=SEED_SHA256,
+            ordinal=SPLIT_ORDINAL[split],
+        )
+        envelope = task_envelope.sanitize_for_solver(
+            row,
+            opaque_task_id=task_id,
+            task_valid=True,
+            platform="linux",
+        )
+        task_envelope.verify_solver_envelope(envelope)
+        leaked = task_envelope.forbidden_key_scan(envelope)
+        if leaked:
+            raise ValidatorError("sanitized envelope failed forbidden-key scan")
+
+        envelope_sha256 = hashlib.sha256(
+            json.dumps(
+                envelope,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+        _json_dump(safe_root / "solver-envelope.json", envelope)
+        safe_summary.update(
+            {
+                "state": "ADMITTED_3_OF_3",
+                "candidate_rank": candidate_rank,
+                "gold_validation_passes": 3,
+                "task_id": task_id,
+                "solver_envelope_sha256": envelope_sha256,
+            }
+        )
+        _json_dump(safe_root / "validator-summary.json", safe_summary)
+        print(f"SAFE_VALIDATOR_RESULT split={split} state=ADMITTED_3_OF_3 rank={candidate_rank}")
+        return 0
+
+    _json_dump(safe_root / "validator-summary.json", safe_summary)
+    print(
+        f"SAFE_VALIDATOR_RESULT split={split} state=NO_VALID_IN_BOUNDED_PREFIX "
+        f"checked={min(max_candidates, len(ordered))}"
+    )
+    return 2
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--split", required=True, choices=sorted(SPLIT_ORDINAL))
+    parser.add_argument("--evaluator-root", required=True)
+    parser.add_argument("--output-root", required=True)
+    parser.add_argument("--max-candidates", type=int, default=4)
+    args = parser.parse_args()
+    return run(
+        split=args.split,
+        evaluator_root=pathlib.Path(args.evaluator_root).resolve(),
+        output_root=pathlib.Path(args.output_root).resolve(),
+        max_candidates=args.max_candidates,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/stage0_control.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/stage0_control.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import hashlib
+import random
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+
+SUPPORTED_SPLITS = ("c", "cpp", "cs", "go", "java", "js", "rust", "ts")
+RUN_SCHEMA = "ultimate-loop-reconstruction-furnace/run-manifest-v1"
+
+
+class FurnaceControlError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class RunManifest:
+    schema_version: str
+    dataset_repo: str
+    dataset_revision: str
+    evaluator_repo: str
+    evaluator_revision: str
+    seed_sha256: str
+    selected_splits: tuple[str, ...]
+    stage: str
+    solver_dataset_access: bool
+
+    def to_dict(self) -> dict[str, Any]:
+        out = asdict(self)
+        out["selected_splits"] = list(self.selected_splits)
+        return out
+
+
+def _exact_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise FurnaceControlError(f"{field} must be a non-empty exact string")
+    return value
+
+
+def _seed_hex(label: str, dataset_revision: str, evaluator_revision: str) -> str:
+    material = "|".join(
+        (
+            _exact_string(label, "seed_label"),
+            _exact_string(dataset_revision, "dataset_revision"),
+            _exact_string(evaluator_revision, "evaluator_revision"),
+        )
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def build_run_manifest(
+    *,
+    stage: str,
+    seed_label: str,
+    dataset_revision: str,
+    evaluator_revision: str,
+    split_count: int,
+    dataset_repo: str = "SWE-bench-Live/MultiLang",
+    evaluator_repo: str = "microsoft/SWE-bench-Live",
+) -> RunManifest:
+    if stage not in {"STAGE0", "STAGE1", "STAGE3"}:
+        raise FurnaceControlError("unsupported stage")
+    if not isinstance(split_count, int) or not 1 <= split_count <= len(SUPPORTED_SPLITS):
+        raise FurnaceControlError("split_count out of range")
+
+    seed_sha256 = _seed_hex(seed_label, dataset_revision, evaluator_revision)
+    rng = random.Random(int(seed_sha256, 16))
+    selected = tuple(rng.sample(list(SUPPORTED_SPLITS), split_count))
+    return RunManifest(
+        schema_version=RUN_SCHEMA,
+        dataset_repo=_exact_string(dataset_repo, "dataset_repo"),
+        dataset_revision=_exact_string(dataset_revision, "dataset_revision"),
+        evaluator_repo=_exact_string(evaluator_repo, "evaluator_repo"),
+        evaluator_revision=_exact_string(evaluator_revision, "evaluator_revision"),
+        seed_sha256=seed_sha256,
+        selected_splits=selected,
+        stage=stage,
+        solver_dataset_access=False,
+    )
+
+
+def candidate_order(
+    rows: Iterable[Mapping[str, Any]],
+    *,
+    split: str,
+    seed_sha256: str,
+) -> list[Mapping[str, Any]]:
+    """Deterministically order raw validator-side candidates without inspecting gold."""
+    if split not in SUPPORTED_SPLITS:
+        raise FurnaceControlError("unsupported split")
+    _exact_string(seed_sha256, "seed_sha256")
+
+    decorated: list[tuple[str, Mapping[str, Any]]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            raise FurnaceControlError("candidate row mapping required")
+        instance_id = _exact_string(row.get("instance_id"), "instance_id")
+        rank = hashlib.sha256(
+            f"{seed_sha256}|{split}|{instance_id}".encode("utf-8")
+        ).hexdigest()
+        decorated.append((rank, row))
+    decorated.sort(key=lambda item: item[0])
+    return [row for _, row in decorated]
+
+
+def opaque_task_id(*, instance_id: str, seed_sha256: str, ordinal: int) -> str:
+    if not isinstance(ordinal, int) or ordinal < 1:
+        raise FurnaceControlError("ordinal must be >= 1")
+    instance_id = _exact_string(instance_id, "instance_id")
+    seed_sha256 = _exact_string(seed_sha256, "seed_sha256")
+    digest = hashlib.sha256(
+        f"{seed_sha256}|task|{ordinal}|{instance_id}".encode("utf-8")
+    ).hexdigest()[:16].upper()
+    return f"FURNACE-{ordinal:02d}-{digest}"
+
+
+def resource_preflight(
+    *,
+    cpu_count: int,
+    memory_gib: float,
+    requested_cpu: int = 4,
+    requested_memory_gib: float = 16.0,
+) -> dict[str, Any]:
+    """Classify host capacity separately from solver performance.
+
+    requested_* defaults mirror the benchmark's ordinary guidance; a specific
+    task may require more and should override them out-of-band.
+    """
+    if cpu_count < 1 or memory_gib <= 0 or requested_cpu < 1 or requested_memory_gib <= 0:
+        raise FurnaceControlError("resource values must be positive")
+    blockers: list[str] = []
+    if cpu_count < requested_cpu:
+        blockers.append("CPU_BELOW_REQUEST")
+    if memory_gib < requested_memory_gib:
+        blockers.append("MEMORY_BELOW_REQUEST")
+    return {
+        "state": "RESOURCE_READY" if not blockers else "RESOURCE_BLOCKED",
+        "solver_failure": False,
+        "cpu_count": cpu_count,
+        "memory_gib": memory_gib,
+        "requested_cpu": requested_cpu,
+        "requested_memory_gib": requested_memory_gib,
+        "blockers": blockers,
+    }
+
+
+def choose_first_valid(
+    ordered_rows: Sequence[Mapping[str, Any]],
+    validation_passes: Mapping[str, int],
+) -> Mapping[str, Any]:
+    """Choose the first 3/3 valid candidate; never skip a valid row for convenience."""
+    for row in ordered_rows:
+        instance_id = _exact_string(row.get("instance_id"), "instance_id")
+        passes = validation_passes.get(instance_id)
+        if passes is None:
+            raise FurnaceControlError("missing gold-validation result in deterministic prefix")
+        if passes not in {0, 1, 2, 3}:
+            raise FurnaceControlError("gold-validation pass count must be in [0, 3]")
+        if passes == 3:
+            return row
+    raise FurnaceControlError("no reproducibly valid candidate in supplied deterministic prefix")

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/stage0_control.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/stage0_control.py
@@ -39,23 +39,17 @@ def _exact_string(value: Any, field: str) -> str:
 
 
 def _seed_hex(label: str, dataset_revision: str, evaluator_revision: str) -> str:
-    material = "|".join(
-        (
-            _exact_string(label, "seed_label"),
-            _exact_string(dataset_revision, "dataset_revision"),
-            _exact_string(evaluator_revision, "evaluator_revision"),
-        )
-    )
+    material = "|".join((
+        _exact_string(label, "seed_label"),
+        _exact_string(dataset_revision, "dataset_revision"),
+        _exact_string(evaluator_revision, "evaluator_revision"),
+    ))
     return hashlib.sha256(material.encode("utf-8")).hexdigest()
 
 
 def build_run_manifest(
-    *,
-    stage: str,
-    seed_label: str,
-    dataset_revision: str,
-    evaluator_revision: str,
-    split_count: int,
+    *, stage: str, seed_label: str, dataset_revision: str,
+    evaluator_revision: str, split_count: int,
     dataset_repo: str = "SWE-bench-Live/MultiLang",
     evaluator_repo: str = "microsoft/SWE-bench-Live",
 ) -> RunManifest:
@@ -63,7 +57,6 @@ def build_run_manifest(
         raise FurnaceControlError("unsupported stage")
     if not isinstance(split_count, int) or not 1 <= split_count <= len(SUPPORTED_SPLITS):
         raise FurnaceControlError("split_count out of range")
-
     seed_sha256 = _seed_hex(seed_label, dataset_revision, evaluator_revision)
     rng = random.Random(int(seed_sha256, 16))
     selected = tuple(rng.sample(list(SUPPORTED_SPLITS), split_count))
@@ -80,25 +73,16 @@ def build_run_manifest(
     )
 
 
-def candidate_order(
-    rows: Iterable[Mapping[str, Any]],
-    *,
-    split: str,
-    seed_sha256: str,
-) -> list[Mapping[str, Any]]:
-    """Deterministically order raw validator-side candidates without inspecting gold."""
+def candidate_order(rows: Iterable[Mapping[str, Any]], *, split: str, seed_sha256: str) -> list[Mapping[str, Any]]:
     if split not in SUPPORTED_SPLITS:
         raise FurnaceControlError("unsupported split")
     _exact_string(seed_sha256, "seed_sha256")
-
     decorated: list[tuple[str, Mapping[str, Any]]] = []
     for row in rows:
         if not isinstance(row, Mapping):
             raise FurnaceControlError("candidate row mapping required")
         instance_id = _exact_string(row.get("instance_id"), "instance_id")
-        rank = hashlib.sha256(
-            f"{seed_sha256}|{split}|{instance_id}".encode("utf-8")
-        ).hexdigest()
+        rank = hashlib.sha256(f"{seed_sha256}|{split}|{instance_id}".encode("utf-8")).hexdigest()
         decorated.append((rank, row))
     decorated.sort(key=lambda item: item[0])
     return [row for _, row in decorated]
@@ -109,47 +93,44 @@ def opaque_task_id(*, instance_id: str, seed_sha256: str, ordinal: int) -> str:
         raise FurnaceControlError("ordinal must be >= 1")
     instance_id = _exact_string(instance_id, "instance_id")
     seed_sha256 = _exact_string(seed_sha256, "seed_sha256")
-    digest = hashlib.sha256(
-        f"{seed_sha256}|task|{ordinal}|{instance_id}".encode("utf-8")
-    ).hexdigest()[:16].upper()
+    digest = hashlib.sha256(f"{seed_sha256}|task|{ordinal}|{instance_id}".encode("utf-8")).hexdigest()[:16].upper()
     return f"FURNACE-{ordinal:02d}-{digest}"
 
 
 def resource_preflight(
-    *,
-    cpu_count: int,
-    memory_gib: float,
-    requested_cpu: int = 4,
-    requested_memory_gib: float = 16.0,
+    *, cpu_count: int, memory_gib: float, requested_cpu: int = 4,
+    guidance_memory_gib: float = 16.0, hard_min_memory_gib: float = 14.0,
 ) -> dict[str, Any]:
-    """Classify host capacity separately from solver performance.
-
-    requested_* defaults mirror the benchmark's ordinary guidance; a specific
-    task may require more and should override them out-of-band.
-    """
-    if cpu_count < 1 or memory_gib <= 0 or requested_cpu < 1 or requested_memory_gib <= 0:
-        raise FurnaceControlError("resource values must be positive")
+    """Separate nominal benchmark guidance from a hard Stage 0 admission floor."""
+    if (
+        cpu_count < 1 or memory_gib <= 0 or requested_cpu < 1
+        or guidance_memory_gib <= 0 or hard_min_memory_gib <= 0
+        or hard_min_memory_gib > guidance_memory_gib
+    ):
+        raise FurnaceControlError("resource values invalid")
     blockers: list[str] = []
+    warnings: list[str] = []
     if cpu_count < requested_cpu:
-        blockers.append("CPU_BELOW_REQUEST")
-    if memory_gib < requested_memory_gib:
-        blockers.append("MEMORY_BELOW_REQUEST")
+        blockers.append("CPU_BELOW_HARD_MIN")
+    if memory_gib < hard_min_memory_gib:
+        blockers.append("MEMORY_BELOW_HARD_MIN")
+    elif memory_gib < guidance_memory_gib:
+        warnings.append("MEMORY_BELOW_GUIDANCE")
+    state = "RESOURCE_BLOCKED" if blockers else ("RESOURCE_READY_WITH_WARNING" if warnings else "RESOURCE_READY")
     return {
-        "state": "RESOURCE_READY" if not blockers else "RESOURCE_BLOCKED",
+        "state": state,
         "solver_failure": False,
         "cpu_count": cpu_count,
         "memory_gib": memory_gib,
         "requested_cpu": requested_cpu,
-        "requested_memory_gib": requested_memory_gib,
+        "guidance_memory_gib": guidance_memory_gib,
+        "hard_min_memory_gib": hard_min_memory_gib,
         "blockers": blockers,
+        "warnings": warnings,
     }
 
 
-def choose_first_valid(
-    ordered_rows: Sequence[Mapping[str, Any]],
-    validation_passes: Mapping[str, int],
-) -> Mapping[str, Any]:
-    """Choose the first 3/3 valid candidate; never skip a valid row for convenience."""
+def choose_first_valid(ordered_rows: Sequence[Mapping[str, Any]], validation_passes: Mapping[str, int]) -> Mapping[str, Any]:
     for row in ordered_rows:
         instance_id = _exact_string(row.get("instance_id"), "instance_id")
         passes = validation_passes.get(instance_id)

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/task_envelope.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/task_envelope.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+class TaskEnvelopeError(ValueError):
+    """Raised when a benchmark record cannot be safely exposed to the solver."""
+
+
+SCHEMA_VERSION = "ultimate-loop-reconstruction-furnace/task-envelope-v1"
+
+# These names must never exist anywhere in the solver-visible envelope.
+FORBIDDEN_KEYS = frozenset(
+    {
+        "patch",
+        "test_patch",
+        "hints_text",
+        "all_hints_text",
+        "pull_number",
+        "issue_numbers",
+        "commit_url",
+        "commit_urls",
+        "FAIL_TO_PASS",
+        "PASS_TO_PASS",
+        "log_parser",
+    }
+)
+
+# Output is constructed from this allowlist; source rows are never copied wholesale.
+ENVELOPE_KEYS = frozenset(
+    {
+        "schema_version",
+        "task_id",
+        "repo",
+        "base_commit",
+        "problem_statement",
+        "rebuild_cmds",
+        "test_cmds",
+        "docker_image",
+        "platform",
+        "task_valid",
+        "network_policy",
+    }
+)
+
+NETWORK_POLICY = "OFFLINE_AFTER_PREPARE"
+
+
+@dataclass(frozen=True)
+class ValidatorProvenance:
+    """Validator-side metadata. Never pass this object to the solver."""
+
+    source_record_sha256: str
+    source_instance_id_sha256: str
+    gold_validation_runs: int
+    gold_validation_passes: int
+
+    @property
+    def task_valid(self) -> bool:
+        return self.gold_validation_runs == 3 and self.gold_validation_passes == 3
+
+
+def _exact_string(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise TaskEnvelopeError(f"{field} must be a non-empty exact string")
+    return value
+
+
+def _string_list(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list) or not value:
+        raise TaskEnvelopeError(f"{field} must be a non-empty list")
+    out: list[str] = []
+    for item in value:
+        out.append(_exact_string(item, field))
+    return out
+
+
+def _sha256_json(value: Any) -> str:
+    try:
+        encoded = json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise TaskEnvelopeError("source record must be canonical-JSON serializable") from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def build_validator_provenance(
+    source_record: Mapping[str, Any],
+    *,
+    gold_validation_runs: int,
+    gold_validation_passes: int,
+) -> ValidatorProvenance:
+    """Build out-of-band provenance without exposing answer-bearing values."""
+
+    if not isinstance(source_record, Mapping):
+        raise TaskEnvelopeError("source_record mapping required")
+    instance_id = _exact_string(source_record.get("instance_id"), "instance_id")
+    if gold_validation_runs != 3:
+        raise TaskEnvelopeError("gold validator must run exactly three times")
+    if not isinstance(gold_validation_passes, int) or not 0 <= gold_validation_passes <= 3:
+        raise TaskEnvelopeError("gold_validation_passes must be in [0, 3]")
+    return ValidatorProvenance(
+        source_record_sha256=_sha256_json(dict(source_record)),
+        source_instance_id_sha256=_sha256_text(instance_id),
+        gold_validation_runs=gold_validation_runs,
+        gold_validation_passes=gold_validation_passes,
+    )
+
+
+def sanitize_for_solver(
+    source_record: Mapping[str, Any],
+    *,
+    opaque_task_id: str,
+    task_valid: bool,
+    platform: str = "linux",
+) -> dict[str, Any]:
+    """Return the only benchmark artifact permitted to enter solver context.
+
+    This is intentionally an allowlist serializer. It never removes forbidden
+    fields from a copied source row; it constructs a new object from scratch.
+    """
+
+    if not isinstance(source_record, Mapping):
+        raise TaskEnvelopeError("source_record mapping required")
+    if task_valid is not True:
+        raise TaskEnvelopeError("only reproducibly gold-valid tasks may enter the furnace")
+
+    task_id = _exact_string(opaque_task_id, "opaque_task_id")
+    repo = _exact_string(source_record.get("repo"), "repo")
+    base_commit = _exact_string(source_record.get("base_commit"), "base_commit")
+    problem_statement = _exact_string(
+        source_record.get("problem_statement"), "problem_statement"
+    )
+    rebuild_cmds = _string_list(source_record.get("rebuild_cmds"), "rebuild_cmds")
+    test_cmds = _string_list(source_record.get("test_cmds"), "test_cmds")
+    docker_image = _exact_string(source_record.get("docker_image"), "docker_image")
+    normalized_platform = _exact_string(platform, "platform")
+
+    envelope = {
+        "schema_version": SCHEMA_VERSION,
+        "task_id": task_id,
+        "repo": repo,
+        "base_commit": base_commit,
+        "problem_statement": problem_statement,
+        "rebuild_cmds": rebuild_cmds,
+        "test_cmds": test_cmds,
+        "docker_image": docker_image,
+        "platform": normalized_platform,
+        "task_valid": True,
+        "network_policy": NETWORK_POLICY,
+    }
+    verify_solver_envelope(envelope)
+    return envelope
+
+
+def verify_solver_envelope(envelope: Mapping[str, Any]) -> None:
+    """Fail closed if the solver-visible artifact drifts from the exact schema."""
+
+    if not isinstance(envelope, Mapping):
+        raise TaskEnvelopeError("solver envelope mapping required")
+    keys = set(envelope)
+    if keys != ENVELOPE_KEYS:
+        extra = sorted(keys - ENVELOPE_KEYS)
+        missing = sorted(ENVELOPE_KEYS - keys)
+        raise TaskEnvelopeError(f"solver envelope shape drift: extra={extra} missing={missing}")
+    leaked = sorted(keys & FORBIDDEN_KEYS)
+    if leaked:
+        raise TaskEnvelopeError(f"forbidden benchmark fields leaked: {leaked}")
+
+    if envelope["schema_version"] != SCHEMA_VERSION:
+        raise TaskEnvelopeError("schema_version mismatch")
+    if envelope["task_valid"] is not True:
+        raise TaskEnvelopeError("task_valid must be true")
+    if envelope["network_policy"] != NETWORK_POLICY:
+        raise TaskEnvelopeError("network policy widened")
+
+    for field in (
+        "task_id",
+        "repo",
+        "base_commit",
+        "problem_statement",
+        "docker_image",
+        "platform",
+    ):
+        _exact_string(envelope[field], field)
+    _string_list(envelope["rebuild_cmds"], "rebuild_cmds")
+    _string_list(envelope["test_cmds"], "test_cmds")
+
+
+def forbidden_key_scan(value: Any) -> list[str]:
+    """Recursively report forbidden key names in an arbitrary solver namespace."""
+
+    found: set[str] = set()
+
+    def visit(node: Any) -> None:
+        if isinstance(node, Mapping):
+            for key, child in node.items():
+                if isinstance(key, str) and key in FORBIDDEN_KEYS:
+                    found.add(key)
+                visit(child)
+        elif isinstance(node, (list, tuple)):
+            for child in node:
+                visit(child)
+
+    visit(value)
+    return sorted(found)

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/task_envelope.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/task_envelope.py
@@ -7,29 +7,40 @@ from typing import Any, Mapping
 
 
 class TaskEnvelopeError(ValueError):
-    """Raised when a benchmark record cannot be safely exposed to the solver."""
+    """Raised when benchmark material cannot be safely exposed to the solver."""
 
 
-SCHEMA_VERSION = "ultimate-loop-reconstruction-furnace/task-envelope-v1"
+SCHEMA_VERSION = "ultimate-loop-reconstruction-furnace/task-envelope-v2"
 
-# These names must never exist anywhere in the solver-visible envelope.
+# Raw benchmark answer/evaluator/validator metadata must never enter solver context.
 FORBIDDEN_KEYS = frozenset(
     {
+        "instance_id",
+        "pull_number",
+        "issue_numbers",
         "patch",
         "test_patch",
         "hints_text",
         "all_hints_text",
-        "pull_number",
-        "issue_numbers",
         "commit_url",
         "commit_urls",
+        "created_at",
+        "rebuild_cmds",
+        "test_cmds",
+        "print_cmds",
+        "log_parser",
         "FAIL_TO_PASS",
         "PASS_TO_PASS",
-        "log_parser",
+        "docker_image",
+        "source_record_sha256",
+        "source_instance_id_sha256",
+        "gold_validation_runs",
+        "gold_validation_passes",
     }
 )
 
-# Output is constructed from this allowlist; source rows are never copied wholesale.
+# Solver receives only the issue and the identity needed to reconstruct the repo.
+# Sandbox/image/build/evaluation metadata remains runner-side.
 ENVELOPE_KEYS = frozenset(
     {
         "schema_version",
@@ -37,9 +48,6 @@ ENVELOPE_KEYS = frozenset(
         "repo",
         "base_commit",
         "problem_statement",
-        "rebuild_cmds",
-        "test_cmds",
-        "docker_image",
         "platform",
         "task_valid",
         "network_policy",
@@ -67,15 +75,6 @@ def _exact_string(value: Any, field: str) -> str:
     if not isinstance(value, str) or not value or value != value.strip():
         raise TaskEnvelopeError(f"{field} must be a non-empty exact string")
     return value
-
-
-def _string_list(value: Any, field: str) -> list[str]:
-    if not isinstance(value, list) or not value:
-        raise TaskEnvelopeError(f"{field} must be a non-empty list")
-    out: list[str] = []
-    for item in value:
-        out.append(_exact_string(item, field))
-    return out
 
 
 def _sha256_json(value: Any) -> str:
@@ -127,8 +126,9 @@ def sanitize_for_solver(
 ) -> dict[str, Any]:
     """Return the only benchmark artifact permitted to enter solver context.
 
-    This is intentionally an allowlist serializer. It never removes forbidden
-    fields from a copied source row; it constructs a new object from scratch.
+    This is an allowlist serializer. It constructs a new object from scratch.
+    Evaluator commands, hidden-test metadata, image identity, raw instance
+    identity, gold material, and validator provenance stay outside the solver.
     """
 
     if not isinstance(source_record, Mapping):
@@ -136,27 +136,15 @@ def sanitize_for_solver(
     if task_valid is not True:
         raise TaskEnvelopeError("only reproducibly gold-valid tasks may enter the furnace")
 
-    task_id = _exact_string(opaque_task_id, "opaque_task_id")
-    repo = _exact_string(source_record.get("repo"), "repo")
-    base_commit = _exact_string(source_record.get("base_commit"), "base_commit")
-    problem_statement = _exact_string(
-        source_record.get("problem_statement"), "problem_statement"
-    )
-    rebuild_cmds = _string_list(source_record.get("rebuild_cmds"), "rebuild_cmds")
-    test_cmds = _string_list(source_record.get("test_cmds"), "test_cmds")
-    docker_image = _exact_string(source_record.get("docker_image"), "docker_image")
-    normalized_platform = _exact_string(platform, "platform")
-
     envelope = {
         "schema_version": SCHEMA_VERSION,
-        "task_id": task_id,
-        "repo": repo,
-        "base_commit": base_commit,
-        "problem_statement": problem_statement,
-        "rebuild_cmds": rebuild_cmds,
-        "test_cmds": test_cmds,
-        "docker_image": docker_image,
-        "platform": normalized_platform,
+        "task_id": _exact_string(opaque_task_id, "opaque_task_id"),
+        "repo": _exact_string(source_record.get("repo"), "repo"),
+        "base_commit": _exact_string(source_record.get("base_commit"), "base_commit"),
+        "problem_statement": _exact_string(
+            source_record.get("problem_statement"), "problem_statement"
+        ),
+        "platform": _exact_string(platform, "platform"),
         "task_valid": True,
         "network_policy": NETWORK_POLICY,
     }
@@ -173,7 +161,9 @@ def verify_solver_envelope(envelope: Mapping[str, Any]) -> None:
     if keys != ENVELOPE_KEYS:
         extra = sorted(keys - ENVELOPE_KEYS)
         missing = sorted(ENVELOPE_KEYS - keys)
-        raise TaskEnvelopeError(f"solver envelope shape drift: extra={extra} missing={missing}")
+        raise TaskEnvelopeError(
+            f"solver envelope shape drift: extra={extra} missing={missing}"
+        )
     leaked = sorted(keys & FORBIDDEN_KEYS)
     if leaked:
         raise TaskEnvelopeError(f"forbidden benchmark fields leaked: {leaked}")
@@ -190,12 +180,9 @@ def verify_solver_envelope(envelope: Mapping[str, Any]) -> None:
         "repo",
         "base_commit",
         "problem_statement",
-        "docker_image",
         "platform",
     ):
         _exact_string(envelope[field], field)
-    _string_list(envelope["rebuild_cmds"], "rebuild_cmds")
-    _string_list(envelope["test_cmds"], "test_cmds")
 
 
 def forbidden_key_scan(value: Any) -> list[str]:

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_stage0_control.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_stage0_control.py
@@ -25,57 +25,40 @@ class Stage0ControlTests(unittest.TestCase):
         )
         self.assertEqual(manifest.selected_splits, ("c", "go"))
         self.assertFalse(manifest.solver_dataset_access)
-        self.assertEqual(
-            manifest.seed_sha256,
-            "050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b",
-        )
+        self.assertEqual(manifest.seed_sha256, "050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b")
 
     def test_candidate_order_is_deterministic_and_gold_agnostic(self) -> None:
-        rows_a = [
-            {"instance_id": "r__x-2", "patch": "gold-two"},
-            {"instance_id": "r__x-1", "patch": "gold-one"},
-        ]
-        rows_b = [
-            {"instance_id": "r__x-2", "patch": "completely-different"},
-            {"instance_id": "r__x-1", "patch": "also-different"},
-        ]
-        order_a = [
-            row["instance_id"]
-            for row in mod.candidate_order(rows_a, split="c", seed_sha256="a" * 64)
-        ]
-        order_b = [
-            row["instance_id"]
-            for row in mod.candidate_order(rows_b, split="c", seed_sha256="a" * 64)
-        ]
+        rows_a = [{"instance_id": "r__x-2", "patch": "gold-two"}, {"instance_id": "r__x-1", "patch": "gold-one"}]
+        rows_b = [{"instance_id": "r__x-2", "patch": "different"}, {"instance_id": "r__x-1", "patch": "also-different"}]
+        order_a = [row["instance_id"] for row in mod.candidate_order(rows_a, split="c", seed_sha256="a" * 64)]
+        order_b = [row["instance_id"] for row in mod.candidate_order(rows_b, split="c", seed_sha256="a" * 64)]
         self.assertEqual(order_a, order_b)
 
     def test_first_valid_is_first_three_of_three_not_cherry_pick(self) -> None:
-        rows = [
-            {"instance_id": "a"},
-            {"instance_id": "b"},
-            {"instance_id": "c"},
-        ]
+        rows = [{"instance_id": "a"}, {"instance_id": "b"}, {"instance_id": "c"}]
         selected = mod.choose_first_valid(rows, {"a": 2, "b": 3, "c": 3})
         self.assertEqual(selected["instance_id"], "b")
 
     def test_missing_validation_in_prefix_fails_closed(self) -> None:
-        rows = [{"instance_id": "a"}, {"instance_id": "b"}]
         with self.assertRaises(mod.FurnaceControlError):
-            mod.choose_first_valid(rows, {"b": 3})
+            mod.choose_first_valid([{"instance_id": "a"}, {"instance_id": "b"}], {"b": 3})
 
-    def test_resource_block_is_not_solver_failure(self) -> None:
+    def test_resource_hard_block_is_not_solver_failure(self) -> None:
         result = mod.resource_preflight(cpu_count=2, memory_gib=8)
         self.assertEqual(result["state"], "RESOURCE_BLOCKED")
         self.assertFalse(result["solver_failure"])
-        self.assertIn("CPU_BELOW_REQUEST", result["blockers"])
-        self.assertIn("MEMORY_BELOW_REQUEST", result["blockers"])
+        self.assertIn("CPU_BELOW_HARD_MIN", result["blockers"])
+        self.assertIn("MEMORY_BELOW_HARD_MIN", result["blockers"])
+
+    def test_nominal_16gb_runner_can_be_ready_with_memory_warning(self) -> None:
+        result = mod.resource_preflight(cpu_count=4, memory_gib=15.0)
+        self.assertEqual(result["state"], "RESOURCE_READY_WITH_WARNING")
+        self.assertEqual(result["blockers"], [])
+        self.assertIn("MEMORY_BELOW_GUIDANCE", result["warnings"])
+        self.assertFalse(result["solver_failure"])
 
     def test_opaque_id_hides_instance_text(self) -> None:
-        task_id = mod.opaque_task_id(
-            instance_id="repo__repo-12345",
-            seed_sha256="b" * 64,
-            ordinal=1,
-        )
+        task_id = mod.opaque_task_id(instance_id="repo__repo-12345", seed_sha256="b" * 64, ordinal=1)
         self.assertNotIn("repo", task_id.lower())
         self.assertNotIn("12345", task_id)
 

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_stage0_control.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_stage0_control.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("stage0_control.py")
+spec = importlib.util.spec_from_file_location("reconstruction_furnace_stage0_control", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+class Stage0ControlTests(unittest.TestCase):
+    def test_pinned_seed_selects_c_and_go(self) -> None:
+        manifest = mod.build_run_manifest(
+            stage="STAGE0",
+            seed_label="ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_STAGE0",
+            dataset_revision="608f7ae9ab8ea1f9f0d030fe04562cf6bd1a0c8b",
+            evaluator_revision="70ec57e852e3f2d195790fe71f553e272c691833",
+            split_count=2,
+        )
+        self.assertEqual(manifest.selected_splits, ("c", "go"))
+        self.assertFalse(manifest.solver_dataset_access)
+        self.assertEqual(
+            manifest.seed_sha256,
+            "050b40668443f667bcc5eabb7ff6c0ea3db5f2e962ac2178ce8e95d4e9e7921b",
+        )
+
+    def test_candidate_order_is_deterministic_and_gold_agnostic(self) -> None:
+        rows_a = [
+            {"instance_id": "r__x-2", "patch": "gold-two"},
+            {"instance_id": "r__x-1", "patch": "gold-one"},
+        ]
+        rows_b = [
+            {"instance_id": "r__x-2", "patch": "completely-different"},
+            {"instance_id": "r__x-1", "patch": "also-different"},
+        ]
+        order_a = [
+            row["instance_id"]
+            for row in mod.candidate_order(rows_a, split="c", seed_sha256="a" * 64)
+        ]
+        order_b = [
+            row["instance_id"]
+            for row in mod.candidate_order(rows_b, split="c", seed_sha256="a" * 64)
+        ]
+        self.assertEqual(order_a, order_b)
+
+    def test_first_valid_is_first_three_of_three_not_cherry_pick(self) -> None:
+        rows = [
+            {"instance_id": "a"},
+            {"instance_id": "b"},
+            {"instance_id": "c"},
+        ]
+        selected = mod.choose_first_valid(rows, {"a": 2, "b": 3, "c": 3})
+        self.assertEqual(selected["instance_id"], "b")
+
+    def test_missing_validation_in_prefix_fails_closed(self) -> None:
+        rows = [{"instance_id": "a"}, {"instance_id": "b"}]
+        with self.assertRaises(mod.FurnaceControlError):
+            mod.choose_first_valid(rows, {"b": 3})
+
+    def test_resource_block_is_not_solver_failure(self) -> None:
+        result = mod.resource_preflight(cpu_count=2, memory_gib=8)
+        self.assertEqual(result["state"], "RESOURCE_BLOCKED")
+        self.assertFalse(result["solver_failure"])
+        self.assertIn("CPU_BELOW_REQUEST", result["blockers"])
+        self.assertIn("MEMORY_BELOW_REQUEST", result["blockers"])
+
+    def test_opaque_id_hides_instance_text(self) -> None:
+        task_id = mod.opaque_task_id(
+            instance_id="repo__repo-12345",
+            seed_sha256="b" * 64,
+            ordinal=1,
+        )
+        self.assertNotIn("repo", task_id.lower())
+        self.assertNotIn("12345", task_id)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_task_envelope.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_task_envelope.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import importlib.util
 import pathlib
+import sys
 import unittest
 
 
@@ -10,6 +11,7 @@ MODULE_PATH = pathlib.Path(__file__).with_name("task_envelope.py")
 spec = importlib.util.spec_from_file_location("reconstruction_furnace_task_envelope", MODULE_PATH)
 assert spec is not None and spec.loader is not None
 mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
 spec.loader.exec_module(mod)
 
 

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_task_envelope.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_task_envelope.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import pathlib
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("task_envelope.py")
+spec = importlib.util.spec_from_file_location("reconstruction_furnace_task_envelope", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+
+
+class TaskEnvelopeTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.source = {
+            "repo": "alien/example",
+            "pull_number": "999",
+            "instance_id": "alien__example-999",
+            "issue_numbers": ["123"],
+            "base_commit": "a" * 40,
+            "patch": "SECRET GOLD PATCH",
+            "test_patch": "SECRET GOLD TEST",
+            "problem_statement": "Observed behavior differs from the documented contract.",
+            "hints_text": "SECRET HINT",
+            "all_hints_text": "SECRET ALL HINTS",
+            "commit_urls": ["https://example.invalid/fix"],
+            "commit_url": "https://example.invalid/base",
+            "rebuild_cmds": ["make -j2"],
+            "test_cmds": ["make check"],
+            "print_cmds": ["cat test-output.log"],
+            "log_parser": "SECRET EVALUATOR PARSER",
+            "FAIL_TO_PASS": ["hidden_failure"],
+            "PASS_TO_PASS": ["hidden_regression"],
+            "docker_image": "example.invalid/furnace:task",
+            "future_dataset_field": {"may_contain": "anything"},
+        }
+
+    def test_allowlist_drops_all_answer_bearing_source_fields(self) -> None:
+        envelope = mod.sanitize_for_solver(
+            self.source,
+            opaque_task_id="FURNACE-A-001",
+            task_valid=True,
+        )
+        self.assertEqual(set(envelope), mod.ENVELOPE_KEYS)
+        self.assertEqual(mod.forbidden_key_scan(envelope), [])
+        serialized = repr(envelope)
+        self.assertNotIn("SECRET GOLD PATCH", serialized)
+        self.assertNotIn("SECRET GOLD TEST", serialized)
+        self.assertNotIn("SECRET HINT", serialized)
+        self.assertNotIn("hidden_failure", serialized)
+        self.assertNotIn("future_dataset_field", serialized)
+        self.assertNotIn("alien__example-999", serialized)
+        self.assertNotIn("999", serialized)
+
+    def test_unknown_solver_field_fails_closed(self) -> None:
+        envelope = mod.sanitize_for_solver(
+            self.source,
+            opaque_task_id="FURNACE-A-002",
+            task_valid=True,
+        )
+        envelope["innocent_future_field"] = "value"
+        with self.assertRaises(mod.TaskEnvelopeError):
+            mod.verify_solver_envelope(envelope)
+
+    def test_forbidden_field_fails_closed_even_if_empty(self) -> None:
+        envelope = mod.sanitize_for_solver(
+            self.source,
+            opaque_task_id="FURNACE-A-003",
+            task_valid=True,
+        )
+        envelope["patch"] = ""
+        with self.assertRaises(mod.TaskEnvelopeError):
+            mod.verify_solver_envelope(envelope)
+        self.assertEqual(mod.forbidden_key_scan(envelope), ["patch"])
+
+    def test_invalid_task_never_enters_solver(self) -> None:
+        with self.assertRaises(mod.TaskEnvelopeError):
+            mod.sanitize_for_solver(
+                self.source,
+                opaque_task_id="FURNACE-A-004",
+                task_valid=False,
+            )
+
+    def test_validator_requires_exactly_three_gold_runs(self) -> None:
+        with self.assertRaises(mod.TaskEnvelopeError):
+            mod.build_validator_provenance(
+                self.source,
+                gold_validation_runs=2,
+                gold_validation_passes=2,
+            )
+
+        provenance = mod.build_validator_provenance(
+            self.source,
+            gold_validation_runs=3,
+            gold_validation_passes=3,
+        )
+        self.assertTrue(provenance.task_valid)
+        self.assertNotIn("alien__example-999", repr(provenance))
+        self.assertNotIn("SECRET GOLD PATCH", repr(provenance))
+
+    def test_three_runs_with_one_failure_is_not_valid(self) -> None:
+        provenance = mod.build_validator_provenance(
+            self.source,
+            gold_validation_runs=3,
+            gold_validation_passes=2,
+        )
+        self.assertFalse(provenance.task_valid)
+
+    def test_recursive_scan_detects_trace_leakage(self) -> None:
+        trace_namespace = {
+            "events": [
+                {"type": "TASK_START"},
+                {"type": "TOOL_RESULT", "payload": {"test_patch": "oops"}},
+            ]
+        }
+        self.assertEqual(mod.forbidden_key_scan(trace_namespace), ["test_patch"])
+
+    def test_source_is_not_mutated(self) -> None:
+        before = copy.deepcopy(self.source)
+        mod.sanitize_for_solver(
+            self.source,
+            opaque_task_id="FURNACE-A-005",
+            task_valid=True,
+        )
+        self.assertEqual(self.source, before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_trace_contract.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_trace_contract.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 import sys
+import tempfile
+import threading
 import unittest
-
 
 MODULE_PATH = pathlib.Path(__file__).with_name("trace_contract.py")
 spec = importlib.util.spec_from_file_location("reconstruction_furnace_trace_contract", MODULE_PATH)
@@ -14,92 +15,233 @@ sys.modules[spec.name] = mod
 spec.loader.exec_module(mod)
 
 
-def event(seq: int, event_type: str, *, ns: int | None = None) -> dict:
-    return {
+def payload(event_type: str, *, tool_id: int = 0) -> dict:
+    values = {
+        "TASK_START": {"subject": "blind repair"},
+        "REPO_DISCOVERY_START": {"scope": "repository"},
+        "REPO_DISCOVERY_END": {"evidence_refs": ["repo-map"]},
+        "REPO_MODEL_REVISION": {"revision_id": "RM-1", "evidence_refs": ["repo-map"]},
+        "FIRST_ACTIONABLE_HYPOTHESIS": {"hypothesis_id": "H-1", "statement": "candidate", "evidence_refs": ["ev-1"]},
+        "HYPOTHESIS_EVIDENCE": {"hypothesis_id": "H-1", "direction": "SUPPORT", "evidence_refs": ["ev-1"]},
+        "DA_FINDING": {"finding_id": "DA-1", "target_id": "H-1", "statement": "attack"},
+        "COUNTER_DA_FINDING": {"finding_id": "CDA-1", "target_id": "DA-1", "statement": "counter"},
+        "PATCH_ATTEMPT": {"patch_id": "P-1", "patch_sha256": "a" * 64},
+        "TEST_RESULT": {"test_id": "T-1", "classification": "PASS", "evidence_refs": ["testlog"]},
+        "FAILURE_SIGNATURE": {"signature": "sig", "evidence_refs": ["testlog"]},
+        "HYPOTHESIS_REOPEN": {"hypothesis_id": "H-1", "reason": "failed"},
+        "MODEL_REVISION": {"revision_id": "RM-2", "reason": "new evidence"},
+        "ROOT_CAUSE_CLASSIFICATION": {"candidate_id": "RC-1", "classification": "LOGIC", "evidence_refs": ["ev-2"]},
+        "INVARIANT_CANDIDATE": {"invariant_id": "I-1", "statement": "x"},
+        "INVARIANT_DECISION": {"invariant_id": "I-1", "decision": "PROMOTE"},
+        "METHOD_MEMORY_REUSE": {"memory_id": "M-1", "source_task_ids": ["OLD-1"]},
+        "FALSE_TRANSFER": {"memory_id": "M-1", "impact": "misled"},
+        "HUMAN_TOUCH": {"action": "none"},
+        "TOOL_INVOCATION": {"tool_class": f"repo-read-{tool_id}"},
+        "OBSERVER_OVERHEAD": {"wall_ns": 10, "cpu_ns": 5, "bytes_written": 100},
+    }
+    return values[event_type]
+
+
+def make_trace(*, include_failure: bool = False, tools: int = 1) -> list[dict]:
+    types = [
+        "TASK_START", "REPO_DISCOVERY_START", "REPO_DISCOVERY_END",
+        "REPO_MODEL_REVISION", "FIRST_ACTIONABLE_HYPOTHESIS",
+        "HYPOTHESIS_EVIDENCE", "DA_FINDING", "COUNTER_DA_FINDING",
+        "PATCH_ATTEMPT", "TEST_RESULT",
+    ]
+    if include_failure:
+        types += ["FAILURE_SIGNATURE", "HYPOTHESIS_REOPEN", "MODEL_REVISION"]
+    rows = []
+    counts = {key: 0 for key in mod.COUNTED_EVENT_TYPES}
+    for typ in types:
+        for key, mapped in mod.COUNTED_EVENT_TYPES.items():
+            if mapped == typ:
+                counts[key] += 1
+        rows.append({
+            "schema_version": mod.TRACE_SCHEMA,
+            "run_id": "RUN-1",
+            "task_id": "TASK-1",
+            "seq": 0,
+            "monotonic_ns": 0,
+            "event_type": typ,
+            "attempt_id": "ATTEMPT-1",
+            "payload": payload(typ),
+        })
+    for i in range(tools):
+        counts["tool_invocations"] += 1
+        rows.append({
+            "schema_version": mod.TRACE_SCHEMA,
+            "run_id": "RUN-1",
+            "task_id": "TASK-1",
+            "seq": 0,
+            "monotonic_ns": 0,
+            "event_type": "TOOL_INVOCATION",
+            "attempt_id": "ATTEMPT-1",
+            "payload": payload("TOOL_INVOCATION", tool_id=i),
+        })
+    rows.append({
         "schema_version": mod.TRACE_SCHEMA,
         "run_id": "RUN-1",
         "task_id": "TASK-1",
-        "seq": seq,
-        "monotonic_ns": seq * 100 if ns is None else ns,
-        "event_type": event_type,
+        "seq": 0,
+        "monotonic_ns": 0,
+        "event_type": "OBSERVER_OVERHEAD",
         "attempt_id": "ATTEMPT-1",
-        "payload": {},
-    }
+        "payload": payload("OBSERVER_OVERHEAD"),
+    })
+    for i, row in enumerate(rows, 1):
+        row["seq"] = i
+        row["monotonic_ns"] = i * 100
+    rows.append({
+        "schema_version": mod.TRACE_SCHEMA,
+        "run_id": "RUN-1",
+        "task_id": "TASK-1",
+        "seq": len(rows) + 1,
+        "monotonic_ns": (len(rows) + 1) * 100,
+        "event_type": "TASK_END",
+        "attempt_id": "ATTEMPT-1",
+        "payload": {"result": "PASS", "event_counts": counts},
+    })
+    return rows
 
 
 class TraceContractTests(unittest.TestCase):
-    def complete_trace(self) -> list[dict]:
-        return [
-            event(i, typ)
-            for i, typ in enumerate(
-                [
-                    "TASK_START",
-                    "REPO_DISCOVERY_START",
-                    "REPO_DISCOVERY_END",
-                    "REPO_MODEL_REVISION",
-                    "FIRST_ACTIONABLE_HYPOTHESIS",
-                    "HYPOTHESIS_EVIDENCE",
-                    "DA_FINDING",
-                    "COUNTER_DA_FINDING",
-                    "PATCH_ATTEMPT",
-                    "TEST_RESULT",
-                    "FAILURE_SIGNATURE",
-                    "HYPOTHESIS_REOPEN",
-                    "MODEL_REVISION",
-                    "ROOT_CAUSE_CLASSIFICATION",
-                    "INVARIANT_CANDIDATE",
-                    "INVARIANT_DECISION",
-                    "METHOD_MEMORY_REUSE",
-                    "FALSE_TRANSFER",
-                    "HUMAN_TOUCH",
-                    "TOOL_INVOCATION",
-                    "OBSERVER_OVERHEAD",
-                    "TASK_END",
-                ],
-                1,
-            )
-        ]
-
-    def test_complete_trace_passes(self) -> None:
-        result = mod.validate_trace(self.complete_trace())
+    def test_clean_first_pass_trace_does_not_need_fake_failure_events(self) -> None:
+        result = mod.validate_trace(make_trace(include_failure=False))
         self.assertTrue(result["complete"])
-        self.assertEqual(result["state"], "TRACE_COMPLETE")
+        self.assertEqual(result["event_type_counts"].get("FAILURE_SIGNATURE", 0), 0)
 
-    def test_missing_event_is_incomplete_not_silently_passed(self) -> None:
-        rows = [row for row in self.complete_trace() if row["event_type"] != "DA_FINDING"]
+    def test_empty_payload_spoof_fails_closed(self) -> None:
+        rows = make_trace()
+        rows[4]["payload"] = {}
+        with self.assertRaises(mod.TraceContractError):
+            mod.validate_trace(rows)
+
+    def test_declared_counts_must_match_observed_events(self) -> None:
+        rows = make_trace(tools=3)
+        rows[-1]["payload"]["event_counts"]["tool_invocations"] = 2
+        result = mod.validate_trace(rows)
+        self.assertFalse(result["complete"])
+        self.assertTrue(result["count_mismatches"])
+
+    def test_patch_before_counter_da_is_incomplete(self) -> None:
+        rows = make_trace()
+        patch = next(i for i, x in enumerate(rows) if x["event_type"] == "PATCH_ATTEMPT")
+        cda = next(i for i, x in enumerate(rows) if x["event_type"] == "COUNTER_DA_FINDING")
+        rows[patch], rows[cda] = rows[cda], rows[patch]
         for i, row in enumerate(rows, 1):
             row["seq"] = i
             row["monotonic_ns"] = i * 100
         result = mod.validate_trace(rows)
         self.assertFalse(result["complete"])
-        self.assertIn("DA_FINDING", result["missing_event_types"])
+        self.assertIn("PATCH_BEFORE_COUNTER_DA", result["order_errors"])
 
     def test_sequence_gap_fails_closed(self) -> None:
-        rows = self.complete_trace()
+        rows = make_trace()
         rows[5]["seq"] = 999
         with self.assertRaises(mod.TraceContractError):
             mod.validate_trace(rows)
 
-    def test_monotonic_regression_fails_closed(self) -> None:
-        rows = self.complete_trace()
-        rows[5]["monotonic_ns"] = 0
-        with self.assertRaises(mod.TraceContractError):
-            mod.validate_trace(rows)
-
     def test_cross_task_trace_fails_closed(self) -> None:
-        rows = self.complete_trace()
+        rows = make_trace()
         rows[4]["task_id"] = "TASK-OTHER"
         with self.assertRaises(mod.TraceContractError):
             mod.validate_trace(rows)
 
-    def test_observer_overhead_can_be_negative_if_noise_wins(self) -> None:
-        self.assertEqual(
-            mod.observer_overhead_pct(
-                baseline_wall_ns=100,
-                observed_wall_ns=90,
-            ),
-            -10.0,
-        )
+    def test_negative_timing_noise_does_not_claim_negative_overhead(self) -> None:
+        self.assertEqual(mod.observer_overhead_pct(baseline_wall_ns=100, observed_wall_ns=90), 0.0)
+
+    def test_burst_recorder_captures_every_event_in_order_and_replays(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            sink = pathlib.Path(td) / "trace.jsonl"
+            rec = mod.TraceRecorder(run_id="RUN-BURST", task_id="TASK-BURST", sink=sink)
+            for typ in [
+                "TASK_START", "REPO_DISCOVERY_START", "REPO_DISCOVERY_END",
+                "REPO_MODEL_REVISION", "FIRST_ACTIONABLE_HYPOTHESIS",
+                "HYPOTHESIS_EVIDENCE", "DA_FINDING", "COUNTER_DA_FINDING",
+            ]:
+                rec.emit(typ, attempt_id="A-1", payload=payload(typ))
+            threads = 8
+            per_thread = 250
+
+            def worker(tid: int) -> None:
+                for i in range(per_thread):
+                    rec.emit(
+                        "TOOL_INVOCATION",
+                        attempt_id="A-1",
+                        payload={"tool_class": f"t{tid}-{i}"},
+                    )
+
+            workers = [threading.Thread(target=worker, args=(i,)) for i in range(threads)]
+            for worker_thread in workers:
+                worker_thread.start()
+            for worker_thread in workers:
+                worker_thread.join()
+
+            rec.emit("PATCH_ATTEMPT", attempt_id="A-1", payload=payload("PATCH_ATTEMPT"))
+            rec.emit("TEST_RESULT", attempt_id="A-1", payload=payload("TEST_RESULT"))
+            stats_before = rec.stats()
+            rec.emit(
+                "OBSERVER_OVERHEAD",
+                attempt_id="A-1",
+                payload={
+                    "wall_ns": stats_before["write_wall_ns"],
+                    "cpu_ns": 0,
+                    "bytes_written": stats_before["bytes_written"],
+                },
+            )
+            counts = {key: 0 for key in mod.COUNTED_EVENT_TYPES}
+            counts["tool_invocations"] = threads * per_thread
+            counts["patch_attempts"] = 1
+            counts["tests"] = 1
+            rec.emit(
+                "TASK_END",
+                attempt_id="A-1",
+                payload={"result": "PASS", "event_counts": counts},
+            )
+
+            memory_rows = rec.snapshot()
+            disk_rows = mod.load_jsonl(sink)
+            self.assertEqual(len(memory_rows), len(disk_rows))
+            self.assertEqual([row["seq"] for row in disk_rows], list(range(1, len(disk_rows) + 1)))
+            self.assertEqual(rec.stats()["events_emitted"], rec.stats()["events_captured"])
+            result = mod.validate_trace(disk_rows)
+            self.assertTrue(result["complete"])
+            self.assertEqual(result["event_type_counts"]["TOOL_INVOCATION"], threads * per_thread)
+
+    def test_nested_forbidden_benchmark_key_fails_closed(self) -> None:
+        rows = make_trace()
+        rows[6]["payload"]["nested"] = {"patch": "gold"}
+        with self.assertRaises(mod.TraceContractError):
+            mod.validate_trace(rows)
+
+    def test_second_task_end_cannot_hide_early_end(self) -> None:
+        rows = make_trace()
+        duplicate = dict(rows[-1])
+        duplicate["seq"] = rows[-1]["seq"]
+        duplicate["monotonic_ns"] = rows[-1]["monotonic_ns"]
+        rows.insert(-1, duplicate)
+        for i, row in enumerate(rows, 1):
+            row["seq"] = i
+            row["monotonic_ns"] = i * 100
+        result = mod.validate_trace(rows)
+        self.assertFalse(result["complete"])
+        self.assertFalse(result["task_end_last"])
+
+    def test_test_result_must_bind_to_prior_patch_attempt(self) -> None:
+        rows = make_trace()
+        test_row = next(row for row in rows if row["event_type"] == "TEST_RESULT")
+        test_row["attempt_id"] = "ATTEMPT-OTHER"
+        result = mod.validate_trace(rows)
+        self.assertFalse(result["complete"])
+        self.assertTrue(any("ATTEMPT-OTHER" in err for err in result["order_errors"]))
+
+    def test_recorder_freezes_nested_payload_against_caller_mutation(self) -> None:
+        rec = mod.TraceRecorder(run_id="RUN-FREEZE", task_id="TASK-FREEZE")
+        original = {"subject": "blind repair", "extra": {"notes": ["before"]}}
+        rec.emit("TASK_START", attempt_id="A-1", payload=original)
+        original["extra"]["notes"][0] = "after"
+        self.assertEqual(rec.snapshot()[0]["payload"]["extra"]["notes"], ["before"])
 
 
 if __name__ == "__main__":

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_trace_contract.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/test_trace_contract.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import unittest
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("trace_contract.py")
+spec = importlib.util.spec_from_file_location("reconstruction_furnace_trace_contract", MODULE_PATH)
+assert spec is not None and spec.loader is not None
+mod = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = mod
+spec.loader.exec_module(mod)
+
+
+def event(seq: int, event_type: str, *, ns: int | None = None) -> dict:
+    return {
+        "schema_version": mod.TRACE_SCHEMA,
+        "run_id": "RUN-1",
+        "task_id": "TASK-1",
+        "seq": seq,
+        "monotonic_ns": seq * 100 if ns is None else ns,
+        "event_type": event_type,
+        "attempt_id": "ATTEMPT-1",
+        "payload": {},
+    }
+
+
+class TraceContractTests(unittest.TestCase):
+    def complete_trace(self) -> list[dict]:
+        return [
+            event(i, typ)
+            for i, typ in enumerate(
+                [
+                    "TASK_START",
+                    "REPO_DISCOVERY_START",
+                    "REPO_DISCOVERY_END",
+                    "REPO_MODEL_REVISION",
+                    "FIRST_ACTIONABLE_HYPOTHESIS",
+                    "HYPOTHESIS_EVIDENCE",
+                    "DA_FINDING",
+                    "COUNTER_DA_FINDING",
+                    "PATCH_ATTEMPT",
+                    "TEST_RESULT",
+                    "FAILURE_SIGNATURE",
+                    "HYPOTHESIS_REOPEN",
+                    "MODEL_REVISION",
+                    "ROOT_CAUSE_CLASSIFICATION",
+                    "INVARIANT_CANDIDATE",
+                    "INVARIANT_DECISION",
+                    "METHOD_MEMORY_REUSE",
+                    "FALSE_TRANSFER",
+                    "HUMAN_TOUCH",
+                    "TOOL_INVOCATION",
+                    "OBSERVER_OVERHEAD",
+                    "TASK_END",
+                ],
+                1,
+            )
+        ]
+
+    def test_complete_trace_passes(self) -> None:
+        result = mod.validate_trace(self.complete_trace())
+        self.assertTrue(result["complete"])
+        self.assertEqual(result["state"], "TRACE_COMPLETE")
+
+    def test_missing_event_is_incomplete_not_silently_passed(self) -> None:
+        rows = [row for row in self.complete_trace() if row["event_type"] != "DA_FINDING"]
+        for i, row in enumerate(rows, 1):
+            row["seq"] = i
+            row["monotonic_ns"] = i * 100
+        result = mod.validate_trace(rows)
+        self.assertFalse(result["complete"])
+        self.assertIn("DA_FINDING", result["missing_event_types"])
+
+    def test_sequence_gap_fails_closed(self) -> None:
+        rows = self.complete_trace()
+        rows[5]["seq"] = 999
+        with self.assertRaises(mod.TraceContractError):
+            mod.validate_trace(rows)
+
+    def test_monotonic_regression_fails_closed(self) -> None:
+        rows = self.complete_trace()
+        rows[5]["monotonic_ns"] = 0
+        with self.assertRaises(mod.TraceContractError):
+            mod.validate_trace(rows)
+
+    def test_cross_task_trace_fails_closed(self) -> None:
+        rows = self.complete_trace()
+        rows[4]["task_id"] = "TASK-OTHER"
+        with self.assertRaises(mod.TraceContractError):
+            mod.validate_trace(rows)
+
+    def test_observer_overhead_can_be_negative_if_noise_wins(self) -> None:
+        self.assertEqual(
+            mod.observer_overhead_pct(
+                baseline_wall_ns=100,
+                observed_wall_ns=90,
+            ),
+            -10.0,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/trace_contract.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/trace_contract.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+TRACE_SCHEMA = "ultimate-loop-reconstruction-furnace/trace-v1"
+REQUIRED_EVENT_TYPES = frozenset(
+    {
+        "TASK_START",
+        "REPO_DISCOVERY_START",
+        "REPO_DISCOVERY_END",
+        "REPO_MODEL_REVISION",
+        "FIRST_ACTIONABLE_HYPOTHESIS",
+        "HYPOTHESIS_EVIDENCE",
+        "DA_FINDING",
+        "COUNTER_DA_FINDING",
+        "PATCH_ATTEMPT",
+        "TEST_RESULT",
+        "FAILURE_SIGNATURE",
+        "HYPOTHESIS_REOPEN",
+        "MODEL_REVISION",
+        "ROOT_CAUSE_CLASSIFICATION",
+        "INVARIANT_CANDIDATE",
+        "INVARIANT_DECISION",
+        "METHOD_MEMORY_REUSE",
+        "FALSE_TRANSFER",
+        "HUMAN_TOUCH",
+        "TOOL_INVOCATION",
+        "OBSERVER_OVERHEAD",
+        "TASK_END",
+    }
+)
+
+
+class TraceContractError(ValueError):
+    pass
+
+
+def _exact(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise TraceContractError(f"{field} must be a non-empty exact string")
+    return value
+
+
+@dataclass(frozen=True)
+class TraceEvent:
+    schema_version: str
+    run_id: str
+    task_id: str
+    seq: int
+    monotonic_ns: int
+    event_type: str
+    attempt_id: str
+    payload: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "run_id": self.run_id,
+            "task_id": self.task_id,
+            "seq": self.seq,
+            "monotonic_ns": self.monotonic_ns,
+            "event_type": self.event_type,
+            "attempt_id": self.attempt_id,
+            "payload": dict(self.payload),
+        }
+
+
+def event_fingerprint(event: Mapping[str, Any]) -> str:
+    encoded = json.dumps(
+        dict(event), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_event(event: Mapping[str, Any]) -> None:
+    expected = {
+        "schema_version",
+        "run_id",
+        "task_id",
+        "seq",
+        "monotonic_ns",
+        "event_type",
+        "attempt_id",
+        "payload",
+    }
+    if not isinstance(event, Mapping) or set(event) != expected:
+        raise TraceContractError("trace event shape drift")
+    if event["schema_version"] != TRACE_SCHEMA:
+        raise TraceContractError("trace schema mismatch")
+    for field in ("run_id", "task_id", "event_type", "attempt_id"):
+        _exact(event[field], field)
+    if not isinstance(event["seq"], int) or event["seq"] < 1:
+        raise TraceContractError("seq must be >= 1")
+    if not isinstance(event["monotonic_ns"], int) or event["monotonic_ns"] < 0:
+        raise TraceContractError("monotonic_ns must be >= 0")
+    if not isinstance(event["payload"], Mapping):
+        raise TraceContractError("payload mapping required")
+
+
+def validate_trace(events: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
+    rows = list(events)
+    if not rows:
+        raise TraceContractError("trace cannot be empty")
+
+    run_id = None
+    task_id = None
+    prior_seq = 0
+    prior_ns = -1
+    seen_types: set[str] = set()
+    duplicate_fingerprints: list[str] = []
+
+    seen_fingerprints: set[str] = set()
+    for event in rows:
+        validate_event(event)
+        if run_id is None:
+            run_id = event["run_id"]
+            task_id = event["task_id"]
+        elif event["run_id"] != run_id or event["task_id"] != task_id:
+            raise TraceContractError("trace crossed run/task boundary")
+        if event["seq"] != prior_seq + 1:
+            raise TraceContractError("trace sequence gap or reorder")
+        if event["monotonic_ns"] < prior_ns:
+            raise TraceContractError("monotonic timestamp regressed")
+        prior_seq = event["seq"]
+        prior_ns = event["monotonic_ns"]
+        seen_types.add(event["event_type"])
+
+        fp = event_fingerprint(event)
+        if fp in seen_fingerprints:
+            duplicate_fingerprints.append(fp)
+        seen_fingerprints.add(fp)
+
+    missing = sorted(REQUIRED_EVENT_TYPES - seen_types)
+    start_ok = rows[0]["event_type"] == "TASK_START"
+    end_ok = rows[-1]["event_type"] == "TASK_END"
+    complete = not missing and start_ok and end_ok
+
+    return {
+        "state": "TRACE_COMPLETE" if complete else "TRACE_INCOMPLETE",
+        "complete": complete,
+        "missing_event_types": missing,
+        "task_start_first": start_ok,
+        "task_end_last": end_ok,
+        "event_count": len(rows),
+        "duplicate_event_fingerprints": duplicate_fingerprints,
+    }
+
+
+def observer_overhead_pct(*, baseline_wall_ns: int, observed_wall_ns: int) -> float:
+    if baseline_wall_ns <= 0 or observed_wall_ns < 0:
+        raise TraceContractError("wall times invalid")
+    return ((observed_wall_ns - baseline_wall_ns) / baseline_wall_ns) * 100.0

--- a/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/trace_contract.py
+++ b/experiments/ULTIMATE_LOOP_RECONSTRUCTION_FURNACE_20260818/trace_contract.py
@@ -1,38 +1,75 @@
 from __future__ import annotations
 
-import hashlib
 import json
-from dataclasses import dataclass
+import threading
+import time
+from collections import Counter
+from pathlib import Path
 from typing import Any, Iterable, Mapping
 
+TRACE_SCHEMA = "ultimate-loop-reconstruction-furnace/trace-v2"
 
-TRACE_SCHEMA = "ultimate-loop-reconstruction-furnace/trace-v1"
-REQUIRED_EVENT_TYPES = frozenset(
-    {
-        "TASK_START",
-        "REPO_DISCOVERY_START",
-        "REPO_DISCOVERY_END",
-        "REPO_MODEL_REVISION",
-        "FIRST_ACTIONABLE_HYPOTHESIS",
-        "HYPOTHESIS_EVIDENCE",
-        "DA_FINDING",
-        "COUNTER_DA_FINDING",
-        "PATCH_ATTEMPT",
-        "TEST_RESULT",
-        "FAILURE_SIGNATURE",
-        "HYPOTHESIS_REOPEN",
-        "MODEL_REVISION",
-        "ROOT_CAUSE_CLASSIFICATION",
-        "INVARIANT_CANDIDATE",
-        "INVARIANT_DECISION",
-        "METHOD_MEMORY_REUSE",
-        "FALSE_TRANSFER",
-        "HUMAN_TOUCH",
-        "TOOL_INVOCATION",
-        "OBSERVER_OVERHEAD",
-        "TASK_END",
-    }
+BASE_REQUIRED_EVENT_TYPES = (
+    "TASK_START",
+    "REPO_DISCOVERY_START",
+    "REPO_DISCOVERY_END",
+    "REPO_MODEL_REVISION",
+    "FIRST_ACTIONABLE_HYPOTHESIS",
+    "HYPOTHESIS_EVIDENCE",
+    "DA_FINDING",
+    "COUNTER_DA_FINDING",
+    "OBSERVER_OVERHEAD",
+    "TASK_END",
 )
+
+COUNTED_EVENT_TYPES = {
+    "patch_attempts": "PATCH_ATTEMPT",
+    "tests": "TEST_RESULT",
+    "failure_signatures": "FAILURE_SIGNATURE",
+    "hypothesis_reopens": "HYPOTHESIS_REOPEN",
+    "model_revisions": "MODEL_REVISION",
+    "root_cause_classifications": "ROOT_CAUSE_CLASSIFICATION",
+    "invariant_candidates": "INVARIANT_CANDIDATE",
+    "invariant_decisions": "INVARIANT_DECISION",
+    "method_memory_reuse": "METHOD_MEMORY_REUSE",
+    "false_transfer": "FALSE_TRANSFER",
+    "human_touches": "HUMAN_TOUCH",
+    "tool_invocations": "TOOL_INVOCATION",
+}
+
+KNOWN_EVENT_TYPES = frozenset(BASE_REQUIRED_EVENT_TYPES) | frozenset(COUNTED_EVENT_TYPES.values())
+
+PAYLOAD_REQUIRED_KEYS = {
+    "TASK_START": {"subject"},
+    "REPO_DISCOVERY_START": {"scope"},
+    "REPO_DISCOVERY_END": {"evidence_refs"},
+    "REPO_MODEL_REVISION": {"revision_id", "evidence_refs"},
+    "FIRST_ACTIONABLE_HYPOTHESIS": {"hypothesis_id", "statement", "evidence_refs"},
+    "HYPOTHESIS_EVIDENCE": {"hypothesis_id", "direction", "evidence_refs"},
+    "DA_FINDING": {"finding_id", "target_id", "statement"},
+    "COUNTER_DA_FINDING": {"finding_id", "target_id", "statement"},
+    "PATCH_ATTEMPT": {"patch_id", "patch_sha256"},
+    "TEST_RESULT": {"test_id", "classification", "evidence_refs"},
+    "FAILURE_SIGNATURE": {"signature", "evidence_refs"},
+    "HYPOTHESIS_REOPEN": {"hypothesis_id", "reason"},
+    "MODEL_REVISION": {"revision_id", "reason"},
+    "ROOT_CAUSE_CLASSIFICATION": {"candidate_id", "classification", "evidence_refs"},
+    "INVARIANT_CANDIDATE": {"invariant_id", "statement"},
+    "INVARIANT_DECISION": {"invariant_id", "decision"},
+    "METHOD_MEMORY_REUSE": {"memory_id", "source_task_ids"},
+    "FALSE_TRANSFER": {"memory_id", "impact"},
+    "HUMAN_TOUCH": {"action"},
+    "TOOL_INVOCATION": {"tool_class"},
+    "OBSERVER_OVERHEAD": {"wall_ns", "cpu_ns", "bytes_written"},
+    "TASK_END": {"result", "event_counts"},
+}
+
+TASK_RESULTS = frozenset({"PASS", "FAIL", "INVALID", "STOPPED"})
+FORBIDDEN_TRACE_KEYS = frozenset({
+    "patch", "test_patch", "hints_text", "all_hints_text", "pull_number",
+    "issue_numbers", "commit_url", "commit_urls", "FAIL_TO_PASS",
+    "PASS_TO_PASS", "log_parser",
+})
 
 
 class TraceContractError(ValueError):
@@ -45,47 +82,69 @@ def _exact(value: Any, field: str) -> str:
     return value
 
 
-@dataclass(frozen=True)
-class TraceEvent:
-    schema_version: str
-    run_id: str
-    task_id: str
-    seq: int
-    monotonic_ns: int
-    event_type: str
-    attempt_id: str
-    payload: Mapping[str, Any]
-
-    def to_dict(self) -> dict[str, Any]:
-        return {
-            "schema_version": self.schema_version,
-            "run_id": self.run_id,
-            "task_id": self.task_id,
-            "seq": self.seq,
-            "monotonic_ns": self.monotonic_ns,
-            "event_type": self.event_type,
-            "attempt_id": self.attempt_id,
-            "payload": dict(self.payload),
-        }
+def _string_list(value: Any, field: str) -> list[str]:
+    if not isinstance(value, list):
+        raise TraceContractError(f"{field} must be a list")
+    return [_exact(item, field) for item in value]
 
 
-def event_fingerprint(event: Mapping[str, Any]) -> str:
-    encoded = json.dumps(
-        dict(event), sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    ).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+def _forbidden_key_scan(value: Any) -> list[str]:
+    found: set[str] = set()
+
+    def visit(node: Any) -> None:
+        if isinstance(node, Mapping):
+            for key, child in node.items():
+                if isinstance(key, str) and key in FORBIDDEN_TRACE_KEYS:
+                    found.add(key)
+                visit(child)
+        elif isinstance(node, (list, tuple)):
+            for child in node:
+                visit(child)
+
+    visit(value)
+    return sorted(found)
+
+
+def _validate_payload(event_type: str, payload: Mapping[str, Any]) -> None:
+    leaked = _forbidden_key_scan(payload)
+    if leaked:
+        raise TraceContractError(f"forbidden benchmark fields leaked into trace: {leaked}")
+    missing = PAYLOAD_REQUIRED_KEYS[event_type] - set(payload)
+    if missing:
+        raise TraceContractError(f"{event_type} payload missing keys: {sorted(missing)}")
+    try:
+        json.dumps(dict(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    except (TypeError, ValueError) as exc:
+        raise TraceContractError("payload must be canonical-JSON serializable") from exc
+
+    if "evidence_refs" in payload:
+        refs = _string_list(payload["evidence_refs"], "evidence_refs")
+        if event_type != "REPO_DISCOVERY_END" and not refs:
+            raise TraceContractError(f"{event_type} requires evidence_refs")
+    if event_type == "HYPOTHESIS_EVIDENCE" and payload["direction"] not in {"SUPPORT", "REFUTE", "MIXED"}:
+        raise TraceContractError("HYPOTHESIS_EVIDENCE direction invalid")
+    if event_type == "PATCH_ATTEMPT":
+        digest = payload["patch_sha256"]
+        if not isinstance(digest, str) or len(digest) != 64 or any(ch not in "0123456789abcdef" for ch in digest.lower()):
+            raise TraceContractError("PATCH_ATTEMPT patch_sha256 invalid")
+    if event_type == "TEST_RESULT" and payload["classification"] not in {"PASS", "FAIL", "BLOCKED", "ERROR"}:
+        raise TraceContractError("TEST_RESULT classification invalid")
+    if event_type == "INVARIANT_DECISION" and payload["decision"] not in {"PROMOTE", "REJECT", "DEFER"}:
+        raise TraceContractError("INVARIANT_DECISION decision invalid")
+    if event_type == "TASK_END":
+        if payload["result"] not in TASK_RESULTS:
+            raise TraceContractError("TASK_END result invalid")
+        counts = payload["event_counts"]
+        if not isinstance(counts, Mapping) or set(counts) != set(COUNTED_EVENT_TYPES):
+            raise TraceContractError("TASK_END event_counts shape drift")
+        if any(not isinstance(v, int) or isinstance(v, bool) or v < 0 for v in counts.values()):
+            raise TraceContractError("TASK_END event_counts must be non-negative integers")
 
 
 def validate_event(event: Mapping[str, Any]) -> None:
     expected = {
-        "schema_version",
-        "run_id",
-        "task_id",
-        "seq",
-        "monotonic_ns",
-        "event_type",
-        "attempt_id",
-        "payload",
+        "schema_version", "run_id", "task_id", "seq", "monotonic_ns",
+        "event_type", "attempt_id", "payload",
     }
     if not isinstance(event, Mapping) or set(event) != expected:
         raise TraceContractError("trace event shape drift")
@@ -93,12 +152,22 @@ def validate_event(event: Mapping[str, Any]) -> None:
         raise TraceContractError("trace schema mismatch")
     for field in ("run_id", "task_id", "event_type", "attempt_id"):
         _exact(event[field], field)
-    if not isinstance(event["seq"], int) or event["seq"] < 1:
+    if event["event_type"] not in KNOWN_EVENT_TYPES:
+        raise TraceContractError("unknown event_type")
+    if not isinstance(event["seq"], int) or isinstance(event["seq"], bool) or event["seq"] < 1:
         raise TraceContractError("seq must be >= 1")
-    if not isinstance(event["monotonic_ns"], int) or event["monotonic_ns"] < 0:
+    if not isinstance(event["monotonic_ns"], int) or isinstance(event["monotonic_ns"], bool) or event["monotonic_ns"] < 0:
         raise TraceContractError("monotonic_ns must be >= 0")
     if not isinstance(event["payload"], Mapping):
         raise TraceContractError("payload mapping required")
+    _validate_payload(event["event_type"], event["payload"])
+
+
+def _first_index(rows: list[Mapping[str, Any]], event_type: str) -> int | None:
+    for idx, row in enumerate(rows):
+        if row["event_type"] == event_type:
+            return idx
+    return None
 
 
 def validate_trace(events: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
@@ -110,10 +179,8 @@ def validate_trace(events: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
     task_id = None
     prior_seq = 0
     prior_ns = -1
-    seen_types: set[str] = set()
-    duplicate_fingerprints: list[str] = []
+    type_counts: Counter[str] = Counter()
 
-    seen_fingerprints: set[str] = set()
     for event in rows:
         validate_event(event)
         if run_id is None:
@@ -127,18 +194,48 @@ def validate_trace(events: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
             raise TraceContractError("monotonic timestamp regressed")
         prior_seq = event["seq"]
         prior_ns = event["monotonic_ns"]
-        seen_types.add(event["event_type"])
+        type_counts[event["event_type"]] += 1
 
-        fp = event_fingerprint(event)
-        if fp in seen_fingerprints:
-            duplicate_fingerprints.append(fp)
-        seen_fingerprints.add(fp)
+    missing = [typ for typ in BASE_REQUIRED_EVENT_TYPES if type_counts[typ] == 0]
+    start_ok = rows[0]["event_type"] == "TASK_START" and type_counts["TASK_START"] == 1
+    end_ok = rows[-1]["event_type"] == "TASK_END" and type_counts["TASK_END"] == 1
 
-    missing = sorted(REQUIRED_EVENT_TYPES - seen_types)
-    start_ok = rows[0]["event_type"] == "TASK_START"
-    end_ok = rows[-1]["event_type"] == "TASK_END"
-    complete = not missing and start_ok and end_ok
+    order_errors: list[str] = []
+    chain = [
+        "TASK_START", "REPO_DISCOVERY_START", "REPO_DISCOVERY_END",
+        "REPO_MODEL_REVISION", "FIRST_ACTIONABLE_HYPOTHESIS",
+        "HYPOTHESIS_EVIDENCE", "DA_FINDING", "COUNTER_DA_FINDING",
+    ]
+    present_chain = [(typ, _first_index(rows, typ)) for typ in chain]
+    for (left, li), (right, ri) in zip(present_chain, present_chain[1:]):
+        if li is not None and ri is not None and li >= ri:
+            order_errors.append(f"{left}_NOT_BEFORE_{right}")
+    patch_idx = _first_index(rows, "PATCH_ATTEMPT")
+    cda_idx = _first_index(rows, "COUNTER_DA_FINDING")
+    if patch_idx is not None and cda_idx is not None and patch_idx <= cda_idx:
+        order_errors.append("PATCH_BEFORE_COUNTER_DA")
+    test_idx = _first_index(rows, "TEST_RESULT")
+    if test_idx is not None and patch_idx is None:
+        order_errors.append("TEST_WITHOUT_PATCH")
+    elif test_idx is not None and patch_idx is not None and test_idx <= patch_idx:
+        order_errors.append("TEST_BEFORE_PATCH")
 
+    prior_patches_by_attempt: set[str] = set()
+    for row in rows:
+        if row["event_type"] == "PATCH_ATTEMPT":
+            prior_patches_by_attempt.add(row["attempt_id"])
+        elif row["event_type"] == "TEST_RESULT" and row["attempt_id"] not in prior_patches_by_attempt:
+            order_errors.append(f"TEST_WITHOUT_PRIOR_PATCH_FOR_ATTEMPT:{row['attempt_id']}")
+
+    declared = rows[-1]["payload"]["event_counts"] if end_ok else None
+    count_mismatches: list[str] = []
+    if declared is not None:
+        for metric, event_type in COUNTED_EVENT_TYPES.items():
+            actual = type_counts[event_type]
+            if declared[metric] != actual:
+                count_mismatches.append(f"{metric}:declared={declared[metric]} actual={actual}")
+
+    complete = not missing and start_ok and end_ok and not order_errors and not count_mismatches
     return {
         "state": "TRACE_COMPLETE" if complete else "TRACE_INCOMPLETE",
         "complete": complete,
@@ -146,11 +243,82 @@ def validate_trace(events: Iterable[Mapping[str, Any]]) -> dict[str, Any]:
         "task_start_first": start_ok,
         "task_end_last": end_ok,
         "event_count": len(rows),
-        "duplicate_event_fingerprints": duplicate_fingerprints,
+        "event_type_counts": dict(sorted(type_counts.items())),
+        "count_mismatches": count_mismatches,
+        "order_errors": order_errors,
     }
 
 
 def observer_overhead_pct(*, baseline_wall_ns: int, observed_wall_ns: int) -> float:
     if baseline_wall_ns <= 0 or observed_wall_ns < 0:
         raise TraceContractError("wall times invalid")
-    return ((observed_wall_ns - baseline_wall_ns) / baseline_wall_ns) * 100.0
+    raw = ((observed_wall_ns - baseline_wall_ns) / baseline_wall_ns) * 100.0
+    return max(0.0, raw)
+
+
+class TraceRecorder:
+    """Thread-safe Stage 0 recorder used to test loss/reorder under burst load."""
+
+    def __init__(self, *, run_id: str, task_id: str, sink: str | Path | None = None) -> None:
+        self.run_id = _exact(run_id, "run_id")
+        self.task_id = _exact(task_id, "task_id")
+        self._lock = threading.Lock()
+        self._seq = 0
+        self._events: list[dict[str, Any]] = []
+        self._bytes_written = 0
+        self._write_wall_ns = 0
+        self._sink = Path(sink) if sink is not None else None
+        if self._sink is not None:
+            self._sink.parent.mkdir(parents=True, exist_ok=True)
+            self._sink.write_text("", encoding="utf-8")
+
+    def emit(self, event_type: str, *, attempt_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+        started = time.perf_counter_ns()
+        with self._lock:
+            self._seq += 1
+            frozen_payload = json.loads(json.dumps(dict(payload), sort_keys=True, ensure_ascii=False))
+            row = {
+                "schema_version": TRACE_SCHEMA,
+                "run_id": self.run_id,
+                "task_id": self.task_id,
+                "seq": self._seq,
+                "monotonic_ns": time.monotonic_ns(),
+                "event_type": event_type,
+                "attempt_id": attempt_id,
+                "payload": frozen_payload,
+            }
+            validate_event(row)
+            self._events.append(row)
+            if self._sink is not None:
+                encoded = json.dumps(row, sort_keys=True, separators=(",", ":"), ensure_ascii=False) + "\n"
+                with self._sink.open("a", encoding="utf-8") as handle:
+                    handle.write(encoded)
+                    handle.flush()
+                self._bytes_written += len(encoded.encode("utf-8"))
+            self._write_wall_ns += time.perf_counter_ns() - started
+        return json.loads(json.dumps(row, sort_keys=True, ensure_ascii=False))
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return json.loads(json.dumps(self._events, sort_keys=True, ensure_ascii=False))
+
+    def stats(self) -> dict[str, int]:
+        with self._lock:
+            return {
+                "events_emitted": self._seq,
+                "events_captured": len(self._events),
+                "bytes_written": self._bytes_written,
+                "write_wall_ns": self._write_wall_ns,
+            }
+
+
+def load_jsonl(path: str | Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        value = json.loads(line)
+        if not isinstance(value, dict):
+            raise TraceContractError("JSONL trace row must be object")
+        rows.append(value)
+    return rows


### PR DESCRIPTION
## Purpose

Prepare the first blind external-generalization run from #353 without allowing benchmark gold material to enter Ultimate Loop / TRACE context.

## Preflight death retained

The ordinary SWE-bench-Live/MultiLang dataset viewer exposes solver-allowed fields adjacent to gold `patch`, `test_patch`, hints, fixing commit URLs, and hidden evaluation material. Direct solver browsing would contaminate the run before reasoning begins.

This PR therefore adds only experiment-local blindness glue:

- strict allowlist task-envelope serialization;
- out-of-band validator provenance fingerprints;
- exact 3-run gold-validity requirement;
- fail-closed solver-envelope schema;
- recursive forbidden-key scan for solver/TRACE namespaces;
- regression cases for raw gold, hints, hidden tests, schema drift, invalid tasks, and trace leakage;
- documented offline-after-prepare boundary.

## Important boundary

This is **not** the benchmark runner, not a crawler, not a model runtime, and not canonical Ultimate Loop authority.

No benchmark task is claimed solved by this PR.

The first attempted manual task selection was intentionally aborted once the viewer contamination surface became evident. A contaminated PASS is worse than a clean failure.

## Next experiment gate

Stage 0 may begin only after an external validator/sampler can:

1. pin the dataset revision;
2. sample outside solver context;
3. run the gold path 3/3;
4. emit only the sanitized envelope;
5. prove forbidden fields never enter solver/TRACE context.

Then the first two unseen telemetry-torture tasks can be admitted.

## Core invariants

`SOLVER DIRECT DATASET ACCESS -> EXPERIMENT INVALID`

`COLUMN IGNORED AFTER RETRIEVAL != COLUMN NEVER ENTERED CONTEXT`

`BROKEN EXPERIMENT HARNESS != SOLVER FAILURE`

`FAILURE WITH CLEAN TRACE > CONTAMINATED PASS`

Refs #353.