### PR TITLE
docs: mark original RTS as explicit-reference-only for agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,134 +1,36 @@
 # AGENTS.md
 
-## Purpose
-This repository is operated with ChatGPT and Codex as development collaborators.
+## Status
+**COLD / FROZEN / HISTORICAL EVIDENCE / EXPLICIT REFERENCE ONLY**
 
-ChatGPT is used for:
-- requirement clarification
-- specification drafting
-- organization policy drafting
-- fix policy drafting
-- review support
-- logging support
+Original RTS development ended on **2026-08-09**. This repository is preserved as historical implementation, evidence corpus, abolition/reconstruction records, and lineage material.
 
-Codex is used for:
-- implementation
-- file organization
-- local fixes
-- path/reference updates
-- test execution
-- reviewable changes
+It is **not** the default current RTS architecture and must not be included in ordinary cross-repository implementation discovery.
 
-This repository must remain reviewable, structured, and rollback-safe.
+## Load rule
+Open this repository only when the task explicitly requires:
+- original RTS history or implementation evidence;
+- abolition/freeze records;
+- reconstruction lineage;
+- BridgePatch material that is specifically canonical here;
+- comparison against a historical RTS decision or artifact.
 
----
+For current work, prefer the relevant active/canonical successor such as `RTS-Evolution`, `Ultimate-Loop`, or the current product repository.
 
-## Core Operating Principles
+## Canonical load order when historical access is required
+1. Read `README.md` and its development-freeze notice.
+2. Read only the cited final freeze/abolition record relevant to the question.
+3. Load targeted historical files/commits only as needed.
+4. Do not scan the full repository by default.
 
-1. Do not edit blindly.
-2. Read repository rules before acting.
-3. Keep tasks small and reviewable.
-4. Separate implementation tasks from organization tasks.
-5. Prefer minimal valid changes.
-6. Preserve rollbackability.
-7. Report uncertainty instead of guessing aggressively.
+## Source of truth
+Historical evidence is authoritative only for what happened in original RTS. It does not automatically define current architecture or current product behavior.
 
----
+## Hard boundaries
+- No new RTS-specific Runtime/Controller/Governance Kernel expansion by default.
+- Do not resurrect frozen responsibilities merely because implementation exists here.
+- Do not present historical code existence as current runtime evidence.
+- Preserve history; do not rewrite old evidence to match later conclusions.
 
-## Task Types
-
-### Implementation Task
-Used when adding or changing behavior.
-
-Rules:
-- do not reorganize unrelated files
-- do not perform broad cleanup unless explicitly requested
-- follow the provided spec
-- keep changes scoped to the task
-- verify the implemented behavior
-
-### Organization Task
-Used when cleaning file structure, naming, placement, or archive boundaries.
-
-Rules:
-- do not change logic unless explicitly required
-- focus on structure only
-- identify clutter, overlap, and ambiguity
-- prefer reviewable file moves
-- preserve references and links
-
-### Fix Task
-Used when something is broken.
-
-Rules:
-- reproduce first
-- identify the smallest likely fix surface
-- do not mix repair with unrelated cleanup
-- verify that the original issue is resolved
-- report cause, changed files, and remaining uncertainty
-
----
-
-## File Handling Rules
-
-- Do not rename, move, merge, or split files unless the task explicitly allows it.
-- Do not modify unrelated directories during a local task.
-- Preserve public-facing documentation unless directly relevant.
-- Do not rewrite large sections for style alone.
-- Prefer incremental, reviewable changes over sweeping rewrites.
-
----
-
-## Repository Safety Rules
-
-- Never make non-trivial edits directly on main.
-- Use one branch per task when possible.
-- Create a checkpoint before major edits.
-- Keep implementation and organization tasks separate.
-- If validation fails, prefer rollback over speculative expansion.
-- If uncertainty increases, stop and report.
-
----
-
-## Expected Output Format
-
-For any non-trivial task, return:
-
-1. Task summary
-2. Files inspected
-3. Files changed
-4. What was done
-5. What was verified
-6. Risks or uncertainty
-7. Suggested next step
-
----
-
-## Priority Order
-
-When rules conflict, prioritize in this order:
-
-1. repository safety
-2. rollbackability
-3. task scope discipline
-4. correctness
-5. cleanliness
-
----
-
-## Default Behavior
-
-If the task is ambiguous:
-- inspect first
-- summarize current structure
-- identify likely safe next actions
-- avoid large speculative edits
-
-If the task is organizational:
-- produce an inventory first unless explicitly told to reorganize immediately
-
-If the task is a fix:
-- reproduce and isolate before editing
-
-If the task is implementation:
-- follow spec and acceptance criteria
+## Stop condition
+If the task can be answered or implemented from a current canonical repository, stop loading RTS and route there. Reopen RTS-specific development only with materially new evidence and an explicit decision.


### PR DESCRIPTION
Adds a concise COLD/FROZEN agent boundary so Codex/Astra-style agents do not treat the historical RTS repository as the default current architecture. No code or historical evidence is changed.