### PR TITLE
Integrate Ultimate Loop shared runtime adapter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,3 +132,29 @@ If the task is a fix:
 
 If the task is implementation:
 - follow spec and acceptance criteria
+
+---
+
+## Ultimate Loop shared runtime adapter
+
+This repository may use the host-installed shared Ultimate Loop Codex runtime, but the shared runtime does not reopen RTS development.
+
+When the user writes `/goal` or explicitly asks to run Ultimate Loop:
+
+1. read `docs/CANONICAL_INDEX.md` first;
+2. read `docs/audit/RTS_DEVELOPMENT_FREEZE_2026-08-09.md` and `docs/audit/RTS_FINAL_ABOLITION_GATE_2026-08.md` before proposing implementation;
+3. treat the repository's current state as `FROZEN / ENDED` unless an explicit human decision authorizes a bounded reopening;
+4. use the shared `ultimate-loop` skill and explicit custom roles only as an analysis/verification mechanism within that boundary;
+5. do not vendor or duplicate the shared Ultimate Loop skill/custom-role files into RTS merely to enable `/goal`.
+
+Hard rules:
+
+- `/goal` != automatic development restart;
+- historical capability != current authority to modify;
+- a new idea, external capability, or benchmark result is a WATCH/DARWIN trigger candidate, not automatic permission to resume implementation;
+- if the correct bounded result is KEEP/FROZEN/NO-CHANGE, stop there instead of inventing work;
+- any material reopening must identify the exact frozen invariant being reconsidered, the new evidence that changes the prior decision, the permitted change surface, and the fresh Reality Gate;
+- `REPOSITORY_IMPLEMENTED != CODEX_RUNTIME_VALIDATED`;
+- `PROMPT NON-MUTATION != TECHNICAL READ-ONLY`.
+
+Repository-local freeze and canonical records override generic global runtime guidance.


### PR DESCRIPTION
## Goal

Allow `/goal` to use the Oracle shared Ultimate Loop runtime in RTS without overwriting the existing repository operating model and without reopening frozen RTS development.

## Change

Updates only the existing `AGENTS.md` by appending a bounded shared-runtime adapter.

The adapter:
- requires `docs/CANONICAL_INDEX.md` and both closure records to be read first;
- preserves RTS as `FROZEN / ENDED` by default;
- makes `/goal` an analysis/verification mechanism, not automatic development restart;
- requires explicit human authorization plus new evidence before any bounded reopening;
- forbids vendoring duplicate shared Ultimate Loop runtime assets into RTS;
- preserves KEEP/FROZEN/NO-CHANGE as valid terminal results.

## Non-goals

- no development restart;
- no implementation change;
- no organization rewrite;
- no modification of closure/canonical records.

## Evidence

- one existing governance file only, +26 / -0;
- adapter HEAD: `2f5fdd354189ff5e0d1aee3d5410ba9b3253976f`;
- no GitHub Actions workflow is associated with this adapter HEAD;
- `docs/CANONICAL_INDEX.md` states RTS development is `FROZEN / ENDED as of 2026-08-09` and engineering continuation is `NO`.

## Promotion gate

Keep Draft until an Oracle shared-runtime `/goal` smoke proves the repo-local freeze wins over generic global runtime behavior and terminates without inventing implementation work.