### PR TITLE
Prototype optional Rework Learning adaptive assist

### DIFF
--- a/.github/workflows/rework-learning-meteor.yml
+++ b/.github/workflows/rework-learning-meteor.yml
@@ -1,0 +1,24 @@
+name: Rework Learning Meteor
+
+on:
+  pull_request:
+    paths:
+      - 'thin-rts/ultimate-loop/rework_learning.py'
+      - 'thin-rts/ultimate-loop/test_rework_learning.py'
+      - 'thin-rts/ultimate-loop/REWORK_LEARNING_DA_COUNTER_DA_2026-08-21.md'
+      - '.github/workflows/rework-learning-meteor.yml'
+  workflow_dispatch:
+
+jobs:
+  meteor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Compile prototype
+        run: python -m py_compile thin-rts/ultimate-loop/rework_learning.py thin-rts/ultimate-loop/test_rework_learning.py
+      - name: Run frozen METEOR regression workload
+        working-directory: thin-rts/ultimate-loop
+        run: python -m unittest -v test_rework_learning.py

--- a/thin-rts/ultimate-loop/REWORK_LEARNING_DA_COUNTER_DA_2026-08-21.md
+++ b/thin-rts/ultimate-loop/REWORK_LEARNING_DA_COUNTER_DA_2026-08-21.md
@@ -1,0 +1,122 @@
+# Ultimate Loop Optional Rework Learning — DA / Counter-DA / METEOR Pilot
+
+Timestamp: 2026-08-21 JST
+Status: `PROTOTYPE / OPTIONAL / NO_PROMOTION_AUTHORITY`
+Tracking: RTS issue #362
+
+## Frozen subject
+
+Add a bounded optional capability that learns where development work repeatedly backtracks, activates assist only for the current difficult zone, and returns to observation after the zone clears.
+
+This is not a universal core responsibility. It must survive as an optional workload/candidate under the existing Ultimate Loop freeze rule.
+
+## Raison d'etre boundary
+
+The capability may consume existing Git/GitHub/trace/operation evidence. It must not create a new daemon or authoritative database merely to duplicate evidence already held elsewhere.
+
+The smallest surviving responsibility is:
+
+1. normalize bounded rework events;
+2. detect current difficult-zone signals without requiring history;
+3. optionally use historical clusters as supporting evidence;
+4. recommend bounded assist actions;
+5. preserve candidate derived knowledge, not copy all raw evidence;
+6. clear assist after demonstrated local success.
+
+## DA — kill the proposal
+
+### DA-01: user surveillance disguised as optimization
+Kill condition: the mechanism needs broad personal profiling or attributes unrelated to the active task.
+
+Response: task_scope/source/operation and bounded friction markers are sufficient. A difficult zone is a temporary task/environment state, not a human trait.
+
+### DA-02: one failure becomes a permanent weakness
+Kill condition: one MULTI_TAB or paste failure creates durable assist or a universal rule.
+
+Response: activation requires a combined signal threshold and current rework evidence. Historical evidence alone cannot force activation.
+
+### DA-03: history dependency makes first use useless
+Kill condition: assist cannot fire until a large history exists.
+
+Response: realtime repetition, backtrack, and friction signals can activate without historical evidence.
+
+### DA-04: assist causes more friction than it removes
+Kill condition: assist remains globally enabled or follows the user into unrelated work.
+
+Response: assist is scoped to the difficult zone and moves through ASSIST_ACTIVE → CLEARING → OBSERVE.
+
+### DA-05: commit count is misread as incompetence
+Kill condition: high commit volume alone is treated as a difficult zone.
+
+Response: commit/trace history is supporting evidence only. Diagnosis must bind repeated responsibility, backtrack, failure recurrence, observation cost, or similar signals.
+
+### DA-06: new storage platform becomes the real product
+Kill condition: implementation requires a new database, crawler, service, or daemon before the pilot can operate.
+
+Response: reject. Existing evidence remains authoritative where available; the prototype accepts bounded event/history inputs.
+
+## Counter-DA — kill the defenses
+
+### C-DA-01: requiring many signals misses obvious live failure
+A current run may have no history but can still show three consecutive paste/tab/retry failures. Therefore history cannot be mandatory.
+
+### C-DA-02: aggressive thresholds can become paternalistic
+A fixed universal threshold is not justified yet. The pilot exposes policy values and freezes only a small default for testing.
+
+### C-DA-03: automatic ENFORCE is premature
+The prototype only computes assist state/actions. It grants no shell/UI execution authority and no promotion authority.
+
+### C-DA-04: clearing too early can oscillate
+One success is not enough. A bounded success tail is required before CLEARING/OBSERVE.
+
+### C-DA-05: historical evidence can become stale
+Old evidence may increase confidence only when scope keys match current work; current successful evidence must prevent old history from forcing assist.
+
+## Prototype contract
+
+Input event fields are bounded to task/operation evidence:
+
+- event_id
+- occurred_at
+- task_scope
+- source
+- operation
+- outcome
+- rework_class
+- from_step / to_step
+- markers
+- evidence_refs
+
+Output includes:
+
+- current/next mode
+- difficult_zone
+- signal score/components
+- bounded assist actions
+- derived knowledge candidates
+- evidence-use statement
+
+No user identity model is required.
+
+## METEOR attacks frozen before implementation review
+
+The regression workload must include at least:
+
+1. realtime activation with zero history;
+2. unrelated historical clusters do not activate assist;
+3. ASSIST_ACTIVE enters CLEARING after a success tail;
+4. CLEARING returns to OBSERVE when the zone stays clear;
+5. massive old negative history cannot override current successful evidence;
+6. one isolated multi-tab event does not become a universal rule.
+
+## Pre-merge re-gate
+
+Before promotion, rerun DA and Counter-DA against implementation evidence and CI. Merge is allowed only if:
+
+- the prototype remains optional and scoped;
+- no new permanent storage/service responsibility was smuggled in;
+- realtime operation does not require history;
+- historical evidence cannot force assist against current success;
+- assist can clear;
+- the frozen METEOR workload passes;
+- no merge/deploy authority is inferred from the evaluator.

--- a/thin-rts/ultimate-loop/REWORK_LEARNING_IMPLEMENTATION_REGATE_2026-08-21.md
+++ b/thin-rts/ultimate-loop/REWORK_LEARNING_IMPLEMENTATION_REGATE_2026-08-21.md
@@ -1,0 +1,107 @@
+# Ultimate Loop Optional Rework Learning — Implementation Re-Gate
+
+Timestamp: 2026-08-21 JST
+Status: `SURVIVES CURRENT PROTOTYPE GATE / OPTIONAL ONLY / PROMOTION AUTHORITY SEPARATE`
+PR: #363
+Issue: #362
+
+## Sequence actually run
+
+`FROZEN SUBJECT → DA → COUNTER-DA → BOUNDED PROTOTYPE → METEOR → IMPLEMENTATION REVIEW → DA/COUNTER-DA REPLAY → MERGE CANDIDATE`
+
+## Prototype finding before final re-gate
+
+The first prototype incorrectly aggregated weak friction signals across every recent scope. Three unrelated one-off signals in three unrelated tasks could therefore combine into one global difficult-zone score and activate assist.
+
+That violated the frozen requirement that assist be limited to the current difficult zone.
+
+The implementation was changed before promotion:
+
+- scoring now occurs per `(task_scope, source, operation)` scope;
+- unrelated scopes cannot pool signals;
+- `active_scope` is explicit in ASSIST_ACTIVE/CLEARING;
+- success-tail clearing is evaluated inside that active scope;
+- missing scope identity fails closed;
+- historical evidence only contributes to an exactly matching scope.
+
+The exact cross-scope contamination case is now a METEOR regression test.
+
+## DA replay against implementation
+
+### DA-01 surveillance/profile creep
+
+Survives under current evidence. The evaluator accepts task/operation events and evidence refs; it requires no user identity or personal trait model.
+
+### DA-02 one failure becomes permanent weakness
+
+Survives. A single isolated MULTI_TAB event stays OBSERVE in the frozen regression workload.
+
+### DA-03 first-use history dependency
+
+Survives. Realtime friction/repetition/backtrack evidence can activate ASSIST_ACTIVE with empty history.
+
+### DA-04 assist spreads globally
+
+First implementation: `DIED` due to cross-scope signal pooling.
+
+Current implementation: repaired. Signals, assist actions and clearing are bound to `active_scope`; unrelated weak scopes do not combine.
+
+### DA-05 commit count becomes incompetence proxy
+
+Survives the prototype boundary. No commit-count input has automatic authority; history is represented only as explicitly derived matching clusters and raises confidence by bounded policy weight.
+
+### DA-06 storage/platform expansion
+
+Survives. Prototype is a pure evaluator + tests + CI gate; no database, daemon, crawler, or always-on service was added.
+
+## Counter-DA replay
+
+### C-DA-01 too conservative to help on first run
+
+Rejected. The zero-history realtime activation case passes.
+
+### C-DA-02 fixed universal thresholds overfit one operator
+
+Still valid as a limitation. Thresholds remain policy inputs and the current defaults are pilot defaults, not canonical universal constants.
+
+### C-DA-03 evaluator quietly gains execution authority
+
+Rejected under current implementation. Output is recommendation/state only; no shell/UI action executor exists.
+
+### C-DA-04 clearing oscillates after one success
+
+Rejected. The default requires a bounded two-success tail and preserves CLEARING as a separate state.
+
+### C-DA-05 stale history overrides current success
+
+Rejected by regression: even very large matching historical rework cannot force assist when current events are successful and contain no current rework event.
+
+## METEOR workload result
+
+GitHub Actions workflow `Rework Learning Meteor` passed on the repaired implementation head.
+
+Frozen attacks include:
+
+- realtime activation without history;
+- unrelated historical scope rejection;
+- assisted-scope clearing;
+- clearing back to observe;
+- stale/large old history cannot override current success;
+- one multi-tab event does not create a universal rule;
+- unrelated weak scopes cannot pool into a difficult zone;
+- missing scope identity fails closed.
+
+## Remaining bounded limitations
+
+- The pilot does not yet ingest Git/GitHub/trace automatically; it evaluates normalized evidence supplied to it.
+- Threshold calibration is not yet proven across operators/workloads.
+- Historical-cluster freshness/decay is not modeled beyond current-scope matching.
+- No claim is made that assist reduces rework until the next material pilot measures before/after outcomes.
+
+These are not hidden. They keep this candidate optional and prevent universal-core promotion.
+
+## Verdict
+
+`OPTIONAL PROTOTYPE SURVIVES CURRENT DA / COUNTER-DA / METEOR GATE`
+
+Merge is acceptable as an optional experimental capability if CI remains green. This verdict does not promote it into the canonical mandatory Ultimate Loop flow and grants no deployment/execution authority.

--- a/thin-rts/ultimate-loop/rework_learning.py
+++ b/thin-rts/ultimate-loop/rework_learning.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+VALID_CLASSES = {"IMPLEMENTATION", "HUMAN_OPERATION", "WORKFLOW"}
+VALID_MODES = {"OBSERVE", "ASSIST_ACTIVE", "CLEARING"}
+
+DEFAULT_POLICY = {
+    "recent_window_events": 8,
+    "assist_repetition_threshold": 3,
+    "assist_backtrack_threshold": 2,
+    "assist_signal_threshold": 3,
+    "clear_success_threshold": 2,
+    "historical_support_weight": 1,
+}
+
+
+@dataclass(frozen=True)
+class Event:
+    event_id: str
+    occurred_at: str
+    task_scope: str
+    source: str
+    operation: str
+    outcome: str
+    rework_class: str
+    from_step: str
+    to_step: str
+    markers: tuple[str, ...]
+    evidence_refs: tuple[str, ...]
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Event":
+        rework_class = str(data.get("rework_class", "WORKFLOW"))
+        if rework_class not in VALID_CLASSES:
+            raise ValueError(f"invalid rework_class: {rework_class}")
+        occurred_at = str(data.get("occurred_at", ""))
+        if not occurred_at:
+            raise ValueError("occurred_at is required")
+        _parse_time(occurred_at)
+        return cls(
+            event_id=str(data.get("event_id", "")),
+            occurred_at=occurred_at,
+            task_scope=str(data.get("task_scope", "")),
+            source=str(data.get("source", "")),
+            operation=str(data.get("operation", "")),
+            outcome=str(data.get("outcome", "UNKNOWN")),
+            rework_class=rework_class,
+            from_step=str(data.get("from_step", "")),
+            to_step=str(data.get("to_step", "")),
+            markers=tuple(str(x) for x in (data.get("markers") or [])),
+            evidence_refs=tuple(str(x) for x in (data.get("evidence_refs") or [])),
+        )
+
+
+def _parse_time(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        raise ValueError("timestamp must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _policy(case: dict[str, Any]) -> dict[str, int]:
+    policy = dict(DEFAULT_POLICY)
+    for key, value in (case.get("policy") or {}).items():
+        if key in policy:
+            policy[key] = int(value)
+    if policy["recent_window_events"] < 1:
+        raise ValueError("recent_window_events must be >= 1")
+    return policy
+
+
+def _scope_key(event: Event) -> tuple[str, str, str]:
+    return event.task_scope, event.source, event.operation
+
+
+def _signal_score(events: list[Event], history: dict[str, Any], policy: dict[str, int]) -> tuple[int, dict[str, int]]:
+    repetitions = Counter(_scope_key(event) for event in events)
+    backtracks = Counter((event.task_scope, event.from_step, event.to_step) for event in events if event.from_step and event.to_step and event.from_step != event.to_step)
+    marker_counts = Counter(marker for event in events for marker in event.markers)
+
+    repeated_scope_hits = sum(1 for count in repetitions.values() if count >= policy["assist_repetition_threshold"])
+    backtrack_hits = sum(1 for count in backtracks.values() if count >= policy["assist_backtrack_threshold"])
+    human_friction_hits = sum(
+        marker_counts.get(marker, 0)
+        for marker in (
+            "MULTI_TAB",
+            "PASTE_FAILURE",
+            "REPEATED_SCREENSHOT",
+            "REPEATED_STATE_DUMP",
+            "COMMAND_RETRY",
+        )
+    )
+
+    historical_hits = 0
+    historical_clusters = history.get("clusters") or []
+    active_keys = {"|".join(_scope_key(event)) for event in events}
+    for cluster in historical_clusters:
+        key = str(cluster.get("scope_key", ""))
+        if key in active_keys and int(cluster.get("rework_count", 0)) > 0:
+            historical_hits += policy["historical_support_weight"]
+
+    components = {
+        "repeated_scope_hits": repeated_scope_hits,
+        "backtrack_hits": backtrack_hits,
+        "human_friction_hits": human_friction_hits,
+        "historical_hits": historical_hits,
+    }
+    score = repeated_scope_hits + backtrack_hits + human_friction_hits + historical_hits
+    return score, components
+
+
+def _assist_actions(events: list[Event]) -> list[str]:
+    markers = {marker for event in events for marker in event.markers}
+    actions: list[str] = []
+    if "MULTI_TAB" in markers:
+        actions.append("CONVERGE_TO_SINGLE_TERMINAL")
+    if "PASTE_FAILURE" in markers or "COMMAND_RETRY" in markers:
+        actions.append("SPLIT_LONG_COMMANDS")
+    if "REPEATED_SCREENSHOT" in markers or "REPEATED_STATE_DUMP" in markers:
+        actions.append("PREFER_AGGREGATED_STATE_DUMP")
+    if any(event.rework_class == "IMPLEMENTATION" for event in events):
+        actions.append("REOPEN_SMALLEST_IMPLEMENTATION_GATE")
+    if any(event.rework_class == "WORKFLOW" for event in events):
+        actions.append("REVIEW_WORKFLOW_SEQUENCE")
+    if any(event.rework_class == "HUMAN_OPERATION" for event in events):
+        actions.append("ADD_BOUNDED_OPERATION_GUIDANCE")
+    return sorted(set(actions))
+
+
+def evaluate(case: dict[str, Any]) -> dict[str, Any]:
+    policy = _policy(case)
+    mode = str(case.get("mode", "OBSERVE"))
+    if mode not in VALID_MODES:
+        raise ValueError(f"invalid mode: {mode}")
+
+    events = [Event.from_dict(raw) for raw in (case.get("events") or [])]
+    events.sort(key=lambda event: _parse_time(event.occurred_at))
+    recent = events[-policy["recent_window_events"] :]
+    history = case.get("history") or {}
+
+    score, components = _signal_score(recent, history, policy)
+    rework_events = [event for event in recent if event.outcome in {"REWORK", "FAILED", "RETRY"}]
+    success_tail = 0
+    for event in reversed(recent):
+        if event.outcome == "SUCCESS":
+            success_tail += 1
+        else:
+            break
+
+    difficult_zone = score >= policy["assist_signal_threshold"] and bool(rework_events)
+    next_mode = mode
+    reasons: list[str] = []
+
+    if mode == "OBSERVE" and difficult_zone:
+        next_mode = "ASSIST_ACTIVE"
+        reasons.append("Current rework signals crossed the bounded assist threshold.")
+    elif mode == "ASSIST_ACTIVE":
+        if success_tail >= policy["clear_success_threshold"]:
+            next_mode = "CLEARING"
+            reasons.append("The assisted scope has a success tail; enter clearing before disabling assist.")
+        else:
+            reasons.append("Assist remains scoped to the active difficult zone.")
+    elif mode == "CLEARING":
+        if difficult_zone:
+            next_mode = "ASSIST_ACTIVE"
+            reasons.append("Rework recurred during clearing; restore bounded assist.")
+        elif success_tail >= policy["clear_success_threshold"]:
+            next_mode = "OBSERVE"
+            reasons.append("The difficult zone cleared without recurrent rework; return to observe.")
+
+    clusters: dict[tuple[str, str, str], list[Event]] = defaultdict(list)
+    for event in rework_events:
+        clusters[_scope_key(event)].append(event)
+
+    knowledge = [
+        {
+            "scope_key": "|".join(key),
+            "rework_count": len(items),
+            "classes": sorted({item.rework_class for item in items}),
+            "markers": sorted({marker for item in items for marker in item.markers}),
+            "evidence_refs": sorted({ref for item in items for ref in item.evidence_refs}),
+        }
+        for key, items in sorted(clusters.items())
+    ]
+
+    return {
+        "schema": "ultimate-loop-rework-learning-report/v0",
+        "mode": mode,
+        "next_mode": next_mode,
+        "difficult_zone": difficult_zone,
+        "signal_score": score,
+        "signal_components": components,
+        "assist_actions": _assist_actions(rework_events) if next_mode == "ASSIST_ACTIVE" else [],
+        "knowledge_candidates": knowledge,
+        "reasons": reasons,
+        "evidence_policy": {
+            "raw_event_count": len(events),
+            "recent_event_count": len(recent),
+            "historical_evidence_used": components["historical_hits"] > 0,
+            "note": "Historical evidence raises confidence but is not required for realtime assist activation.",
+        },
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Evaluate optional Ultimate Loop rework-learning assist state")
+    parser.add_argument("case", type=Path)
+    args = parser.parse_args()
+    case = json.loads(args.case.read_text(encoding="utf-8"))
+    print(json.dumps(evaluate(case), ensure_ascii=False, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/thin-rts/ultimate-loop/rework_learning.py
+++ b/thin-rts/ultimate-loop/rework_learning.py
@@ -10,6 +10,7 @@ from typing import Any
 
 VALID_CLASSES = {"IMPLEMENTATION", "HUMAN_OPERATION", "WORKFLOW"}
 VALID_MODES = {"OBSERVE", "ASSIST_ACTIVE", "CLEARING"}
+REWORK_OUTCOMES = {"REWORK", "FAILED", "RETRY"}
 
 DEFAULT_POLICY = {
     "recent_window_events": 8,
@@ -44,12 +45,19 @@ class Event:
         if not occurred_at:
             raise ValueError("occurred_at is required")
         _parse_time(occurred_at)
+
+        task_scope = str(data.get("task_scope", "")).strip()
+        source = str(data.get("source", "")).strip()
+        operation = str(data.get("operation", "")).strip()
+        if not task_scope or not source or not operation:
+            raise ValueError("task_scope, source, and operation are required to prevent cross-scope learning")
+
         return cls(
             event_id=str(data.get("event_id", "")),
             occurred_at=occurred_at,
-            task_scope=str(data.get("task_scope", "")),
-            source=str(data.get("source", "")),
-            operation=str(data.get("operation", "")),
+            task_scope=task_scope,
+            source=source,
+            operation=operation,
             outcome=str(data.get("outcome", "UNKNOWN")),
             rework_class=rework_class,
             from_step=str(data.get("from_step", "")),
@@ -73,6 +81,8 @@ def _policy(case: dict[str, Any]) -> dict[str, int]:
             policy[key] = int(value)
     if policy["recent_window_events"] < 1:
         raise ValueError("recent_window_events must be >= 1")
+    if policy["assist_signal_threshold"] < 1 or policy["clear_success_threshold"] < 1:
+        raise ValueError("assist and clearing thresholds must be >= 1")
     return policy
 
 
@@ -80,12 +90,40 @@ def _scope_key(event: Event) -> tuple[str, str, str]:
     return event.task_scope, event.source, event.operation
 
 
-def _signal_score(events: list[Event], history: dict[str, Any], policy: dict[str, int]) -> tuple[int, dict[str, int]]:
-    repetitions = Counter(_scope_key(event) for event in events)
-    backtracks = Counter((event.task_scope, event.from_step, event.to_step) for event in events if event.from_step and event.to_step and event.from_step != event.to_step)
+def _scope_text(key: tuple[str, str, str]) -> str:
+    return "|".join(key)
+
+
+def _history_hit(scope_key: tuple[str, str, str], history: dict[str, Any], policy: dict[str, int]) -> int:
+    wanted = _scope_text(scope_key)
+    for cluster in history.get("clusters") or []:
+        if str(cluster.get("scope_key", "")) == wanted and int(cluster.get("rework_count", 0)) > 0:
+            return policy["historical_support_weight"]
+    return 0
+
+
+def _scope_signal(events: list[Event], history: dict[str, Any], policy: dict[str, int]) -> tuple[int, dict[str, int]]:
+    if not events:
+        return 0, {
+            "repeated_scope_hits": 0,
+            "backtrack_hits": 0,
+            "human_friction_hits": 0,
+            "historical_hits": 0,
+        }
+
+    scope_key = _scope_key(events[0])
+    if any(_scope_key(event) != scope_key for event in events):
+        raise ValueError("_scope_signal accepts exactly one scope")
+
+    repetitions = len(events)
+    backtracks = Counter(
+        (event.from_step, event.to_step)
+        for event in events
+        if event.from_step and event.to_step and event.from_step != event.to_step
+    )
     marker_counts = Counter(marker for event in events for marker in event.markers)
 
-    repeated_scope_hits = sum(1 for count in repetitions.values() if count >= policy["assist_repetition_threshold"])
+    repeated_scope_hits = int(repetitions >= policy["assist_repetition_threshold"])
     backtrack_hits = sum(1 for count in backtracks.values() if count >= policy["assist_backtrack_threshold"])
     human_friction_hits = sum(
         marker_counts.get(marker, 0)
@@ -97,14 +135,7 @@ def _signal_score(events: list[Event], history: dict[str, Any], policy: dict[str
             "COMMAND_RETRY",
         )
     )
-
-    historical_hits = 0
-    historical_clusters = history.get("clusters") or []
-    active_keys = {"|".join(_scope_key(event)) for event in events}
-    for cluster in historical_clusters:
-        key = str(cluster.get("scope_key", ""))
-        if key in active_keys and int(cluster.get("rework_count", 0)) > 0:
-            historical_hits += policy["historical_support_weight"]
+    historical_hits = _history_hit(scope_key, history, policy)
 
     components = {
         "repeated_scope_hits": repeated_scope_hits,
@@ -112,8 +143,7 @@ def _signal_score(events: list[Event], history: dict[str, Any], policy: dict[str
         "human_friction_hits": human_friction_hits,
         "historical_hits": historical_hits,
     }
-    score = repeated_scope_hits + backtrack_hits + human_friction_hits + historical_hits
-    return score, components
+    return sum(components.values()), components
 
 
 def _assist_actions(events: list[Event]) -> list[str]:
@@ -134,6 +164,16 @@ def _assist_actions(events: list[Event]) -> list[str]:
     return sorted(set(actions))
 
 
+def _success_tail(events: list[Event]) -> int:
+    count = 0
+    for event in reversed(events):
+        if event.outcome == "SUCCESS":
+            count += 1
+        else:
+            break
+    return count
+
+
 def evaluate(case: dict[str, Any]) -> dict[str, Any]:
     policy = _policy(case)
     mode = str(case.get("mode", "OBSERVE"))
@@ -145,24 +185,57 @@ def evaluate(case: dict[str, Any]) -> dict[str, Any]:
     recent = events[-policy["recent_window_events"] :]
     history = case.get("history") or {}
 
-    score, components = _signal_score(recent, history, policy)
-    rework_events = [event for event in recent if event.outcome in {"REWORK", "FAILED", "RETRY"}]
-    success_tail = 0
-    for event in reversed(recent):
-        if event.outcome == "SUCCESS":
-            success_tail += 1
-        else:
-            break
+    by_scope: dict[tuple[str, str, str], list[Event]] = defaultdict(list)
+    for event in recent:
+        by_scope[_scope_key(event)].append(event)
 
-    difficult_zone = score >= policy["assist_signal_threshold"] and bool(rework_events)
+    scope_reports: dict[str, dict[str, Any]] = {}
+    for key, scoped_events in by_scope.items():
+        score, components = _scope_signal(scoped_events, history, policy)
+        scoped_rework = [event for event in scoped_events if event.outcome in REWORK_OUTCOMES]
+        scope_reports[_scope_text(key)] = {
+            "signal_score": score,
+            "signal_components": components,
+            "rework_count": len(scoped_rework),
+            "success_tail": _success_tail(scoped_events),
+            "difficult_zone": score >= policy["assist_signal_threshold"] and bool(scoped_rework),
+        }
+
+    requested_active_scope = str(case.get("active_scope") or "").strip()
+    if mode in {"ASSIST_ACTIVE", "CLEARING"} and requested_active_scope:
+        active_scope = requested_active_scope
+    else:
+        ranked = sorted(
+            scope_reports.items(),
+            key=lambda item: (item[1]["difficult_zone"], item[1]["signal_score"], item[1]["rework_count"]),
+            reverse=True,
+        )
+        active_scope = ranked[0][0] if ranked else None
+
+    active_report = scope_reports.get(active_scope or "", {
+        "signal_score": 0,
+        "signal_components": {
+            "repeated_scope_hits": 0,
+            "backtrack_hits": 0,
+            "human_friction_hits": 0,
+            "historical_hits": 0,
+        },
+        "rework_count": 0,
+        "success_tail": 0,
+        "difficult_zone": False,
+    })
+    active_events = [event for event in recent if _scope_text(_scope_key(event)) == active_scope]
+    active_rework = [event for event in active_events if event.outcome in REWORK_OUTCOMES]
+
+    difficult_zone = bool(active_report["difficult_zone"])
     next_mode = mode
     reasons: list[str] = []
 
     if mode == "OBSERVE" and difficult_zone:
         next_mode = "ASSIST_ACTIVE"
-        reasons.append("Current rework signals crossed the bounded assist threshold.")
+        reasons.append("One bounded scope crossed the assist threshold; unrelated scopes were not aggregated.")
     elif mode == "ASSIST_ACTIVE":
-        if success_tail >= policy["clear_success_threshold"]:
+        if active_report["success_tail"] >= policy["clear_success_threshold"]:
             next_mode = "CLEARING"
             reasons.append("The assisted scope has a success tail; enter clearing before disabling assist.")
         else:
@@ -170,18 +243,19 @@ def evaluate(case: dict[str, Any]) -> dict[str, Any]:
     elif mode == "CLEARING":
         if difficult_zone:
             next_mode = "ASSIST_ACTIVE"
-            reasons.append("Rework recurred during clearing; restore bounded assist.")
-        elif success_tail >= policy["clear_success_threshold"]:
+            reasons.append("Rework recurred in the same active scope during clearing; restore bounded assist.")
+        elif active_report["success_tail"] >= policy["clear_success_threshold"]:
             next_mode = "OBSERVE"
-            reasons.append("The difficult zone cleared without recurrent rework; return to observe.")
+            reasons.append("The active difficult zone cleared without recurrent rework; return to observe.")
 
     clusters: dict[tuple[str, str, str], list[Event]] = defaultdict(list)
-    for event in rework_events:
-        clusters[_scope_key(event)].append(event)
+    for event in recent:
+        if event.outcome in REWORK_OUTCOMES:
+            clusters[_scope_key(event)].append(event)
 
     knowledge = [
         {
-            "scope_key": "|".join(key),
+            "scope_key": _scope_text(key),
             "rework_count": len(items),
             "classes": sorted({item.rework_class for item in items}),
             "markers": sorted({marker for item in items for marker in item.markers}),
@@ -194,17 +268,19 @@ def evaluate(case: dict[str, Any]) -> dict[str, Any]:
         "schema": "ultimate-loop-rework-learning-report/v0",
         "mode": mode,
         "next_mode": next_mode,
+        "active_scope": active_scope,
         "difficult_zone": difficult_zone,
-        "signal_score": score,
-        "signal_components": components,
-        "assist_actions": _assist_actions(rework_events) if next_mode == "ASSIST_ACTIVE" else [],
+        "signal_score": active_report["signal_score"],
+        "signal_components": active_report["signal_components"],
+        "scope_reports": scope_reports,
+        "assist_actions": _assist_actions(active_rework) if next_mode == "ASSIST_ACTIVE" else [],
         "knowledge_candidates": knowledge,
         "reasons": reasons,
         "evidence_policy": {
             "raw_event_count": len(events),
             "recent_event_count": len(recent),
-            "historical_evidence_used": components["historical_hits"] > 0,
-            "note": "Historical evidence raises confidence but is not required for realtime assist activation.",
+            "historical_evidence_used": active_report["signal_components"]["historical_hits"] > 0,
+            "note": "Historical evidence raises confidence only inside a matching scope and is not required for realtime activation.",
         },
     }
 

--- a/thin-rts/ultimate-loop/test_rework_learning.py
+++ b/thin-rts/ultimate-loop/test_rework_learning.py
@@ -36,6 +36,7 @@ class ReworkLearningTests(unittest.TestCase):
         self.assertEqual(report["next_mode"], "ASSIST_ACTIVE")
         self.assertTrue(report["difficult_zone"])
         self.assertFalse(report["evidence_policy"]["historical_evidence_used"])
+        self.assertEqual(report["active_scope"], "bank-checkout|ssh|runtime-check")
         self.assertIn("CONVERGE_TO_SINGLE_TERMINAL", report["assist_actions"])
         self.assertIn("SPLIT_LONG_COMMANDS", report["assist_actions"])
 
@@ -54,20 +55,26 @@ class ReworkLearningTests(unittest.TestCase):
         self.assertEqual(report["signal_components"]["historical_hits"], 0)
 
     def test_assist_is_scoped_and_enters_clearing_after_success_tail(self):
+        scope = "bank-checkout|ssh|runtime-check"
         case = {
             "mode": "ASSIST_ACTIVE",
+            "active_scope": scope,
             "events": [
                 event(1, markers=["MULTI_TAB"]),
                 event(2, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
                 event(3, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
+                event(4, task="unrelated", source="ui", operation="form", markers=["PASTE_FAILURE"]),
             ],
         }
         report = rework_learning.evaluate(case)
+        self.assertEqual(report["active_scope"], scope)
         self.assertEqual(report["next_mode"], "CLEARING")
 
     def test_clearing_returns_to_observe_after_stable_success(self):
+        scope = "bank-checkout|ssh|runtime-check"
         case = {
             "mode": "CLEARING",
+            "active_scope": scope,
             "events": [
                 event(1, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
                 event(2, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
@@ -101,6 +108,26 @@ class ReworkLearningTests(unittest.TestCase):
         }
         report = rework_learning.evaluate(case)
         self.assertEqual(report["next_mode"], "OBSERVE")
+
+    def test_meteor_unrelated_scopes_cannot_pool_weak_signals(self):
+        case = {
+            "mode": "OBSERVE",
+            "events": [
+                event(1, task="a", source="ssh", operation="x", markers=["MULTI_TAB"]),
+                event(2, task="b", source="ui", operation="y", markers=["PASTE_FAILURE"]),
+                event(3, task="c", source="browser", operation="z", markers=["COMMAND_RETRY"]),
+            ],
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "OBSERVE")
+        self.assertFalse(report["difficult_zone"])
+        self.assertEqual(len(report["scope_reports"]), 3)
+
+    def test_missing_scope_identity_fails_closed(self):
+        broken = event(1)
+        broken["operation"] = ""
+        with self.assertRaises(ValueError):
+            rework_learning.evaluate({"mode": "OBSERVE", "events": [broken]})
 
 
 if __name__ == "__main__":

--- a/thin-rts/ultimate-loop/test_rework_learning.py
+++ b/thin-rts/ultimate-loop/test_rework_learning.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import unittest
+
+import rework_learning
+
+
+def event(i, *, outcome="REWORK", markers=None, task="bank-checkout", source="ssh", operation="runtime-check", from_step="CHECK", to_step="CONFIG"):
+    return {
+        "event_id": f"e{i}",
+        "occurred_at": f"2026-08-21T01:{i:02d}:00Z",
+        "task_scope": task,
+        "source": source,
+        "operation": operation,
+        "outcome": outcome,
+        "rework_class": "HUMAN_OPERATION" if markers else "WORKFLOW",
+        "from_step": from_step,
+        "to_step": to_step,
+        "markers": markers or [],
+        "evidence_refs": [f"trace:{i}"],
+    }
+
+
+class ReworkLearningTests(unittest.TestCase):
+    def test_realtime_signals_can_activate_without_history(self):
+        case = {
+            "mode": "OBSERVE",
+            "events": [
+                event(1, markers=["MULTI_TAB"]),
+                event(2, markers=["PASTE_FAILURE"]),
+                event(3, markers=["COMMAND_RETRY"]),
+            ],
+            "history": {"clusters": []},
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "ASSIST_ACTIVE")
+        self.assertTrue(report["difficult_zone"])
+        self.assertFalse(report["evidence_policy"]["historical_evidence_used"])
+        self.assertIn("CONVERGE_TO_SINGLE_TERMINAL", report["assist_actions"])
+        self.assertIn("SPLIT_LONG_COMMANDS", report["assist_actions"])
+
+    def test_history_supports_but_does_not_force_unrelated_scope(self):
+        case = {
+            "mode": "OBSERVE",
+            "events": [event(1, task="new-scope", source="ui", operation="form")],
+            "history": {
+                "clusters": [
+                    {"scope_key": "old-scope|ssh|runtime-check", "rework_count": 99}
+                ]
+            },
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "OBSERVE")
+        self.assertEqual(report["signal_components"]["historical_hits"], 0)
+
+    def test_assist_is_scoped_and_enters_clearing_after_success_tail(self):
+        case = {
+            "mode": "ASSIST_ACTIVE",
+            "events": [
+                event(1, markers=["MULTI_TAB"]),
+                event(2, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
+                event(3, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
+            ],
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "CLEARING")
+
+    def test_clearing_returns_to_observe_after_stable_success(self):
+        case = {
+            "mode": "CLEARING",
+            "events": [
+                event(1, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
+                event(2, outcome="SUCCESS", markers=[], from_step="RUN", to_step="DONE"),
+            ],
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "OBSERVE")
+        self.assertFalse(report["difficult_zone"])
+
+    def test_meteor_old_learning_does_not_override_current_success(self):
+        case = {
+            "mode": "OBSERVE",
+            "events": [
+                event(1, outcome="SUCCESS", markers=[], task="bank-checkout"),
+                event(2, outcome="SUCCESS", markers=[], task="bank-checkout"),
+            ],
+            "history": {
+                "clusters": [
+                    {"scope_key": "bank-checkout|ssh|runtime-check", "rework_count": 500}
+                ]
+            },
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "OBSERVE")
+        self.assertFalse(report["difficult_zone"])
+
+    def test_meteor_single_multi_tab_event_is_not_universal_rule(self):
+        case = {
+            "mode": "OBSERVE",
+            "events": [event(1, markers=["MULTI_TAB"], task="one-off")],
+        }
+        report = rework_learning.evaluate(case)
+        self.assertEqual(report["next_mode"], "OBSERVE")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes experiment scope from #362 without changing the canonical core flow.

Implements a bounded optional rework-learning evaluator with realtime-first difficult-zone detection, historical evidence as support only, scoped ASSIST_ACTIVE/CLEARING/OBSERVE transitions, derived knowledge candidates, and no execution/promotion authority.

DA / Counter-DA / METEOR was run before and after implementation. The first prototype died on a real design flaw: unrelated weak friction signals could pool across scopes and trigger global assist. That was repaired by explicit `(task_scope, source, operation)` scoring, `active_scope`, scope-local clearing, exact-scope historical support, and fail-closed missing scope identity.

`Rework Learning Meteor` passed on repaired code head `88ffdd1e...`; the final commit is documentation-only and records the post-implementation re-gate.

Current verdict: optional prototype survives current gate. This PR does not make Rework Learning mandatory core behavior and grants no deployment/execution authority.